### PR TITLE
<feature> WAF GeoMatch support

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -399,16 +399,16 @@
                     solution.CloudFront.Compress,
                     securityProfile.ProtocolPolicy) ]
             [#local restrictions = {} ]
-            [#if solution.CloudFront.CountryGroups?has_content]
-                [#list asArray(solution.CloudFront.CountryGroups) as countryGroup]
-                    [#local group = (countryGroups[countryGroup])!{}]
-                    [#if group.Locations?has_content]
-                        [#local restrictions +=
-                            getCFGeoRestriction(group.Locations, group.Blacklist!false) ]
-                        [#break]
-                    [/#if]
-                [/#list]
+            [#local whitelistedCountryCodes = getGroupCountryCodes(solution.CloudFront.CountryGroups![], false) ]
+            [#if whitelistedCountryCodes?has_content]
+                [#local restrictions = getCFGeoRestriction(whitelistedCountryCodes, false) ]
+            [#else]
+                [#local blacklistedCountryCodes = getGroupCountryCodes(solution.CloudFront.CountryGroups![], true) ]
+                [#if blacklistedCountryCodes?has_content]
+                    [#local restrictions = getCFGeoRestriction(blacklistedCountryCodes, true) ]
+                [/#if]
             [/#if]
+
             [@createCFDistribution
                 id=cfResources["distribution"].Id
                 dependencies=stageId

--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -351,15 +351,14 @@
 
     [#if deploymentSubsetRequired(CDN_COMPONENT_TYPE, true)]
         [#local restrictions = {} ]
-        [#if solution.CountryGroups?has_content]
-            [#list asArray(solution.CountryGroups) as countryGroup]
-                [#local group = (countryGroups[countryGroup])!{}]
-                [#if group.Locations?has_content]
-                    [#local restrictions +=
-                        getCFGeoRestriction(group.Locations, group.Blacklist!false) ]
-                    [#break]
-                [/#if]
-            [/#list]
+        [#local whitelistedCountryCodes = getGroupCountryCodes(solution.CountryGroups![], false) ]
+        [#if whitelistedCountryCodes?has_content]
+            [#local restrictions = getCFGeoRestriction(whitelistedCountryCodes, false) ]
+        [#else]
+            [#local blacklistedCountryCodes = getGroupCountryCodes(solution.CountryGroups![], true) ]
+            [#if blacklistedCountryCodes?has_content]
+                [#local restrictions = getCFGeoRestriction(blacklistedCountryCodes, true) ]
+            [/#if]
         [/#if]
 
         [#local errorResponses = []]


### PR DESCRIPTION
## Description
Add support for blacklisted and whitelisted geo matches in WAF configurations.

## Motivation and Context
This will permit regional APIs to to geoblocked.

## How Has This Been Tested?
Via deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] merge corresponding engine PR - https://github.com/hamlet-io/engine/pull/1290

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
