### PR TITLE
fix: init configuration ordering for ec2

### DIFF
--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -43,6 +43,21 @@
     } ]
 [/#function]
 
+[#function getInitConfigDirectories ignoreErrors=false priority=0 ]
+    [#return
+        {
+            "${priority}_Directories" : {
+                "commands": {
+                    "01Directories" : {
+                        "command" : "mkdir --parents --mode=0755 /etc/codeontap && mkdir --parents --mode=0755 /opt/codeontap/bootstrap && mkdir --parents --mode=0755 /opt/codeontap/scripts && mkdir --parents --mode=0755 /var/log/codeontap",
+                        "ignoreErrors" : ignoreErrors
+                    }
+                }
+            }
+        }
+    ]
+[/#function]
+
 [#function getInitConfigBootstrap occurrence operationsBucket dataBucket ignoreErrors=false priority=1 ]
     [#local role = (occurrence.Configuration.Settings.Product["Role"].Value)!""]
     [#return
@@ -105,21 +120,6 @@
                     },
                     "02Initialise" : {
                         "command" : "/opt/codeontap/bootstrap/init.sh",
-                        "ignoreErrors" : ignoreErrors
-                    }
-                }
-            }
-        }
-    ]
-[/#function]
-
-[#function getInitConfigDirectories ignoreErrors=false priority=2 ]
-    [#return
-        {
-            "${priority}_Directories" : {
-                "commands": {
-                    "01Directories" : {
-                        "command" : "mkdir --parents --mode=0755 /etc/codeontap && mkdir --parents --mode=0755 /opt/codeontap/bootstrap && mkdir --parents --mode=0755 /opt/codeontap/scripts && mkdir --parents --mode=0755 /var/log/codeontap",
                         "ignoreErrors" : ignoreErrors
                     }
                 }

--- a/test/run_aws_template_tests.sh
+++ b/test/run_aws_template_tests.sh
@@ -25,7 +25,7 @@ for unit in $UNIT_LIST; do
     ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -l application -u $unit > /dev/null 2>&1 || true
 done
 
-cot test generate --directory "${TEST_OUTPUT_DIR}" -o "${TEST_OUTPUT_DIR}/test_templates.py"
+hamlet test generate --directory "${TEST_OUTPUT_DIR}" -o "${TEST_OUTPUT_DIR}/test_templates.py"
 
 cd "${TEST_OUTPUT_DIR}"
 echo "Running Tests..."

--- a/test/run_aws_template_tests.sh
+++ b/test/run_aws_template_tests.sh
@@ -4,7 +4,7 @@ echo "###############################################"
 echo "# Running template tests for the AWS provider #"
 echo "###############################################"
 
-TEST_OUTPUT_DIR="${TEST_OUTPUT_DIR:-"./cot_tests"}"
+TEST_OUTPUT_DIR="${TEST_OUTPUT_DIR:-"./hamlet_tests"}"
 
 if [[ -d "${TEST_OUTPUT_DIR}" ]]; then
     rm -r "${TEST_OUTPUT_DIR}"
@@ -29,4 +29,4 @@ cot test generate --directory "${TEST_OUTPUT_DIR}" -o "${TEST_OUTPUT_DIR}/test_t
 
 cd "${TEST_OUTPUT_DIR}"
 echo "Running Tests..."
-cot test run -t "./test_templates.py"
+hamlet test run -t "./test_templates.py"


### PR DESCRIPTION
## Description
Minor fix to create directories before they are used by other boot strap scripts

## Motivation and Context
Found that logging on the other bootstrap scripts were failing because /var/log/codeontap was missing. Turns out it was being created after the boostrap process was run.

## How Has This Been Tested?
Tested on an active deployment 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
