### PR TITLE
<fix> template output mapping to attributes

### DIFF
--- a/aws/components/template/state.ftl
+++ b/aws/components/template/state.ftl
@@ -12,7 +12,7 @@
         [#local attributes = mergeObjects(
                                 attributes,
                                 {
-                                    attribute.AttributeType?upper_case : getExistingReference(templateId, solution.AttributeType)
+                                    attribute.AttributeType?upper_case : getExistingReference(templateId, attribute.AttributeType)
                                 } )]
     [/#list]
 


### PR DESCRIPTION
## Description
Fixes the mapping setup for template outputs to attributes

## Motivation and Context
only returning the ref attribute


## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
