### PR TITLE
fix(cdn): add behaviour for mobile ota

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -208,6 +208,19 @@
                         originPrefix
                     )]
                 [#local origins += otaOrigin ]
+
+                [#local behaviour = getCFSPACacheBehaviour(
+                    otaOrigin,
+                    behaviourPattern,
+                    {
+                        "Default" : subSolution.CachingTTL.Default,
+                        "Max" : subSolution.CachingTTL.Maximum,
+                        "Min" : subSolution.CachingTTL.Minimum
+                    },
+                    subSolution.Compress,
+                    eventHandlers,
+                    _context.ForwardHeaders)]
+                    [#local routeBehaviours += behaviour ]
                 [#break]
 
             [#case S3_COMPONENT_TYPE ]


### PR DESCRIPTION
## Description
Each CDN route requires at least one behaviour to link the frontend to the origin. This adds a behaviour for the mobile ota link

## Motivation and Context
CDN route wasn't working

## How Has This Been Tested?
Tested on active deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
