### PR TITLE
fix: Permit iam/lg passes before component created

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -12,7 +12,7 @@
     [#local resources = occurrence.State.Resources ]
     [#local attributes = occurrence.State.Attributes ]
     [#local buildSettings = occurrence.Configuration.Settings.Build ]
-    [#local buildRegistry = buildSettings["BUILD_FORMATS"].Value[0] ]
+    [#local buildRegistry = (buildSettings["BUILD_FORMATS"].Value[0])!"COT-Fatal No build format defined" ]
     [#local roles = occurrence.State.Roles]
 
     [#local apiId      = resources["apigateway"].Id]

--- a/aws/components/spa/setup.ftl
+++ b/aws/components/spa/setup.ftl
@@ -80,7 +80,7 @@
         [/#switch]
     [/#list]
 
-    [#if ! distributions?has_content ]
+    [#if (! distributions?has_content) && deploymentSubsetRequired("epilogue", false) ]
         [@fatal
             message="An SPA must have at least 1 CDN Route component link - Add an inbound CDN Route link to the SPA"
             context=solution


### PR DESCRIPTION
## Description
Tweak apigateway and spa so iam/lg passes can be run before component are created.

## Motivation and Context
iam and lg passes need to berun before components are created.

## How Has This Been Tested?
Customer deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] None of the above.
