### PR TITLE
<fix> default output for template resource

### DIFF
--- a/aws/services/cfn/resource.ftl
+++ b/aws/services/cfn/resource.ftl
@@ -54,7 +54,13 @@
             "TemplateURL" : tempalteUrl,
             "Tags" : tags
         }
-        outputs=outputs
+        outputs=
+            {
+                REFERENCE_ATTRIBUTE_TYPE : {
+                    "UseRef" : true
+                }
+            } +
+            outputs
         dependencies=dependencies
     /]
 [/#macro]


### PR DESCRIPTION
## Description
Always add the ref output to the cfn Netsted template resource

## Motivation and Context
Since our processing assumes that at least one resource in a component will have an output we need to make sure that Nested templates always have one. This is important since the rest of the outputs are dynamic so in some templates you might not want to map any of the outputs 

## How Has This Been Tested?
tested on local deployment with links enabled ( See https://github.com/hamlet-io/engine/pull/1289 for the link fix) 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
