### PR TITLE
<fix> only add subnet outputs in network component

### DIFF
--- a/aws/components/network/setup.ftl
+++ b/aws/components/network/setup.ftl
@@ -169,16 +169,18 @@
                 [/#list]
 
                 [#local tierListId = formatId( "subnetList", core.Id, tierId) ]
-                [@cfOutput
-                        tierListId,
-                        {
-                            "Fn::Join": [
-                                ",",
-                                tierSubnetIdRefs
-                            ]
-                        },
-                        true
-                /]
+                [#if deploymentSubsetRequired(NETWORK_COMPONENT_TYPE, true)]
+                    [@cfOutput
+                            tierListId,
+                            {
+                                "Fn::Join": [
+                                    ",",
+                                    tierSubnetIdRefs
+                                ]
+                            },
+                            true
+                    /]
+                [/#if]
 
             [/#if]
         [/#list]


### PR DESCRIPTION
## Description
minor fix to restrict when  the subnet list outputs are included in templates

## Motivation and Context
Without this PR the ouputs were being added to all segment level outputs not just the network one

## How Has This Been Tested?
tested in local deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] None of the above.
