### PR TITLE
fix(cdn): dont use s3 website endpoint in s3 backed origins

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -199,11 +199,7 @@
                 [#local spaBaselineComponentIds = getBaselineComponentIds(spaBaselineLinks)]
                 [#local cfAccess = getExistingReference(spaBaselineComponentIds["CDNOriginKey"]!"")]
 
-                [#if isPresent(originLinkTargetConfiguration.Solution.Website) ]
-                    [#local originBucket = (originLinkTargetAttributes["WEBSITE_URL"])?remove_beginning("http://") ]
-                [#else]
-                    [#local originBucket = originLinkTargetAttributes["NAME"] ]
-                [/#if]
+                [#local originBucket = originLinkTargetAttributes["NAME"] ]
 
                 [#local origin =
                     getCFS3Origin(


### PR DESCRIPTION
## Description
Removes overriding the S3 origin endpoint when an S3 component has website hosting enabled. 


## Motivation and Context
This isn't actually supported by CloudFront and the deployment fails

## How Has This Been Tested?
Tested on deployed environment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
