### PR TITLE
fix(transitgateway): remove dynamic tags from cfn updates

### DIFF
--- a/aws/services/transitgateway/resource.ftl
+++ b/aws/services/transitgateway/resource.ftl
@@ -20,7 +20,9 @@
                     "disable"
                 )
             }
-        tags=getCfTemplateCoreTags(name)
+        tags=[
+            { "Key" : "Name", "Value" : name }
+        ]
     /]
 [/#macro]
 
@@ -41,7 +43,9 @@
                 "VpcId" : vpc,
                 "TransitGatewayId" : transitGateway
             }
-        tags=getCfTemplateCoreTags(name)
+        tags=[
+            { "Key" : "Name", "Value" : name }
+        ]
     /]
 [/#macro]
 
@@ -89,7 +93,9 @@
             {
                 "TransitGatewayId" : transitGateway
             }
-        tags=getCfTemplateCoreTags(name)
+        tags=[
+            { "Key" : "Name", "Value" : name }
+        ]
     /]
 [/#macro]
 


### PR DESCRIPTION
## Description
Reduces tags on transit gateway down to name only

## Motivation and Context
This has been done for a couple of reasons
- Updates to tags actually replace the transitgateway components ( why??? ) 
- There is a known issue ( confirmed with support case ) where tag updates to transit gateways in change sets cause the stack update to fail 

We currently include the configuration reference ( jenkins job number if run on Jenkins ) 

## How Has This Been Tested?
Tested on active deployment 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
