### PR TITLE
fix(router): Always set ASN on transit gateway

### DIFF
--- a/aws/components/router/setup.ftl
+++ b/aws/components/router/setup.ftl
@@ -22,7 +22,6 @@
         [@createTransitGateway
             id=transitGatewayId
             name=transitGatewayName
-            bgpEnabled=BGPConfiguration.Enabled
             amznSideAsn=BGPConfiguration.ASN
             ecmpSupport=BGPConfiguration.ECMP
         /]

--- a/aws/services/transitgateway/resource.ftl
+++ b/aws/services/transitgateway/resource.ftl
@@ -3,7 +3,6 @@
 [#macro createTransitGateway
             id
             name
-            bgpEnabled
             amznSideAsn
             ecmpSupport
     ]
@@ -14,13 +13,9 @@
         properties=
             {
                 "DefaultRouteTableAssociation" : "disable",
-                "DefaultRouteTablePropagation" : "disable"
+                "DefaultRouteTablePropagation" : "disable",
+                "AmazonSideAsn" : amznSideAsn
             } +
-            attributeIfTrue(
-                "AmazonSideAsn",
-                bgpEnabled,
-                amznSideAsn
-            ) +
             attributeIfTrue(
                 "VpnEcmpSupport",
                 bgpEnabled,

--- a/aws/services/transitgateway/resource.ftl
+++ b/aws/services/transitgateway/resource.ftl
@@ -14,16 +14,12 @@
             {
                 "DefaultRouteTableAssociation" : "disable",
                 "DefaultRouteTablePropagation" : "disable",
-                "AmazonSideAsn" : amznSideAsn
-            } +
-            attributeIfTrue(
-                "VpnEcmpSupport",
-                bgpEnabled,
-                ecmpSupport?then(
+                "AmazonSideAsn" : amznSideAsn,
+                "VpnEcmpSupport" : ecmpSupport?then(
                     "enable",
                     "disable"
                 )
-            )
+            }
         tags=getCfTemplateCoreTags(name)
     /]
 [/#macro]


### PR DESCRIPTION
## Description
Always specify the BGP ASN for a transit gateway regardless if BGP is enabled or not

## Motivation and Context
When deploying a transit gateway if you don't specify the BGP ASN the default ASN is assigned. This ASN happens to be the same ASN assigned on Customer gateways which AWS doesn't support and so using the defaults causes the deployment to fail

## How Has This Been Tested?
Tested on local active deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
