### PR TITLE
feat(ecs): support udp based port mappings

### DIFF
--- a/aws/services/ecs/resource.ftl
+++ b/aws/services/ecs/resource.ftl
@@ -50,7 +50,7 @@
 ]
 
 [#list ecsMappings as type, mappings]
-    [@addOutputMapping 
+    [@addOutputMapping
         provider=AWS_PROVIDER
         resourceType=type
         mappings=mappings
@@ -171,7 +171,12 @@
                     {
                         "ContainerPort" : ports[portMapping.ContainerPort].Port,
                         "HostPort" : portMapping.DynamicHostPort?then(0, ports[portMapping.HostPort].Port)
-                    }
+                    } +
+                    attributeIfTrue(
+                        "Protocol",
+                        (ports[portMapping.ContainerPort].IPProtocol == "udp"),
+                        "udp"
+                    )
                 ]
             ]
         [/#list]
@@ -348,4 +353,3 @@
         outputs=ECS_SERVICE_OUTPUT_MAPPINGS
     /]
 [/#macro]
-


### PR DESCRIPTION
## Description
Adds support for udp based port mappings in task definitions

## Motivation and Context
The default is to use tcp and didn't allow for setting udp based port mappings

## How Has This Been Tested?
Tested locally and on active deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
