### PR TITLE
feature(userpool): get client secret on deploy

### DIFF
--- a/aws/components/userpool/setup.ftl
+++ b/aws/components/userpool/setup.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 [#macro aws_userpool_cf_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["template" ] /]
+    [@addDefaultGenerationContract subsets=["template", "epilogue" ] /]
 [/#macro]
 
 [#macro aws_userpool_cf_setup_solution occurrence ]
@@ -9,6 +9,12 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
     [#local resources = occurrence.State.Resources]
+
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+    [#local cmkKeyId = baselineComponentIds["Encryption"]!"" ]
+    [#local cmkKeyArn = getReference(cmkKeyId, ARN_ATTRIBUTE_TYPE)]
 
     [#local userPoolId                 = resources["userpool"].Id]
     [#local userPoolName               = resources["userpool"].Name]
@@ -634,6 +640,29 @@
                     callbackUrls=callbackUrls
                     logoutUrls=logoutUrls
                     dependencies=clientDepedencies
+                /]
+            [/#if]
+            [#if deploymentSubsetRequired("epilogue", false) && subSolution.ClientGenerateSecret ]
+                [@addToDefaultBashScriptOutput
+                    content=
+                    [
+                        r'case ${STACK_OPERATION} in',
+                        r'  create|update)',
+                        r'    user_pool_id="$(get_cloudformation_stack_output "' + regionId + r'" ' + r' "${STACK_NAME}" ' + userPoolId + r' "ref" || return $?)"',
+                        r'    client_id="$(get_cloudformation_stack_output "' + regionId + r'" ' + r' "${STACK_NAME}" ' + userPoolClientId + r' "ref" || return $?)"',
+                        r'    client_secret="$(aws --region "' + regionId + r'" --output text cognito-idp describe-user-pool-client --user-pool-id "${user_pool_id}" --client-id "${client_id}" --query "UserPoolClient.ClientSecret" || return $?)"',
+                        r'    encrypted_client_secret="$(encrypt_kms_string "' + regionId + r'" ' + r' "${client_secret}" ' + r' "' + cmkKeyArn + r'" || return $?)"'
+                    ] +
+                    pseudoStackOutputScript(
+                        "Userpool Client secret",
+                        {
+                            formatId(userPoolClientId, "key") : r'${encrypted_client_secret}'
+                        },
+                        userPoolClientId
+                    ) +
+                    [
+                        "esac"
+                    ]
                 /]
             [/#if]
         [/#if]

--- a/aws/components/userpool/state.ftl
+++ b/aws/components/userpool/state.ftl
@@ -163,6 +163,10 @@
     [#local parentAttributes = parent.State.Attributes ]
     [#local parentResources = parent.State.Resources ]
 
+    [#local encryptionScheme = (solution.EncryptionScheme)?has_content?then(
+                    solution.EncryptionScheme?ensure_ends_with(":"),
+                    "" )]
+
     [#if core.SubComponent.Id == "default" && (parentResources["client"]!{})?has_content ]
         [#local userPoolClientId    = parentResources["client"].Id ]
         [#local userPoolClientName  = parentResources["client"].Name ]
@@ -186,7 +190,7 @@
             attributeIfTrue(
                 "SECRET",
                 solution.ClientGenerateSecret,
-                getExistingReference(userPoolClientId. KEY_ATTRIBUTE_TYPE)
+                getExistingReference(userPoolClientId, KEY_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme)
             ),
             "Roles" : {
                 "Inbound" : {},

--- a/aws/components/userpool/state.ftl
+++ b/aws/components/userpool/state.ftl
@@ -182,7 +182,12 @@
             {
                 "CLIENT" : getExistingReference(userPoolClientId),
                 "LB_OAUTH_SCOPE" : (solution.OAuth.Scopes)?join(" ")
-            },
+            } +
+            attributeIfTrue(
+                "SECRET",
+                solution.ClientGenerateSecret,
+                getExistingReference(userPoolClientId. KEY_ATTRIBUTE_TYPE)
+            ),
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {}


### PR DESCRIPTION
## Description
Adds support for saving the user pool client secret as an encrypted pseduo stack so that the can be provided to other components 

## Motivation and Context
Allows for secure storage of the userpool client secret so that it can be used by other components

## How Has This Been Tested?
Tested on active deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
