### PR TITLE
feat(globaldb): initial support for the globalDb component

### DIFF
--- a/aws/components/configstore/setup.ftl
+++ b/aws/components/configstore/setup.ftl
@@ -15,8 +15,10 @@
     [#local tableSortKey = parentResources["table"].SortKey!"" ]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData" ] )]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+    [#local kmsKeyId = baselineComponentIds["Encryption"]]
+
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
 
@@ -240,6 +242,8 @@
             billingMode=parentSolution.Table.Billing
             writeCapacity=parentSolution.Table.Capacity.Write
             readCapacity=parentSolution.Table.Capacity.Read
+            encrypted=parentSolution.Table.Encrypted
+            kmsKeyId=kmsKeyId
             attributes=dynamoTableKeyAttributes
             keys=dynamoTableKeys
         /]

--- a/aws/components/globaldb/id.ftl
+++ b/aws/components/globaldb/id.ftl
@@ -1,0 +1,11 @@
+[#ftl]
+[@addResourceGroupInformation
+    type=GLOBALDB_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_DYNAMODB_SERVICE
+        ]
+/]

--- a/aws/components/globaldb/setup.ftl
+++ b/aws/components/globaldb/setup.ftl
@@ -1,0 +1,46 @@
+[#ftl]
+[#macro aws_globaldb_cf_generationcontract_solution occurrence ]
+    [@addDefaultGenerationContract subsets=["template" ] /]
+[/#macro]
+
+[#macro aws_globaldb_cf_setup_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+    [#local resources = occurrence.State.Resources]
+
+    [#local tableId = resources["table"].Id ]
+    [#local tableKey = resources["table"].Key ]
+    [#local tableSortKey = resources["table"].SortKey!"" ]
+
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+
+    [#local kmsKeyId = baselineComponentIds["Encryption"]]
+
+    [#local dynamoTableKeys = getDynamoDbTableKey(tableKey , "hash")]
+    [#local dynamoTableKeyAttributes = getDynamoDbTableAttribute( tableKey, STRING_TYPE)]
+
+    [#if (solution.SecondaryKey!"")?has_content ]
+        [#local dynamoTableKeys += getDynamoDbTableKey(tableSortKey, "range" )]
+        [#local dynamoTableKeyAttributes += getDynamoDbTableAttribute(tableSortKey, STRING_TYPE)]
+    [/#if]
+
+
+    [#if deploymentSubsetRequired(GLOBALDB_COMPONENT_TYPE, true) ]
+        [@createDynamoDbTable
+            id=tableId
+            backupEnabled=solution.Table.Backup.Enabled
+            billingMode=solution.Table.Billing
+            writeCapacity=solution.Table.Capacity.Write
+            readCapacity=solution.Table.Capacity.Read
+            attributes=dynamoTableKeyAttributes
+            encrypted=solution.Table.Encrypted
+            ttlKey=solution.TTLKey
+            kmsKeyId=kmsKeyId
+            keys=dynamoTableKeys
+        /]
+    [/#if]
+[/#macro]

--- a/aws/components/globaldb/setup.ftl
+++ b/aws/components/globaldb/setup.ftl
@@ -11,6 +11,7 @@
     [#local resources = occurrence.State.Resources]
 
     [#local tableId = resources["table"].Id ]
+    [#local tableName = resources["table"].Name ]
     [#local tableKey = resources["table"].Key ]
     [#local tableSortKey = resources["table"].SortKey!"" ]
 
@@ -32,6 +33,7 @@
     [#if deploymentSubsetRequired(GLOBALDB_COMPONENT_TYPE, true) ]
         [@createDynamoDbTable
             id=tableId
+            name=tableName
             backupEnabled=solution.Table.Backup.Enabled
             billingMode=solution.Table.Billing
             writeCapacity=solution.Table.Capacity.Write

--- a/aws/components/globaldb/state.ftl
+++ b/aws/components/globaldb/state.ftl
@@ -1,0 +1,51 @@
+[#ftl]
+
+[#macro aws_globaldb_cf_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local id = formatResourceId(AWS_DYNAMODB_TABLE_RESOURCE_TYPE, core.Id )]
+    [#local key = solution.PrimaryKey ]
+
+    [#local sortKey = "" ]
+    [#if (solution.SecondaryKey!"")?has_content ]
+        [#local sortKey = "instance" ]
+    [/#if]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "table" : {
+                    "Id" : id,
+                    "Key" : key,
+                    "SortKey" : sortKey,
+                    "Type" : AWS_DYNAMODB_TABLE_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : {
+                "TABLE_NAME" : getExistingReference(id),
+                "TABLE_ARN" : getExistingReference(id, ARN_ATTRIBUTE_TYPE),
+                "TABLE_KEY" : key
+            } +
+            attributeIfContent(
+                "TABLE_SORT_KEY",
+                sortKey
+            ),
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {
+                    "default" : "consume",
+                    "consume" : dynamoDbViewerPermission(
+                                    getReference(id, ARN_ATTRIBUTE_TYPE)
+                                ),
+                    "produce" : dynamodbProducePermission(
+                                    getReference(id, ARN_ATTRIBUTE_TYPE)
+                                ),
+                    "all"     : dynamodbAllPermission(
+                                    getReference(id,ARN_ATTRIBUTE_TYPE)
+                                )
+               }
+            }
+        }
+    ]
+[/#macro]

--- a/aws/components/globaldb/state.ftl
+++ b/aws/components/globaldb/state.ftl
@@ -17,6 +17,7 @@
             "Resources" : {
                 "table" : {
                     "Id" : id,
+                    "Name" : core.FullName,
                     "Key" : key,
                     "SortKey" : sortKey,
                     "Type" : AWS_DYNAMODB_TABLE_RESOURCE_TYPE

--- a/aws/services/dynamodb/resource.ftl
+++ b/aws/services/dynamodb/resource.ftl
@@ -111,6 +111,7 @@
         attributes
         keys
         encrypted
+        name=""
         ttlKey=""
         kmsKeyId=""
         name=""
@@ -140,6 +141,10 @@
                 "KeySchema" : asArray(keys),
                 "Tags" : getCfTemplateCoreTags(name)
             } +
+            attributeIfContent(
+                "TableName",
+                name
+            ) +
             attributeIfTrue(
                 "PointInTimeRecoverySpecification",
                 backupEnabled,

--- a/aws/services/dynamodb/resource.ftl
+++ b/aws/services/dynamodb/resource.ftl
@@ -14,7 +14,7 @@
     }
 ]
 
-[@addOutputMapping 
+[@addOutputMapping
     provider=AWS_PROVIDER
     resourceType=AWS_DYNAMODB_TABLE_RESOURCE_TYPE
     mappings=DYNAMODB_OUTPUT_MAPPINGS
@@ -110,6 +110,9 @@
         billingMode
         attributes
         keys
+        encrypted
+        ttlKey=""
+        kmsKeyId=""
         name=""
         streamEnabled=false
         streamViewType=""
@@ -157,6 +160,23 @@
                 streamEnabled,
                 {
                     "StreamViewType" : streamViewType
+                }
+            ) +
+            attributeIfTrue(
+                "SSESpecification",
+                encrypted,
+                {
+                    "KMSMasterKeyId" : getReference(kmsKeyId, ARN_ATTRIBUTE_TYPE),
+                    "SSEEnabled" : true,
+                    "SSEType" : "KMS"
+                }
+            ) +
+            attributeIfContent(
+                "TimeToLiveSpecification",
+                ttlKey,
+                {
+                "AttributeName" : ttlKey,
+                "Enabled" : true
                 }
             )
         outputs=DYNAMODB_OUTPUT_MAPPINGS +


### PR DESCRIPTION
## Description
AWS Implementation of https://github.com/hamlet-io/engine/pull/1325 
Supports the provisioning of globalDbs using the AWS DynamoDB service 

## Motivation and Context
Allows for the deployment and control of system level configuration of DyanmoDB Tables 


## How Has This Been Tested?
Tested locally using active deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
