### PR TITLE
feat(mobileapp): OTA CDN on Routes

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -191,6 +191,24 @@
         [#local originLinkTargetAttributes = originLink.State.Attributes ]
 
         [#switch originLinkTargetCore.Type]
+            [#case MOBILEAPP_COMPONENT_TYPE ]
+                [#local spaBaslineProfile = originLinkTargetConfiguration.Solution.Profiles.Baseline ]
+                [#local spaBaselineLinks = getBaselineLinks(originLink, [ "CDNOriginKey" ])]
+                [#local spaBaselineComponentIds = getBaselineComponentIds(spaBaselineLinks)]
+                [#local cfAccess = getExistingReference(spaBaselineComponentIds["CDNOriginKey"]!"")]
+
+                [#local originBucket = originLinkTargetAttributes["OTA_ARTEFACT_BUCKET"]]
+                [#local originPrefix = originLinkTargetAttributes["OTA_ARTEFACT_PREFIX"]]
+
+                [#local otaOrigin =
+                    getCFS3Origin(
+                        originId,
+                        originBucket,
+                        cfAccess,
+                        originPrefix
+                    )]
+                [#local origins += otaOrigin ]
+                [#break]
 
             [#case S3_COMPONENT_TYPE ]
 


### PR DESCRIPTION
## Description
Supports OTA updates for mobile apps on an CDN to follow the path of the CDN route rather than defining its own path 


## Motivation and Context
Currently the mobile app to CDN route uses the S3 component which requires you to use the core relative path of the mobile app to serve the OTA content. The OTA currently locks the path the OTA is available on to the core relative path of the mobile app. This means that you can't use the CDN route paths to control where the OTA is served from publically

## How Has This Been Tested?
Tested on a live deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
