### PR TITLE
<fix> CDN Route attribute formatting

### DIFF
--- a/aws/components/cdn/state.ftl
+++ b/aws/components/cdn/state.ftl
@@ -76,7 +76,7 @@
                 }
             },
             "Attributes" : parentAttributes + {
-                "URL" : formatAbsolutePath( parentAttributes["URL"], pathPattern?remove_ending("*") )
+                "URL" : formatRelativePath( parentAttributes["URL"], pathPattern?remove_ending("*") )
             },
             "Roles" : {
                 "Inbound" : {},


### PR DESCRIPTION
## Description
Minor fix to the CDN Route URL attribute

## Motivation and Context
The url was being formatted as an absolute path so included a slash at the start. This is an invalid URL 

## How Has This Been Tested?
Tested in local deployment 


## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] None of the above.
