### PR TITLE
fix: Permit iam/lg pass for uncreated components

### DIFF
--- a/aws/components/mobileapp/state.ftl
+++ b/aws/components/mobileapp/state.ftl
@@ -77,7 +77,9 @@
     [#if (otaCDNURL!"")?has_content ]
         [#local otaURL = otaCDNURL ]
     [#else]
-        [#local otaURL = otaS3URL ]
+        [#if (otaS3URL!"")?has_content ]
+            [#local otaURL = otaS3URL ]
+        [/#if]
     [/#if]
 
     [#assign componentState =

--- a/aws/components/userpool/setup.ftl
+++ b/aws/components/userpool/setup.ftl
@@ -29,7 +29,8 @@
         [#local userPoolCustomDomainName = resources["customdomain"].Name ]
         [#local userPoolCustomDomainCertArn = resources["customdomain"].CertificateArn]
 
-        [#if ! userPoolCustomDomainCertArn?has_content ]
+        [#-- Certificate required ifnot doing the iam subset --]
+        [#if (! userPoolCustomDomainCertArn?has_content) && deploymentSubsetRequired(USERPOOL_COMPONENT_TYPE, true) ]
             [@fatal
                 message="ACM Certificate required in us-east-1"
                 context=resources


### PR DESCRIPTION
## Description
A couple of fixes to permit an iam or lg pass when componets are yet to be created.

## Motivation and Context
iam and lg subsets are often run before their corresponding components are created.

## How Has This Been Tested?
Customer deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
