### PR TITLE
Router component

### DIFF
--- a/aws/components/gateway/id.ftl
+++ b/aws/components/gateway/id.ftl
@@ -7,7 +7,8 @@
     services=
         [
             AWS_ELASTIC_COMPUTE_SERVICE,
-            AWS_VIRTUAL_PRIVATE_CLOUD_SERVICE
+            AWS_VIRTUAL_PRIVATE_CLOUD_SERVICE,
+            AWS_TRANSIT_GATEWAY_SERVICE
         ]
 /]
 
@@ -18,6 +19,7 @@
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=
         [
-            AWS_VIRTUAL_PRIVATE_CLOUD_SERVICE
+            AWS_VIRTUAL_PRIVATE_CLOUD_SERVICE,
+            AWS_TRANSIT_GATEWAY_SERVICE
         ]
 /]

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -243,7 +243,7 @@
                     vpc=getReference(vpcId)
                 /]
 
-                [@createTransitGatewayRouteTablePropogation
+                [@createTransitGatewayRouteTablePropagation
                     id=transitGatewayRoutePropogationId
                     transitGatewayAttachment=getReference(transitGatewayAttachementId)
                     transitGatewayRouteTable=transitGatewayRouteTable

--- a/aws/components/gateway/state.ftl
+++ b/aws/components/gateway/state.ftl
@@ -73,6 +73,34 @@
             [/#if]
             [#break]
 
+        [#case "router" ]
+            [#local resources += {
+                "transitGatewayAttachement" : {
+                        "Id" : formatResourceId(
+                            AWS_TRANSITGATEWAY_ATTACHMENT_RESOURCE_TYPE,
+                            core.Id
+                        ),
+                        "Name" : core.FullName,
+                        "Type" : AWS_TRANSITGATEWAY_ATTACHMENT_RESOURCE_TYPE
+                },
+                "routePropogation" : {
+                        "Id" : formatResourceId(
+                            AWS_TRANSITGATEWAY_ROUTETABLE_PROPOGATION_TYPE,
+                            core.Id
+                        ),
+                        "Type" : AWS_TRANSITGATEWAY_ROUTETABLE_PROPOGATION_TYPE
+                },
+                "routeAssociation" : {
+                    "Id" : formatResourceId(
+                        AWS_TRANSITGATEWAY_ROUTETABLE_ASSOCIATION_TYPE,
+                        core.Id
+                    ),
+                    "Type" : AWS_TRANSITGATEWAY_ROUTETABLE_ASSOCIATION_TYPE
+                }
+
+            }]
+            [#break]
+
         [#case "vpcendpoint"]
                 [#local resources += {
                     "sg" : {
@@ -174,6 +202,7 @@
         [#case "natgw"]
         [#case "igw"]
         [#case "endpoint" ]
+        [#case "router" ]
             [#break]
 
         [#case "vpcendpoint"]

--- a/aws/components/network/setup.ftl
+++ b/aws/components/network/setup.ftl
@@ -168,7 +168,7 @@
                     [/#if]
                 [/#list]
 
-                [#local tierListId = formatId( "subnetList", core.Id, tierId) ]
+                [#local tierListId = formatId( AWS_VPC_SUBNETLIST_TYPE, core.Id, tierId) ]
                 [#if deploymentSubsetRequired(NETWORK_COMPONENT_TYPE, true)]
                     [@cfOutput
                             tierListId,

--- a/aws/components/network/state.ftl
+++ b/aws/components/network/state.ftl
@@ -22,10 +22,10 @@
                                     solution.Logging.EnableFlowLogs ]
 
     [#local vpcFlowLogEnabled = isPresent(segmentObject.Operations)?then(
-        isPresent(environmentObject.Operations.FlowLogs) || 
+        isPresent(environmentObject.Operations.FlowLogs) ||
         isPresent(segmentObject.Operations.FlowLogs) ||
         solution.Logging.EnableFlowLogs,
-        isPresent(environmentObject.Operations.FlowLogs) || 
+        isPresent(environmentObject.Operations.FlowLogs) ||
         solution.Logging.EnableFlowLogs
     )]
 

--- a/aws/components/router/id.ftl
+++ b/aws/components/router/id.ftl
@@ -1,0 +1,11 @@
+[#ftl]
+[@addResourceGroupInformation
+    type=NETWORK_ROUTER_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_TRANSIT_GATEWAY_SERVICE
+        ]
+/]

--- a/aws/components/router/id.ftl
+++ b/aws/components/router/id.ftl
@@ -1,11 +1,36 @@
 [#ftl]
 [@addResourceGroupInformation
     type=NETWORK_ROUTER_COMPONENT_TYPE
-    attributes=[]
+    attributes=[
+        {
+            "Names": "ResourceSharing",
+            "Description" : "Allows for the resource to be shared with other Accounts",
+            "Children" : [
+                {
+                    "Names" : "Enabled",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Names" : "AccountPrincipals",
+                    "Description" : "List of AWS Account Ids or Organisation ARNS to share the resource with",
+                    "Type": ARRAY_OF_STRING_TYPE,
+                    "Default" : []
+                },
+                {
+                    "Names" : "AllowExternalPrincipals",
+                    "Description" : "Allow resources to be shared outside of the Organisation",
+                    "Type" : BOOLEAN_TYPE,
+                    "Default" : false
+                }
+            ]
+        }
+    ]
     provider=AWS_PROVIDER
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=
         [
-            AWS_TRANSIT_GATEWAY_SERVICE
+            AWS_TRANSIT_GATEWAY_SERVICE,
+            AWS_RESOURCE_ACCESS_SERVICE
         ]
 /]

--- a/aws/components/router/setup.ftl
+++ b/aws/components/router/setup.ftl
@@ -30,7 +30,7 @@
         [@createTransitGatewayRouteTable
             id=routeTableId
             name=routeTableName
-            transitGatewayId=transitGatewayId
+            transitGateway=getReference(transitGatewayId)
         /]
 
     [/#if]

--- a/aws/components/router/setup.ftl
+++ b/aws/components/router/setup.ftl
@@ -1,0 +1,38 @@
+[#ftl]
+[#macro aws_router_cf_generationcontract_segment occurrence ]
+    [@addDefaultGenerationContract subsets="template" /]
+[/#macro]
+
+[#macro aws_router_cf_setup_segment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core ]
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local resources = occurrence.State.Resources ]
+
+    [#local transitGatewayId = resources["transitGateway"].Id ]
+    [#local transitGatewayName = resources["transitGateway"].Name ]
+    [#local routeTableId = resources["routeTable"].Id ]
+    [#local routeTableName = resources["routeTable"].Name ]
+
+    [#local BGPConfiguration = solution.BGP]
+
+    [#if deploymentSubsetRequired(NETWORK_ROUTER_COMPONENT_TYPE, true)]
+
+        [@createTransitGateway
+            id=transitGatewayId
+            name=transitGatewayName
+            bgpEnabled=BGPConfiguration.Enabled
+            amznSideAsn=BGPConfiguration.ASN
+            ecmpSupport=BGPConfiguration.ECMP
+        /]
+
+        [@createTransitGatewayRouteTable
+            id=routeTableId
+            name=routeTableName
+            transitGatewayId=transitGatewayId
+        /]
+
+    [/#if]
+
+[/#macro]

--- a/aws/components/router/setup.ftl
+++ b/aws/components/router/setup.ftl
@@ -33,6 +33,31 @@
             transitGateway=getReference(transitGatewayId)
         /]
 
-    [/#if]
+        [#if solution["aws:ResourceSharing"].Enabled ]
 
+            [#local resourceShareId = resources["resourceShare"].Id ]
+            [#local resourceShareName = resources["resourceShare"].Name ]
+
+            [#local transitGatewayArn = formatRegionalArn(
+                "ec2",
+                {
+                    "Fn::Join": [
+                        "/",
+                        [
+                            "transit-gateway",
+                            getReference(transitGatewayId)
+                        ]
+                    ]
+                }
+                )]
+
+            [@createResourceAccessShare
+                id=resourceShareId
+                name=resourceShareName
+                allowNonOrgPrincipals=solution["aws:ResourceSharing"].AllowExternalPrincipals
+                principals=solution["aws:ResourceSharing"].AccountPrincipals
+                resourceArns=[ transitGatewayArn ]
+            /]
+        [/#if]
+    [/#if]
 [/#macro]

--- a/aws/components/router/state.ftl
+++ b/aws/components/router/state.ftl
@@ -20,7 +20,16 @@
                     "Name" : core.FullName,
                     "Type" : AWS_TRANSITGATEWAY_ROUTETABLE_RESOURCE_TYPE
                 }
-            },
+            } +
+            attributeIfTrue(
+                "resourceShare",
+                solution["aws:ResourceSharing"].Enabled,
+                {
+                    "Id" : formatResourceId(AWS_RESOURCEACCESS_SHARE_RESOURCE_TYPE),
+                    "Name" : core.FullName,
+                    "Type" : AWS_RESOURCEACCESS_SHARE_RESOURCE_TYPE
+                }
+            ),
             "Attributes" : {
             },
             "Roles" : {

--- a/aws/components/router/state.ftl
+++ b/aws/components/router/state.ftl
@@ -1,0 +1,32 @@
+[#ftl]
+
+[#macro aws_router_cf_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local routerId = formatResourceId(AWS_TRANSITGATEWAY_GATEWAY_RESOURCE_TYPE, core.Id) ]
+    [#local routeTableId = formatResourceId(AWS_TRANSITGATEWAY_ROUTETABLE_RESOURCE_TYPE, core.Id) ]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "transitGateway" : {
+                    "Id" : routerId,
+                    "Name" : core.FullName,
+                    "Type" : AWS_TRANSITGATEWAY_GATEWAY_RESOURCE_TYPE
+                },
+                "routeTable" : {
+                    "Id" : routeTableId,
+                    "Name" : core.FullName,
+                    "Type" : AWS_TRANSITGATEWAY_ROUTETABLE_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : {
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]

--- a/aws/services/resourceaccess/id.ftl
+++ b/aws/services/resourceaccess/id.ftl
@@ -1,0 +1,4 @@
+[#ftl]
+
+[#-- Resources --]
+[#assign AWS_RESOURCEACCESS_SHARE_RESOURCE_TYPE = "resourceAccessShare" ]

--- a/aws/services/resourceaccess/resource.ftl
+++ b/aws/services/resourceaccess/resource.ftl
@@ -1,0 +1,23 @@
+[#ftl]
+
+[#macro createResourceAccessShare
+            id
+            name
+            allowNonOrgPrincipals
+            principals
+            resourceArns
+    ]
+
+    [@cfResource
+        id=id
+        type="AWS::RAM::ResourceShare"
+        properties=
+            {
+                "AllowExternalPrincipals" : allowNonOrgPrincipals,
+                "Name" : name,
+                "Principals" : principals,
+                "ResourceArns" : resourceArns
+            }
+        tags=getCfTemplateCoreTags(name)
+    /]
+[/#macro]

--- a/aws/services/service.ftl
+++ b/aws/services/service.ftl
@@ -22,6 +22,7 @@
 [#assign AWS_KINESIS_SERVICE = "kinesis"]
 [#assign AWS_LAMBDA_SERVICE = "lambda"]
 [#assign AWS_RELATIONAL_DATABASE_SERVICE = "rds"]
+[#assign AWS_RESOURCE_ACCESS_SERVICE = "resourceaccess" ]
 [#assign AWS_ROUTE53_SERVICE = "dns"]
 [#assign AWS_SIMPLE_STORAGE_SERVICE = "s3"]
 [#assign AWS_SIMPLE_EMAIL_SERVICE = "ses"]

--- a/aws/services/service.ftl
+++ b/aws/services/service.ftl
@@ -28,6 +28,7 @@
 [#assign AWS_SIMPLE_NOTIFICATION_SERVICE = "sns"]
 [#assign AWS_SIMPLE_QUEUEING_SERVICE = "sqs"]
 [#assign AWS_SYSTEMS_MANAGER_SERVICE = "ssm"]
+[#assign AWS_TRANSIT_GATEWAY_SERVICE = "transitgateway" ]
 [#assign AWS_VIRTUAL_PRIVATE_CLOUD_SERVICE = "vpc"]
 [#assign AWS_WEB_APPLICATION_FIREWALL_SERVICE = "waf"]
 [#assign AWS_AUTOSCALING_SERVICE="autoscaling"]

--- a/aws/services/transitgateway/id.ftl
+++ b/aws/services/transitgateway/id.ftl
@@ -1,0 +1,10 @@
+[#ftl]
+
+[#-- Resources --]
+[#assign AWS_TRANSITGATEWAY_GATEWAY_RESOURCE_TYPE = "transitGateway" ]
+[#assign AWS_TRANSITGATEWAY_ATTACHMENT_RESOURCE_TYPE = "transitGatewayAttachment" ]
+[#assign AWS_TRANSITGATEWAY_ROUTE_RESOURCE_TYPE = "transitGatewayRoute" ]
+
+[#assign AWS_TRANSITGATEWAY_ROUTETABLE_RESOURCE_TYPE = "transitGatewayRouteTable" ]
+[#assign AWS_TRANSITGATEWAY_ROUTETABLE_ASSOCIATION_TYPE = "transitGatewayRouteTableAssociation" ]
+[#assign AWS_TRANSITGATEWAY_ROUTETABLE_PROPOGATION_TYPE = "transitGatewayRouteTablePropogation" ]

--- a/aws/services/transitgateway/resource.ftl
+++ b/aws/services/transitgateway/resource.ftl
@@ -36,9 +36,9 @@
 [#macro createTransitGatewayAttachment
             id
             name
-            transitGatewayId
-            subnetIds
-            vpcId
+            transitGateway
+            subnets
+            vpc
     ]
 
     [@cfResource
@@ -46,9 +46,9 @@
         type="AWS::EC2::TransitGatewayAttachment"
         properties=
             {
-                "SubnetIds" : getReferences(subnetIds),
-                "TransitGatewayId" : getReference(transitGatewayId),
-                "VpcId" : getReference(vpcId)
+                "SubnetIds" : subnets,
+                "VpcId" : vpc,
+                "TransitGatewayId" : transitGateway
             }
         tags=getCfTemplateCoreTags(name)
     /]
@@ -56,8 +56,8 @@
 
 [#macro createTransitGatewayRoute
             id
-            transitGatewayRouteTableId
-            transitGatewayAttachmentId=""
+            transitGatewayRouteTable
+            transitGatewayAttachment=""
             destinationCidr=""
             blackhole=false
     ]
@@ -67,7 +67,7 @@
         type="AWS::EC2::TransitGatewayRoute"
         properties=
             {
-                "TransitGatewayRouteTableId" : getReference(transitGatewayRouteTableId)
+                "TransitGatewayRouteTableId" : transitGatewayRouteTable
             } +
             attributeIfContent(
                 "DestinationCidrBlock",
@@ -79,7 +79,7 @@
             ) +
             attributeIfContent(
                 "TransitGatewayAttachmentId",
-                getReference(transitGatewayAttachmentId)
+                transitGatewayAttachment
             )
     /]
 [/#macro]
@@ -87,7 +87,7 @@
 [#macro createTransitGatewayRouteTable
             id
             name
-            transitGatewayId
+            transitGateway
     ]
 
     [@cfResource
@@ -95,7 +95,7 @@
         type="AWS::EC2::TransitGatewayRouteTable"
         properties=
             {
-                "TransitGatewayId" : getReference(transitGatewayId)
+                "TransitGatewayId" : transitGateway
             }
         tags=getCfTemplateCoreTags(name)
     /]
@@ -104,8 +104,8 @@
 
 [#macro createTransitGatewayRouteTableAssociation
             id
-            transitGatewayAttachmentId
-            transitGatewayRouteTableId
+            transitGatewayAttachment
+            transitGatewayRouteTable
     ]
 
     [@cfResource
@@ -113,16 +113,16 @@
         type="AWS::EC2::TransitGatewayRouteTableAssociation"
         properties=
             {
-                "TransitGatewayAttachmentId" : getReference(transitGatewayAttachmentId),
-                "TransitGatewayRouteTableId" : getReference(transitGatewayRouteTableId)
+                "TransitGatewayAttachmentId" : transitGatewayAttachment,
+                "TransitGatewayRouteTableId" : transitGatewayRouteTable
             }
     /]
 [/#macro]
 
 [#macro createTransitGatewayRouteTablePropogation
             id
-            transitGatewayAttachmentId
-            transitGatewayRouteTableId
+            transitGatewayAttachment
+            transitGatewayRouteTable
     ]
 
     [@cfResource
@@ -130,8 +130,8 @@
         type="AWS::EC2::TransitGatewayRouteTablePropagation"
         properties=
             {
-                "TransitGatewayAttachmentId" : getReference(transitGatewayAttachmentId),
-                "TransitGatewayRouteTableId" : getReference(transitGatewayRouteTableId)
+                "TransitGatewayAttachmentId" : transitGatewayAttachment,
+                "TransitGatewayRouteTableId" : transitGatewayRouteTable
             }
     /]
 [/#macro]

--- a/aws/services/transitgateway/resource.ftl
+++ b/aws/services/transitgateway/resource.ftl
@@ -119,7 +119,7 @@
     /]
 [/#macro]
 
-[#macro createTransitGatewayRouteTablePropogation
+[#macro createTransitGatewayRouteTablePropagation
             id
             transitGatewayAttachment
             transitGatewayRouteTable

--- a/aws/services/transitgateway/resource.ftl
+++ b/aws/services/transitgateway/resource.ftl
@@ -1,0 +1,137 @@
+[#ftl]
+
+[#macro createTransitGateway
+            id
+            name
+            bgpEnabled
+            amznSideAsn
+            ecmpSupport
+    ]
+
+    [@cfResource
+        id=id
+        type="AWS::EC2::TransitGateway"
+        properties=
+            {
+                "DefaultRouteTableAssociation" : "disable",
+                "DefaultRouteTablePropagation" : "disable"
+            } +
+            attributeIfTrue(
+                "AmazonSideAsn",
+                bgpEnabled,
+                amznSideAsn
+            ) +
+            attributeIfTrue(
+                "VpnEcmpSupport",
+                bgpEnabled,
+                ecmpSupport?then(
+                    "enable",
+                    "disable"
+                )
+            )
+        tags=getCfTemplateCoreTags(name)
+    /]
+[/#macro]
+
+[#macro createTransitGatewayAttachment
+            id
+            name
+            transitGatewayId
+            subnetIds
+            vpcId
+    ]
+
+    [@cfResource
+        id=id
+        type="AWS::EC2::TransitGatewayAttachment"
+        properties=
+            {
+                "SubnetIds" : getReferences(subnetIds),
+                "TransitGatewayId" : getReference(transitGatewayId),
+                "VpcId" : getReference(vpcId)
+            }
+        tags=getCfTemplateCoreTags(name)
+    /]
+[/#macro]
+
+[#macro createTransitGatewayRoute
+            id
+            transitGatewayRouteTableId
+            transitGatewayAttachmentId=""
+            destinationCidr=""
+            blackhole=false
+    ]
+
+    [@cfResource
+        id=id
+        type="AWS::EC2::TransitGatewayRoute"
+        properties=
+            {
+                "TransitGatewayRouteTableId" : getReference(transitGatewayRouteTableId)
+            } +
+            attributeIfContent(
+                "DestinationCidrBlock",
+                destinationCidr
+            ) +
+            attributeIftrue(
+                "Blackhole",
+                blackhole
+            ) +
+            attributeIfContent(
+                "TransitGatewayAttachmentId",
+                getReference(transitGatewayAttachmentId)
+            )
+    /]
+[/#macro]
+
+[#macro createTransitGatewayRouteTable
+            id
+            name
+            transitGatewayId
+    ]
+
+    [@cfResource
+        id=id
+        type="AWS::EC2::TransitGatewayRouteTable"
+        properties=
+            {
+                "TransitGatewayId" : getReference(transitGatewayId)
+            }
+        tags=getCfTemplateCoreTags(name)
+    /]
+[/#macro]
+
+
+[#macro createTransitGatewayRouteTableAssociation
+            id
+            transitGatewayAttachmentId
+            transitGatewayRouteTableId
+    ]
+
+    [@cfResource
+        id=id
+        type="AWS::EC2::TransitGatewayRouteTableAssociation"
+        properties=
+            {
+                "TransitGatewayAttachmentId" : getReference(transitGatewayAttachmentId),
+                "TransitGatewayRouteTableId" : getReference(transitGatewayRouteTableId)
+            }
+    /]
+[/#macro]
+
+[#macro createTransitGatewayRouteTablePropogation
+            id
+            transitGatewayAttachmentId
+            transitGatewayRouteTableId
+    ]
+
+    [@cfResource
+        id=id
+        type="AWS::EC2::TransitGatewayRouteTablePropagation"
+        properties=
+            {
+                "TransitGatewayAttachmentId" : getReference(transitGatewayAttachmentId),
+                "TransitGatewayRouteTableId" : getReference(transitGatewayRouteTableId)
+            }
+    /]
+[/#macro]

--- a/aws/services/vpc/id.ftl
+++ b/aws/services/vpc/id.ftl
@@ -14,6 +14,7 @@
 [#assign AWS_VPC_NETWORK_ACL_ASSOCIATION_TYPE = "association" ]
 
 [#assign AWS_VPC_SUBNET_TYPE = "subnet"]
+[#assign AWS_VPC_SUBNETLIST_TYPE = "subnetList" ]
 
 [#assign AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE = "securityGroup" ]
 [#assign AWS_VPC_SECURITY_GROUP_INGRESS_RESOURCE_TYPE = "securityGroupIngress" ]


### PR DESCRIPTION
## Description
AWS support for https://github.com/hamlet-io/engine/pull/1327 

Adds the router component based on the AWS Transit Gateway service. The router deployment itself is a single transit gateway with a single route table. 

The attachment and routing of networks on the Transit gateway is managed by the gateway service. The gateway service should link to a router and based on this the gateway will attach to the transit gateway, route propagation is enabled by default to reduce the configuration required for the networks. 

Adds support for using AWS Resource Access Manager which allows for sharing specific resources between AWS accounts, in this case allows sharing the router between different accounts to form a network mesh between different AWS account VPCs

## Motivation and Context
Supports routing between different AWS VPCs or on premises networks using VPN or Direct Connect links

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
