### PR TITLE
<fix>db use name for hibernated alerts

### DIFF
--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -380,7 +380,7 @@
                     [#local resourceDimensions = [
                         {
                             "Name": "DBInstanceIdentifier",
-                            "Value": getExistingReference(rdsId)
+                            "Value": rdsFullName
                         }
                     ]]
                 [#else]


### PR DESCRIPTION
## Description
Use the name of the RDS instance when creating alerts for hibernated  db instances. 

## Motivation and Context
This allows for alarms to be retained during hibernation activities 

## How Has This Been Tested?
tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] None of the above.
