### PR TITLE
<fix> userpool scope seperators

### DIFF
--- a/aws/components/userpool/setup.ftl
+++ b/aws/components/userpool/setup.ftl
@@ -382,7 +382,7 @@
                                             (environment[settingsPrefix + "OIDC_CLIENT_SECRET"])!"COTFatal: ClientSecret not defined"
                         ),
                         "authorize_scopes" : valueIfContent(
-                                                (subSolution.OIDC.Scopes?join(","))!"",
+                                                (subSolution.OIDC.Scopes?join(" "))!"",
                                                 (environment[settingsPrefix + "OIDC_SCOPES"])!"COTFatal: Scopes not defined"
                         ),
                         "attributes_request_method" : valueIfContent(

--- a/aws/components/userpool/state.ftl
+++ b/aws/components/userpool/state.ftl
@@ -181,7 +181,7 @@
             parentAttributes +
             {
                 "CLIENT" : getExistingReference(userPoolClientId),
-                "LB_OAUTH_SCOPE" : (solution.OAuth.Scopes)?join(", ")
+                "LB_OAUTH_SCOPE" : (solution.OAuth.Scopes)?join(" ")
             },
             "Roles" : {
                 "Inbound" : {},
@@ -248,7 +248,7 @@
             scopeResources,
             "Attributes" : {
                 "IDENTIFIER" : getExistingReference(resourceServerId),
-                "SCOPES" : scopeNames?join(",")
+                "SCOPES" : scopeNames?join(" ")
             },
             "Roles" : {
                 "Inbound" : {},


### PR DESCRIPTION
## Description
use spaces as separators for user OIDC scopes instead of ',' 

## Motivation and Context
This aligns with the standard and what Cognito expects for its configuration.  Not sure why this was found earlier, but maybe we haven't used multiple scopes


## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
