### PR TITLE
Gateway endpoint es role

### DIFF
--- a/aws/components/es/setup.ftl
+++ b/aws/components/es/setup.ftl
@@ -98,8 +98,8 @@
     [#local cognitoIntegration = false ]
     [#local cognitoConfig = {
             "Enabled" : false,
-            "RoleArn" : getExistingReference(esServiceRoleId, ARN_ATTRIBUTE_TYPE)
-    } ]
+            "RoleArn" : getReference(esServiceRoleId, ARN_ATTRIBUTE_TYPE)
+    }]
 
     [#local esPolicyStatements = [] ]
 

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -239,8 +239,8 @@
                                             [#break]
 
                                         [#case "endpoint" ]
-                                            [#local endpointScope = gwSolution.EndpointScope ]
-                                            [#local endpointType = gwSolution.EndpointType ]
+                                            [#local endpointScope = (gwSolution.EndpointScope)!"COTFatal: EndpointScope not defined - required for endpoint engine" ]
+                                            [#local endpointType = (gwSolution.EndpointType)!"COTFatal: EndpointType not defined - required for endpoint engine" ]
 
                                             [#switch endpointScope ]
                                                 [#case "zone" ]


### PR DESCRIPTION
## Description
A couple of fixes 
- lookup for service role when not using subsets in ES Cognito integration 
- Add exception based on gateway engine type for missing configuration

## Motivation and Context
- ES failing to deploy using current cognito configuration when not using a subset 
- Other gateway endpoints failing to generate as the gateway configuration requried the endpoint specific configuration

## How Has This Been Tested?
Tested on deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
