### PR TITLE
Static transit routes

### DIFF
--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -273,17 +273,28 @@
                         vpc=getReference(vpcId)
                     /]
 
-                    [@createTransitGatewayRouteTablePropagation
-                        id=transitGatewayRoutePropogationId
-                        transitGatewayAttachment=getReference(transitGatewayAttachementId)
-                        transitGatewayRouteTable=transitGatewayRouteTable
-                    /]
-
                     [@createTransitGatewayRouteTableAssociation
                         id=routeTableAssociationId
                         transitGatewayAttachment=getReference(transitGatewayAttachementId)
                         transitGatewayRouteTable=transitGatewayRouteTable
                     /]
+
+                    [#list sourceCidrs as souceCidr ]
+                        [#local vpcRouteId = formatResourceId(
+                                AWS_TRANSITGATEWAY_ROUTE_RESOURCE_TYPE,
+                                gwCore.Id,
+                                souceCidr?index
+                        )]
+
+                        [#if deploymentSubsetRequired(EXTERNALNETWORK_COMPONENT_TYPE, true)]
+                            [@createTransitGatewayRoute
+                                    id=vpcRouteId
+                                    transitGatewayRouteTable=transitGatewayRouteTable
+                                    transitGatewayAttachment=getReference(transitGatewayAttachementId)
+                                    destinationCidr=souceCidr
+                            /]
+                        [/#if]
+                    [/#list]
                 [/#if]
                 [#break]
         [/#switch]

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -286,14 +286,12 @@
                                 souceCidr?index
                         )]
 
-                        [#if deploymentSubsetRequired(EXTERNALNETWORK_COMPONENT_TYPE, true)]
-                            [@createTransitGatewayRoute
-                                    id=vpcRouteId
-                                    transitGatewayRouteTable=transitGatewayRouteTable
-                                    transitGatewayAttachment=getReference(transitGatewayAttachementId)
-                                    destinationCidr=souceCidr
-                            /]
-                        [/#if]
+                        [@createTransitGatewayRoute
+                                id=vpcRouteId
+                                transitGatewayRouteTable=transitGatewayRouteTable
+                                transitGatewayAttachment=getReference(transitGatewayAttachementId)
+                                destinationCidr=souceCidr
+                        /]
                     [/#list]
                 [/#if]
                 [#break]


### PR DESCRIPTION
## Description
Replace route propagation for transit gateway links to VPC with a static route 

## Motivation and Context
An account who has had a transit gateway shared with it can create attachments and routes on the transit gateway but cannot create propagations 

This approach moves to using static network routes instead. Since we have the localnet IP address group this is easy to manage and if required finer grain subnets can be configured using this approach as well

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
