### PR TITLE
feature: public identity providers

### DIFF
--- a/aws/components/userpool/setup.ftl
+++ b/aws/components/userpool/setup.ftl
@@ -358,18 +358,80 @@
             [/#list]
 
             [#switch authProviderEngine ]
+                [#case "Google"]
+                [#case "Amazon"]
+                    [#local providerDetails = {
+                        "client_id" : valueIfContent(
+                                            (subSolution[authProviderName].ClientId)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_CLIENT_ID"])!"COTFatal: ClientId not defined"
+                        ),
+                        "client_secret" : valueIfContent(
+                                            (subSolution[authProviderName].ClientSecret)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_CLIENT_SECRET"])!"COTFatal: ClientSecret not defined"
+                        ),
+                        "authorize_scopes" : valueIfContent(
+                                            (subSolution[authProviderName].Scopes)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_SCOPES"])!"COTFatal: Scopes not defined"
+                        )
+                    }]
+                    [#break]
+
+                [#case "Facebook" ]
+                    [#local providerDetails = {
+                        "client_id" : valueIfContent(
+                                            (subSolution[authProviderName].ClientId)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_CLIENT_ID"])!"COTFatal: ClientId not defined"
+                        ),
+                        "client_secret" : valueIfContent(
+                                            (subSolution[authProviderName].ClientSecret)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_CLIENT_SECRET"])!"COTFatal: ClientSecret not defined"
+                        ),
+                        "authorize_scopes" : valueIfContent(
+                                            (subSolution[authProviderName].Scopes)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_SCOPES"])!"COTFatal: Scopes not defined"
+                        ),
+                        "api_version" : valueIfContent(
+                                            (subSolution[authProviderName].APIVersion)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_API_VERSION"])!"COTFatal: APIVersion not defined"
+                        )
+                    }]
+                    [#break]
+
+                [#case "Apple"]
+                    [#local providerDetails = {
+                        "client_id" : valueIfContent(
+                                            (subSolution[authProviderName].ClientId)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_CLIENT_ID"])!"COTFatal: ClientId not defined"
+                        ),
+                        "team_id" : valueIfContent(
+                                            (subSolution[authProviderName].TeamId)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_TEAM_ID"])!"COTFatal: TeamId not defined"
+                        ),
+                        "key_id" : valueIfContent(
+                                            (subSolution[authProviderName].KeyId)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_KEY_ID"])!"COTFatal: KeyId not defined"
+                        ),
+                        "private_key" : valueIfContent(
+                                            (subSolution[authProviderName].PrivateKey)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_PRIVATE_KEY"])!"COTFatal: PrivateKey not defined"
+                        ),
+                        "authorize_scopes" : valueIfContent(
+                                            (subSolution[authProviderName].Scopes)!"",
+                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_SCOPES"])!"COTFatal: Scopes not defined"
+                        )
+                    }]
+                    [#break]
+
                 [#case "SAML" ]
                     [#local providerDetails = {
                         "MetadataURL" : valueIfContent(
                                             (subSolution.SAML.MetadataUrl)!"",
                                             (environment[ settingsPrefix + "SAML_METADATA_URL"])!"COTFatal: MetadataUrl not defined"
                         ),
-                        "IDPSignout" : valueIfContent(
-                                            (environment[settingsPrefix + "SAML_IDP_SIGNOUT"])!"",
-                                            subSolution.SAML.EnableIDPSignOut?c
-                        )
+                        "IDPSignout" :  subSolution.SAML.EnableIDPSignOut
                     }]
                     [#break]
+
                 [#case "OIDC" ]
 
                     [#local providerDetails = {

--- a/aws/services/cognito/resource.ftl
+++ b/aws/services/cognito/resource.ftl
@@ -461,6 +461,17 @@
         dependencies=""
         outputId=""
  ]
+
+    [#-- override some of the providers which use longer names --]
+    [#switch providerType ]
+        [#case "Amazon" ]
+            [#local providerType = "LoginWithAmazon" ]
+            [#break]
+        [#case "Apple"]
+            [#local providerType = "SignInWithApple" ]
+            [#break]
+    [/#switch]
+
     [@cfResource
         id=id
         type="AWS::Cognito::UserPoolIdentityProvider"

--- a/test/run_aws_template_tests.sh
+++ b/test/run_aws_template_tests.sh
@@ -25,7 +25,7 @@ for unit in $UNIT_LIST; do
     ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -l application -u $unit > /dev/null 2>&1 || true
 done
 
-cot test generate --directory "${TEST_OUTPUT_DIR}" -o "${TEST_OUTPUT_DIR}/test_templates.py"
+hamlet test generate --directory "${TEST_OUTPUT_DIR}" -o "${TEST_OUTPUT_DIR}/test_templates.py"
 
 cd "${TEST_OUTPUT_DIR}"
 echo "Running Tests..."


### PR DESCRIPTION
## Description
Add support for userpool federation with the public based identity providers, Google, Apple, Facebook and Amazon 

## Motivation and Context
Extends the login configuration support which is a lot easier now that cfn supports them all 

## How Has This Been Tested?
Tested with a pass of the userpool for syntax, have not tested with these providers as  I didn't have an app which was configured with the providers

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
