### PR TITLE
feature(gateway): link based gateway support

### DIFF
--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -208,12 +208,9 @@
                                                 [@createRoute
                                                     id=formatRouteId(zoneRouteTableId, core.Id, cidr?index)
                                                     routeTableId=zoneRouteTableId
-                                                    route=
-                                                        {
-                                                            "Type" : "nat",
-                                                            "NatId" : natGatewayId,
-                                                            "CIDR" : cidr
-                                                        }
+                                                    destinationType="nat"
+                                                    destinationAttribtue=getReference(natGatewayId)
+                                                    destinationCidr=cidr
                                                 /]
                                             [/#list]
                                             [#break]
@@ -226,12 +223,9 @@
                                                         [@createRoute
                                                             id=formatRouteId(zoneRouteTableId, core.Id, cidr?index)
                                                             routeTableId=zoneRouteTableId
-                                                            route=
-                                                                {
-                                                                    "Type" : "gateway",
-                                                                    "IgwId" : IGWId,
-                                                                    "CIDR" : cidr
-                                                                }
+                                                            destinationType="gateway"
+                                                            destinationAttribtue=getReference(IGWId)
+                                                            destinationCidr=cidr
                                                             dependencies=IGWAttachementId
                                                         /]
                                                     [/#list]
@@ -242,6 +236,37 @@
                                                     /]
                                                 [/#if]
                                             [/#if]
+                                            [#break]
+
+                                        [#case "endpoint" ]
+                                            [#local endpointScope = gwSolution.EndpointScope ]
+                                            [#local endpointType = gwSolution.EndpointType ]
+
+                                            [#switch endpointScope ]
+                                                [#case "zone" ]
+                                                    [#local zoneResources = gwResources["Zones"]]
+                                                    [#if multiAZ ]
+                                                        [#local gateway = zoneResources[zone]["endpoint"] ]
+                                                    [#else]
+                                                        [#local gateway = zoneResources[zones[0]]["endpoint"] ]
+                                                    [/#if]
+                                                    [#break]
+
+                                                [#case "network" ]
+                                                    [#local gateway = gwResources["endpoint"]]
+                                                    [#break]
+                                            [/#switch]
+
+                                            [#list cidrs as cidr ]
+                                                [@createRoute
+                                                    id=formatRouteId(zoneRouteTableId, core.Id, cidr?index)
+                                                    routeTableId=zoneRouteTableId
+                                                    destinationType=endpointType
+                                                    destinationAttribtue=gateway.EndpointAttribute
+                                                    destinationCidr=cidr
+                                                /]
+                                            [/#list]
+
                                             [#break]
                                         [/#switch]
                                     [/#if]

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -209,7 +209,7 @@
                                                     id=formatRouteId(zoneRouteTableId, core.Id, cidr?index)
                                                     routeTableId=zoneRouteTableId
                                                     destinationType="nat"
-                                                    destinationAttribtue=getReference(natGatewayId)
+                                                    destinationAttribute=getReference(natGatewayId)
                                                     destinationCidr=cidr
                                                 /]
                                             [/#list]
@@ -224,7 +224,7 @@
                                                             id=formatRouteId(zoneRouteTableId, core.Id, cidr?index)
                                                             routeTableId=zoneRouteTableId
                                                             destinationType="gateway"
-                                                            destinationAttribtue=getReference(IGWId)
+                                                            destinationAttribute=getReference(IGWId)
                                                             destinationCidr=cidr
                                                             dependencies=IGWAttachementId
                                                         /]
@@ -262,7 +262,7 @@
                                                     id=formatRouteId(zoneRouteTableId, core.Id, cidr?index)
                                                     routeTableId=zoneRouteTableId
                                                     destinationType=endpointType
-                                                    destinationAttribtue=gateway.EndpointAttribute
+                                                    destinationAttribute=gateway.EndpointAttribute
                                                     destinationCidr=cidr
                                                 /]
                                             [/#list]

--- a/aws/components/gateway/state.ftl
+++ b/aws/components/gateway/state.ftl
@@ -83,6 +83,53 @@
                 }]
             [#break]
 
+        [#case "endpoint" ]
+
+            [#local scope = solution.EndpointScope]
+
+            [#list solution.Endpoints as id,endpoint ]
+                [#local endpointLink = getLinkTarget(occurrence, endpoint.Link)]
+
+                [#if endpointLink?has_content ]
+                    [#switch scope ]
+
+                        [#case "zone" ]
+
+                            [#local endpointZone = zones[endpoint.Zone] ]
+
+                            [#if asArray(zoneResources)?seq_contains( endpointZone.Id )]
+                                [#local zoneResources = mergeObjects(
+                                        zoneResources,
+                                        {
+                                            endpointZone.Id : {
+                                                "endpoint" : {
+                                                    "Id" : formatResourceId( AWS_VPC_ENDPOINT_RESOURCE_TYPE, core.Id, endpointZone.Id),
+                                                    "EndpointAttribute" : (endpointLink.State.Attributes[endpoint.Attribute])!"",
+                                                    "Type" : AWS_VPC_ENDPOINT_RESOURCE_TYPE
+                                                }
+                                            }
+                                        }
+                                )]
+                            [/#if]
+                            [#break]
+
+                        [#case "network" ]
+                            [#local resources = mergeObjects(
+                                    resources,
+                                    {
+                                        "endpoint" : {
+                                            "Id" : formatResourceId( AWS_VPC_ENDPOINT_RESOURCE_TYPE, core.Id ),
+                                            "EndpointAttribute" : (endpointLink.State.Attributes[endpoint.Attribute])!"",
+                                            "Type" : AWS_VPC_ENDPOINT_RESOURCE_TYPE
+                                        }
+                                    }
+                            )]
+                            [#break]
+                    [/#switch]
+                [/#if]
+            [/#list]
+            [#break]
+
         [#default]
             [@fatal
                 message="Unknown Engine Type"
@@ -125,9 +172,8 @@
 
     [#switch engine ]
         [#case "natgw"]
-            [#break]
-
         [#case "igw"]
+        [#case "endpoint" ]
             [#break]
 
         [#case "vpcendpoint"]
@@ -141,11 +187,11 @@
                     [#local resources = mergeObjects( resources, {
                         "vpcEndpoints" : {
                             "vpcEndpoint" + id : {
-                                "Id" : formatResourceId(AWS_VPC_ENDPOINNT_RESOURCE_TYPE, core.Id, replaceAlphaNumericOnly(id, "X")),
+                                "Id" : formatResourceId(AWS_VPC_VPCENDPOINNT_RESOURCE_TYPE, core.Id, replaceAlphaNumericOnly(id, "X")),
                                 "EndpointType" : networkEndpoint.Type?lower_case,
                                 "EndpointZones" : endpointZones[id],
                                 "ServiceName" : networkEndpoint.ServiceName,
-                                "Type" : AWS_VPC_ENDPOINNT_RESOURCE_TYPE
+                                "Type" : AWS_VPC_VPCENDPOINNT_RESOURCE_TYPE
                             }
                         }
                     })]

--- a/aws/components/gateway/state.ftl
+++ b/aws/components/gateway/state.ftl
@@ -187,11 +187,11 @@
                     [#local resources = mergeObjects( resources, {
                         "vpcEndpoints" : {
                             "vpcEndpoint" + id : {
-                                "Id" : formatResourceId(AWS_VPC_VPCENDPOINNT_RESOURCE_TYPE, core.Id, replaceAlphaNumericOnly(id, "X")),
+                                "Id" : formatResourceId(AWS_VPC_VPCENDPOINT_RESOURCE_TYPE, core.Id, replaceAlphaNumericOnly(id, "X")),
                                 "EndpointType" : networkEndpoint.Type?lower_case,
                                 "EndpointZones" : endpointZones[id],
                                 "ServiceName" : networkEndpoint.ServiceName,
-                                "Type" : AWS_VPC_VPCENDPOINNT_RESOURCE_TYPE
+                                "Type" : AWS_VPC_VPCENDPOINT_RESOURCE_TYPE
                             }
                         }
                     })]

--- a/aws/components/network/setup.ftl
+++ b/aws/components/network/setup.ftl
@@ -223,7 +223,7 @@
                                 id=legacyIGWRouteId
                                 routeTableId=routeTableId
                                 destinationType="gateway"
-                                destinationAttribtue=getReference(legacyIGWResourceId)
+                                destinationAttribute=getReference(legacyIGWResourceId)
                                 destinationCidr="0.0.0.0/0"
                             /]
                         [/#if]

--- a/aws/components/network/setup.ftl
+++ b/aws/components/network/setup.ftl
@@ -222,12 +222,9 @@
                             [@createRoute
                                 id=legacyIGWRouteId
                                 routeTableId=routeTableId
-                                route=
-                                    {
-                                        "Type" : "gateway",
-                                        "IgwId" : legacyIGWResourceId,
-                                        "CIDR" : "0.0.0.0/0"
-                                    }
+                                destinationType="gateway"
+                                destinationAttribtue=getReference(legacyIGWResourceId)
+                                destinationCidr="0.0.0.0/0"
                             /]
                         [/#if]
 

--- a/aws/services/vpc/id.ftl
+++ b/aws/services/vpc/id.ftl
@@ -21,7 +21,7 @@
 [#assign AWS_VPC_IGW_RESOURCE_TYPE = "igw" ]
 [#assign AWS_VPC_IGW_ATTACHMENT_TYPE = formatId( AWS_VPC_IGW_RESOURCE_TYPE, "attachment") ]
 [#assign AWS_VPC_NAT_GATEWAY_RESOURCE_TYPE = "natGateway" ]
-[#assign AWS_VPC_VPCENDPOINNT_RESOURCE_TYPE = "vpcEndPoint"]
+[#assign AWS_VPC_VPCENDPOINT_RESOURCE_TYPE = "vpcEndPoint"]
 [#assign AWS_VPC_ENDPOINT_RESOURCE_TYPE = "endpointGateway" ]
 
 [#function formatSecurityGroupId ids...]
@@ -194,7 +194,7 @@
 
 [#function formatVPCEndPointId service extensions...]
     [#return formatSegmentResourceId(
-        AWS_VPC_VPCENDPOINNT_RESOURCE_TYPE,
+        AWS_VPC_VPCENDPOINT_RESOURCE_TYPE,
         service,
         extensions)]
 [/#function]

--- a/aws/services/vpc/id.ftl
+++ b/aws/services/vpc/id.ftl
@@ -20,10 +20,9 @@
 
 [#assign AWS_VPC_IGW_RESOURCE_TYPE = "igw" ]
 [#assign AWS_VPC_IGW_ATTACHMENT_TYPE = formatId( AWS_VPC_IGW_RESOURCE_TYPE, "attachment") ]
-
 [#assign AWS_VPC_NAT_GATEWAY_RESOURCE_TYPE = "natGateway" ]
-
-[#assign AWS_VPC_ENDPOINNT_RESOURCE_TYPE = "vpcEndPoint"]
+[#assign AWS_VPC_VPCENDPOINNT_RESOURCE_TYPE = "vpcEndPoint"]
+[#assign AWS_VPC_ENDPOINT_RESOURCE_TYPE = "endpointGateway" ]
 
 [#function formatSecurityGroupId ids...]
     [#return formatResourceId(
@@ -195,14 +194,7 @@
 
 [#function formatVPCEndPointId service extensions...]
     [#return formatSegmentResourceId(
-        AWS_VPC_ENDPOINNT_RESOURCE_TYPE,
+        AWS_VPC_VPCENDPOINNT_RESOURCE_TYPE,
         service,
         extensions)]
 [/#function]
-
-
-
-
-
-
-

--- a/aws/services/vpc/resource.ftl
+++ b/aws/services/vpc/resource.ftl
@@ -385,7 +385,7 @@
             id,
             routeTableId,
             destinationType,
-            destinationAttribtue,
+            destinationAttribute,
             destinationCidr,
             dependencies=""]
 
@@ -399,7 +399,7 @@
         [#case "gateway"]
             [#local properties +=
                 {
-                    "GatewayId" : destinationAttribtue
+                    "GatewayId" : destinationAttribute
                 }
             ]
             [#break]
@@ -407,7 +407,7 @@
         [#case "instance"]
             [#local properties +=
                 {
-                    "InstanceId" : destinationAttribtue
+                    "InstanceId" : destinationAttribute
                 }
             ]
             [#break]
@@ -415,7 +415,7 @@
         [#case "networkinterface" ]
             [#local properties +=
                 {
-                    "NetworkInterfaceId" : destinationAttribtue
+                    "NetworkInterfaceId" : destinationAttribute
                 }
             ]
             [#break]
@@ -423,7 +423,7 @@
         [#case "nat"]
             [#local properties +=
                 {
-                    "NatGatewayId" : destinationAttribtue
+                    "NatGatewayId" : destinationAttribute
                 }
             ]
             [#break]
@@ -431,7 +431,7 @@
         [#case "peering" ]
             [#local properties +=
                 {
-                    "VpcPeeringConnectionId" : destinationAttribtue
+                    "VpcPeeringConnectionId" : destinationAttribute
                 }
             ]
             [#break]
@@ -439,7 +439,7 @@
         [#case "transit" ]
             [#local properties +=
                 {
-                    "TransitGatewayId" : destinationAttribtue
+                    "TransitGatewayId" : destinationAttribute
                 }
             ]
             [#break]

--- a/aws/services/vpc/resource.ftl
+++ b/aws/services/vpc/resource.ftl
@@ -384,20 +384,22 @@
 [#macro createRoute
             id,
             routeTableId,
-            route
+            destinationType,
+            destinationAttribtue,
+            destinationCidr,
             dependencies=""]
 
     [#local properties =
         {
             "RouteTableId" : getReference(routeTableId),
-            "DestinationCidrBlock" : route.CIDR
+            "DestinationCidrBlock" : destinationCidr
         }
     ]
-    [#switch route.Type]
+    [#switch (destinationType)?lower_case ]
         [#case "gateway"]
             [#local properties +=
                 {
-                    "GatewayId" : getReference(route.IgwId)
+                    "GatewayId" : destinationAttribtue
                 }
             ]
             [#break]
@@ -405,7 +407,15 @@
         [#case "instance"]
             [#local properties +=
                 {
-                    "InstanceId" : getReference(route.InstanceId)
+                    "InstanceId" : destinationAttribtue
+                }
+            ]
+            [#break]
+
+        [#case "networkinterface" ]
+            [#local properties +=
+                {
+                    "NetworkInterfaceId" : destinationAttribtue
                 }
             ]
             [#break]
@@ -413,10 +423,27 @@
         [#case "nat"]
             [#local properties +=
                 {
-                    "NatGatewayId" : getReference(route.NatId)
+                    "NatGatewayId" : destinationAttribtue
                 }
             ]
             [#break]
+
+        [#case "peering" ]
+            [#local properties +=
+                {
+                    "VpcPeeringConnectionId" : destinationAttribtue
+                }
+            ]
+            [#break]
+
+        [#case "transit" ]
+            [#local properties +=
+                {
+                    "TransitGatewayId" : destinationAttribtue
+                }
+            ]
+            [#break]
+
 
     [/#switch]
     [@cfResource


### PR DESCRIPTION
## Description
Adds support for link based network gateways using the `endpoint` engine type 

Adds support for all of the routing endpoints supported through Cloudformation Ec2:Routes using link based components. This allows them to be deployed manually via the console while still integrating with the hamlet deployed network

## Motivation and Context

Allows for integration of complex network component setups like peering which are difficult to cooridinate with infrastructure as code deployments as they require two parties to setup the infrastructure at the same time. With the endpoint engine the details of the peering connection can be provided through an external component attribute. This can also be extended to support linking to other components which offer routing services such as vm instances or network interfaces
 
## How Has This Been Tested?
Tested on active deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
