### PR TITLE
<fix> userpool alias syntax

### DIFF
--- a/aws/components/userpool/setup.ftl
+++ b/aws/components/userpool/setup.ftl
@@ -128,7 +128,7 @@
         [#local smsVerification = true]
     [/#if]
 
-    [#if solution.VerifyEmail || ( solution.LoginAliases.seq_contains("email"))]
+    [#if solution.VerifyEmail || ( asArray(solution.LoginAliases)?seq_contains("email"))]
         [#if ! (solution.Schema["email"]!"")?has_content ]
             [@fatal
                 message="Schema Attribute required: email - Add Schema listed in detail"


### PR DESCRIPTION
## Description
minor fix to the userpool alias syntax which wasn't compatible freemarker.

## Motivation and Context
We hadn't seen this before as it only occurs when the email alias isn't used in a userpool. Which is pretty uncommon

## How Has This Been Tested?
generated user pool test

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Breaking Actions
none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
