### PR TITLE
fix: check component subset for cfn resources

### DIFF
--- a/aws/components/userpool/setup.ftl
+++ b/aws/components/userpool/setup.ftl
@@ -425,15 +425,17 @@
                     [#break]
             [/#switch]
 
-            [@createUserPoolAuthProvider
-                id=authProviderId
-                name=authProviderName
-                userPoolId=userPoolId
-                providerType=authProviderEngine
-                providerDetails=providerDetails
-                attributeMappings=attributeMappings
-                idpIdentifiers=subSolution.IDPIdentifiers
-            /]
+            [#if deploymentSubsetRequired(USERPOOL_COMPONENT_TYPE, true) ]
+                [@createUserPoolAuthProvider
+                    id=authProviderId
+                    name=authProviderName
+                    userPoolId=userPoolId
+                    providerType=authProviderEngine
+                    providerDetails=providerDetails
+                    attributeMappings=attributeMappings
+                    idpIdentifiers=subSolution.IDPIdentifiers
+                /]
+            [/#if]
         [/#if]
 
         [#if subCore.Type == USERPOOL_CLIENT_COMPONENT_TYPE]
@@ -489,7 +491,7 @@
 
                     [#list linkTarget.State.Resources as id,linkResource ]
 
-                        [@debug message="linkResource"  context=linkResource enabled=true /]
+                        [@debug message="linkResource"  context=linkResource enabled=false /]
                         [#if linkResource.Type == AWS_COGNITO_USERPOOL_RESOURCESCOPE_RESOURCE_TYPE ]
                             [#if resourceScope.Scopes?seq_contains(linkResource.Name)]
 
@@ -602,13 +604,15 @@
                     [ getUserPoolResourceScope(scope.Name, scope.Description ) ]]
             [/#list]
 
-            [@createUserPoolResourceServer
-                id=resourceServerId
-                name=resourceServerName
-                identifier=serverIdentifier
-                userPoolId=userPoolId
-                scopes=resourceScopes
-            /]
+            [#if deploymentSubsetRequired(USERPOOL_COMPONENT_TYPE, true) ]
+                [@createUserPoolResourceServer
+                    id=resourceServerId
+                    name=resourceServerName
+                    identifier=serverIdentifier
+                    userPoolId=userPoolId
+                    scopes=resourceScopes
+                /]
+            [/#if]
         [/#if]
     [/#list]
 


### PR DESCRIPTION
## Description
Only call the cfResource macro during component subset for userpool resources 


## Motivation and Context
Deploying in other subsets was overriding and breaking the userpool configuration

## How Has This Been Tested?
Tested with product deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
