### PR TITLE
feat(apigatewa): add TLS configuration for domain names

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -416,7 +416,7 @@
                 certificate=valueIfContent(
                     getCFCertificate(
                         cfResources["distribution"].CertificateId,
-                        securityProfile.HTTPSProfile,
+                        securityProfile.CDNHTTPSProfile,
                         solution.CloudFront.AssumeSNI),
                     cfResources["distribution"].CertificateId!"")
                 comment=cfResources["distribution"].Name
@@ -454,7 +454,8 @@
                 type="AWS::ApiGateway::DomainName"
                 properties=
                     {
-                        "DomainName" : value["domain"].Name
+                        "DomainName" : value["domain"].Name,
+                        "SecurityPolicy" : securityProfile.GatewayHTTPSProfile
                     } +
                     valueIfTrue(
                         {


### PR DESCRIPTION
## Description
Adds support for configuring the security policy on a custom domain name on API Gateways. Also aligns setup with https://github.com/hamlet-io/engine/pull/1320 to show that there are two HTTPS profiles on an API Gateway

## Motivation and Context
When using regional API without CloudFront you still need to be able to set the Security Profile. This also ensures that if you are using CloudFront the link between the API Gateway and the Cloudfront distribution is secured as required

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
