### PR TITLE
fix: Auth provider configuration defaulting logic

### DIFF
--- a/aws/components/userpool/setup.ftl
+++ b/aws/components/userpool/setup.ftl
@@ -337,7 +337,7 @@
             [#local authProviderId = subResources["authprovider"].Id ]
             [#local authProviderName = subResources["authprovider"].Name ]
             [#local authProviderEngine = subSolution.Engine]
-            [#local settingsPrefix = subSolution.SettingsPrefix?upper_case?ensure_ends_with("_") ]
+            [#local settingsPrefix = subSolution.SettingsPrefix?upper_case ]
 
             [#local linkTargets = getLinkTargets(subOccurrence) ]
             [#local baselineLinks = getBaselineLinks(subOccurrence, [] )]
@@ -361,72 +361,72 @@
                 [#case "Google"]
                 [#case "Amazon"]
                     [#local providerDetails = {
-                        "client_id" : valueIfContent(
-                                            (subSolution[authProviderName].ClientId)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_CLIENT_ID"])!"COTFatal: ClientId not defined"
+                        "client_id" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "CLIENT", "ID"],"_") ])!"",
+                                            (subSolution[authProviderEngine].ClientId)!"COTFatal: ClientId not defined"
                         ),
-                        "client_secret" : valueIfContent(
-                                            (subSolution[authProviderName].ClientSecret)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_CLIENT_SECRET"])!"COTFatal: ClientSecret not defined"
+                        "client_secret" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "CLIENT", "SECRET"],"_") ])!"",
+                                            (subSolution[authProviderEngine].ClientSecret)!"COTFatal: ClientSecret not defined"
                         ),
-                        "authorize_scopes" : valueIfContent(
-                                            (subSolution[authProviderName].Scopes)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_SCOPES"])!"COTFatal: Scopes not defined"
+                        "authorize_scopes" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "SCOPES"],"_") ])!"",
+                                            (subSolution[authProviderEngine].Scopes)!"COTFatal: Scopes not defined"
                         )
                     }]
                     [#break]
 
                 [#case "Facebook" ]
                     [#local providerDetails = {
-                        "client_id" : valueIfContent(
-                                            (subSolution[authProviderName].ClientId)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_CLIENT_ID"])!"COTFatal: ClientId not defined"
+                        "client_id" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "CLIENT", "ID"],"_") ])!"",
+                                            (subSolution[authProviderEngine].ClientId)!"COTFatal: ClientId not defined"
                         ),
-                        "client_secret" : valueIfContent(
-                                            (subSolution[authProviderName].ClientSecret)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_CLIENT_SECRET"])!"COTFatal: ClientSecret not defined"
+                        "client_secret" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "CLIENT", "SECRET"],"_") ])!"",
+                                            (subSolution[authProviderEngine].ClientSecret)!"COTFatal: ClientSecret not defined"
                         ),
-                        "authorize_scopes" : valueIfContent(
-                                            (subSolution[authProviderName].Scopes)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_SCOPES"])!"COTFatal: Scopes not defined"
+                        "authorize_scopes" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "SCOPES"],"_") ])!"",
+                                            (subSolution[authProviderEngine].Scopes)!"COTFatal: Scopes not defined"
                         ),
-                        "api_version" : valueIfContent(
-                                            (subSolution[authProviderName].APIVersion)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_API_VERSION"])!"COTFatal: APIVersion not defined"
+                        "api_version" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "API", "VERSION"],"_") ])!"",
+                                            (subSolution[authProviderEngine].APIVersion)!"COTFatal: APIVersion not defined"
                         )
                     }]
                     [#break]
 
                 [#case "Apple"]
                     [#local providerDetails = {
-                        "client_id" : valueIfContent(
-                                            (subSolution[authProviderName].ClientId)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_CLIENT_ID"])!"COTFatal: ClientId not defined"
+                        "client_id" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "CLIENT", "ID"],"_") ])!"",
+                                            (subSolution[authProviderEngine].ClientId)!"COTFatal: ClientId not defined"
                         ),
-                        "team_id" : valueIfContent(
-                                            (subSolution[authProviderName].TeamId)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_TEAM_ID"])!"COTFatal: TeamId not defined"
+                        "team_id" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "TEAM", "ID"],"_") ])!"",
+                                            (subSolution[authProviderEngine].TeamId)!"COTFatal: TeamId not defined"
                         ),
-                        "key_id" : valueIfContent(
-                                            (subSolution[authProviderName].KeyId)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_KEY_ID"])!"COTFatal: KeyId not defined"
+                        "key_id" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "KEY", "ID"],"_") ])!"",
+                                            (subSolution[authProviderEngine].KeyId)!"COTFatal: KeyId not defined"
                         ),
-                        "private_key" : valueIfContent(
-                                            (subSolution[authProviderName].PrivateKey)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_PRIVATE_KEY"])!"COTFatal: PrivateKey not defined"
+                        "private_key" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "PRIVATE", "KEY"],"_") ])!"",
+                                            (subSolution[authProviderEngine].PrivateKey)!"COTFatal: PrivateKey not defined"
                         ),
-                        "authorize_scopes" : valueIfContent(
-                                            (subSolution[authProviderName].Scopes)!"",
-                                            (environment[ settingsPrefix + "_" + authProviderName?upper_case + "_SCOPES"])!"COTFatal: Scopes not defined"
+                        "authorize_scopes" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "SCOPES"],"_") ])!"",
+                                            (subSolution[authProviderEngine].Scopes)!"COTFatal: Scopes not defined"
                         )
                     }]
                     [#break]
 
                 [#case "SAML" ]
                     [#local providerDetails = {
-                        "MetadataURL" : valueIfContent(
-                                            (subSolution.SAML.MetadataUrl)!"",
-                                            (environment[ settingsPrefix + "SAML_METADATA_URL"])!"COTFatal: MetadataUrl not defined"
+                        "MetadataURL" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, authProviderName?upper_case, "SAML", "METADATA", "URL"],"_") ])!"",
+                                            (subSolution[authProviderEngine].MetadataUrl)!"COTFatal: MetadataUrl not defined"
                         ),
                         "IDPSignout" :  subSolution.SAML.EnableIDPSignOut
                     }]
@@ -435,57 +435,62 @@
                 [#case "OIDC" ]
 
                     [#local providerDetails = {
-                        "client_id" : valueIfContent(
-                                            (subSolution.OIDC.ClientId)!"",
-                                            (environment[ settingsPrefix + "OIDC_CLIENT_ID"])!"COTFatal: ClientId not defined"
+                        "client_id" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, "OIDC", "CLIENT", "ID"],"_") ])!"",
+                                            (subSolution.OIDC.ClientId)!"COTFatal: ClientId not defined"
                         ),
-                        "client_secret" : valueIfContent(
-                                            (subSolution.OIDC.ClientSecret)!"",
-                                            (environment[settingsPrefix + "OIDC_CLIENT_SECRET"])!"COTFatal: ClientSecret not defined"
+                        "client_secret" : contentIfContent(
+                                            (environment[ concatenate([settingsPrefix, "OIDC", "CLIENT", "SECRET"],"_") ])!"",
+                                            (subSolution.OIDC.ClientSecret)!"COTFatal: ClientSecret not defined"
                         ),
-                        "authorize_scopes" : valueIfContent(
-                                                (subSolution.OIDC.Scopes?join(" "))!"",
-                                                (environment[settingsPrefix + "OIDC_SCOPES"])!"COTFatal: Scopes not defined"
+                        "authorize_scopes" : contentIfContent(
+                                                (environment[ concatenate([settingsPrefix, "OIDC", "SCOPES"],"_") ])!"",
+                                                (subSolution.OIDC.Scopes?join(" "))!"COTFatal: Scopes not defined"
                         ),
-                        "attributes_request_method" : valueIfContent(
-                                                (subSolution.OIDC.AttributesHttpMethod)!"",
-                                                (environment[settingsPrefix + "OIDC_ATTRIBUTES_HTTP_METHOD"])!"COTFatal: AttributesHttpMethod not defined"
+                        "attributes_request_method" : contentIfContent(
+                                                (environment[ concatenate([settingsPrefix, "OIDC", "ATTRIBUTES", "HTTP", "METHOD"],"_") ])!"",
+                                                (subSolution.OIDC.AttributesHttpMethod)!"COTFatal: AttributesHttpMethod not defined"
                         ),
-                        "oidc_issuer" : valueIfContent(
-                                                (subSolution.OIDC.Issuer)!"",
-                                                (environment[settingsPrefix + "OIDC_ISSUER"])!"COTFatal: Issuer not defined"
+                        "oidc_issuer" : contentIfContent(
+                                                (environment[ concatenate([settingsPrefix, "OIDC", "ISSUER"],"_") ])!"",
+                                                (subSolution.OIDC.Issuer)!"COTFatal: Issuer not defined"
                         )
                     } +
                     attributeIfContent(
                         "authorize_url",
-                        valueIfContent(
-                            (subSolution.OIDC.AuthorizeUrl)!"",
-                            (environment[settingsPrefix + "OIDC_AUTHORIZE_URL"])!""
+                        contentIfContent(
+                            (environment[ concatenate([settingsPrefix, "OIDC", "AUTHORIZE", "URL"],"_") ])!"",
+                            (subSolution.OIDC.AuthorizeUrl)!""
                         )
                     ) +
                     attributeIfContent(
                         "token_url",
-                        valueIfContent(
-                            (subSolution.OIDC.TokenUrl)!"",
-                            (environment[settingsPrefix + "OIDC_TOKEN_URL"])!""
+                        contentIfContent(
+                            (environment[ concatenate([settingsPrefix, "OIDC", "TOKEN", "URL"],"_") ])!"",
+                            (subSolution.OIDC.TokenUrl)!""
                         )
                     ) +
                     attributeIfContent(
                         "attributes_url",
-                        valueIfContent(
-                            (subSolution.OIDC.AttributesUrl)!"",
-                            (environment[settingsPrefix + "OIDC_ATTRIBUTES_URL"])!""
+                        contentIfContent(
+                            (environment[ concatenate([settingsPrefix, "OIDC", "ATTRIBUTES", "URL"],"_") ])!"",
+                            (subSolution.OIDC.AttributesUrl)!""
                         )
                     ) +
                     attributeIfContent(
                         "jwks_uri",
-                        valueIfContent(
-                            (subSolution.OIDC.JwksUrl)!"",
-                            (environment[settingsPrefix + "OIDC_JWKS_URL"])!""
+                        contentIfContent(
+                            (environment[ concatenate([settingsPrefix, "OIDC", "JWKS", "URL"],"_") ])!"",
+                            (subSolution.OIDC.JwksUrl)!""
                         )
                     )]
                     [#break]
             [/#switch]
+
+            [#-- Ensure authorize_scopes is a space separated list --]
+            [#if providerDetails.authorize_scopes?has_content && providerDetails.authorize_scopes?is_sequence]
+                [#local providerDetails += {"authorize_scopes" : providerDetails.authorize_scopes?join(" ")} ]
+            [/#if]
 
             [#if deploymentSubsetRequired(USERPOOL_COMPONENT_TYPE, true) ]
                 [@createUserPoolAuthProvider


### PR DESCRIPTION
## Description
- Use contentIfContent so correct selection of provided values occurs
- Preference environment values to solution values
- Use concatenate to generate environment keys to support SettingsPrefix being an empty string.
- authorise_scopes examples show a space separated list not an array. An array doesn't work well with environment provided values either.

## Motivation and Context
Bug fixes

## How Has This Been Tested?
Customer deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
