### PR TITLE
<fix>remove reference lookup on hibernate templates

### DIFF
--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -375,7 +375,8 @@
                 [@debug message="Monitored resource" context=monitoredResource enabled=false /]
 
                 [#-- when replacing the instance the database is removed so we need to override refrences to keep the alarms around --]
-                [#if monitoredResource.Id == rdsId && (commandLineOptions.Deployment.Unit.Alternative!"") == "replace1" ]
+                [#if monitoredResource.Id == rdsId &&
+                        ((commandLineOptions.Deployment.Unit.Alternative!"") == "replace1" || hibernate ) ]
                     [#local resourceDimensions = [
                         {
                             "Name": "DBInstanceIdentifier",


### PR DESCRIPTION
## Description
When generating templates for hibernation we need to remove all references to the database. This PR ensures that alarms don't get Ref lookups

## Motivation and Context
Allows templates to be conformant with Cloudformation requireemnts 

## How Has This Been Tested?
TEsted in a deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
