### PR TITLE
<refactor> Expand the S3 permissions given to OAI

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -250,10 +250,19 @@
                                     {
                                         "CanonicalUser": cfAccessCanonicalIds
                                     }
-                                )
+                                ) +
+                                s3ListPermission(
+                                    bucketName,
+                                    formatSegmentPrefixPath("settings"),
+                                    "*",
+                                    {
+                                        "CanonicalUser": cfAccessCanonicalIds
+                                    }
+                                ),
                                 cfAccessCanonicalIds,
                                 []
-                            )]
+                            )
+                        ]
                         [#break]
                     [#case "appdata" ]
                         [#if dataPublicEnabled ]


### PR DESCRIPTION
## Description
OAIs can now list buckets so that S3 returns 404 not 403 for missing objects.

## Motivation and Context
If a cloudfront distribution for an SPA needs to be whitelisted, the logical apporach is to use WAF. However while WAF will return a 403, this is converted to a 200 and content displayed if an error page against a 403 code is configured. 

At present we configure the 403 by default for error pages because of the default S3 behaviour.. By giving the OAI additional permissions, S3 will return a 404 not a 403, the error page need only be configured for a 404, and WAF will work as expected.

## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [ ] The baseline template needs to be rerun before any SPA CDN deployments to pick up the updated OAI permissions.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
