### PR TITLE
feat(router): support for static routes

### DIFF
--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -227,17 +227,15 @@
                     [#case EXTERNALSERVICE_COMPONENT_TYPE]
                         [#if gwSolution.Engine == "router" ]
                             [#local transitGateway = linkTargetAttributes["TRANSIT_GATEWAY_ID"]!"" ]
-                            [#local transitGatewayRouteTable = linkTargetAttributes["ROUTE_TABLE_ID"]!"" ]
 
-                            [#if transitGateway?has_content && transitGatewayRouteTable?has_content ]
+                            [#if transitGateway?has_content ]
                                 [#local routerFound = true  ]
                                 [#local localRouter = false ]
                             [#else]
                                 [@fatal
                                     message="Could not find Attributes for external Transit Gateway or multiple gateways set"
                                     context={
-                                        "TRANSIT_GATEWAY_ID" : linkTargetAttributes["TRANSIT_GATEWAY_ID"]!"",
-                                        "ROUTE_TABLE_ID" : linkTargetAttributes["ROUTE_TABLE_ID"]!""
+                                        "TRANSIT_GATEWAY_ID" : linkTargetAttributes["TRANSIT_GATEWAY_ID"]!""
                                     }
                                 /]
                                 [#continue]

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -93,7 +93,7 @@
                 [#if !legacyIGW ]
                     [#local IGWId = gwResources["internetGateway"].Id ]
                     [#local IGWName = gwResources["internetGateway"].Name ]
-                    [#local IGWAttachementId = gwResources["internetGatewayAttachement"].Id ]
+                    [#local IGWAttachmentId = gwResources["internetGatewayAttachment"].Id ]
 
                     [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, true)]
                         [@createIGW
@@ -101,7 +101,7 @@
                             name=IGWName
                         /]
                         [@createIGWAttachment
-                            id=IGWAttachementId
+                            id=IGWAttachmentId
                             vpcId=vpcId
                             igwId=IGWId
                         /]
@@ -119,13 +119,13 @@
                 [#local localRouter = true]
                 [#local routerFound = false]
 
-                [#local attachementSubnets = [] ]
+                [#local attachmentSubnets = [] ]
                 [#list networkResources["subnets"][gwCore.Tier.Id] as zone,resources]
-                    [#local attachementSubnets += [ resources["subnet"].Id ] ]
+                    [#local attachmentSubnets += [ resources["subnet"].Id ] ]
                 [/#list]
 
-                [#local transitGatewayAttachementId = gwResources["transitGatewayAttachement"].Id ]
-                [#local transitGatewayAttachementName = gwResources["transitGatewayAttachement"].Name ]
+                [#local transitGatewayAttachmentId = gwResources["transitGatewayAttachment"].Id ]
+                [#local transitGatewayAttachmentName = gwResources["transitGatewayAttachment"].Name ]
                 [#local transitGatewayRoutePropogationId = gwResources["routePropogation"].Id ]
                 [#local routeTableAssociationId = gwResources["routeAssociation"].Id ]
                 [#break]
@@ -258,17 +258,17 @@
 
                 [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, true)]
                     [@createTransitGatewayAttachment
-                        id=transitGatewayAttachementId
-                        name=transitGatewayAttachementName
+                        id=transitGatewayAttachmentId
+                        name=transitGatewayAttachmentName
                         transitGateway=transitGateway
-                        subnets=getReferences(attachementSubnets)
+                        subnets=getReferences(attachmentSubnets)
                         vpc=getReference(vpcId)
                     /]
 
                     [#if localRouter ]
                         [@createTransitGatewayRouteTableAssociation
                             id=routeTableAssociationId
-                            transitGatewayAttachment=getReference(transitGatewayAttachementId)
+                            transitGatewayAttachment=getReference(transitGatewayAttachmentId)
                             transitGatewayRouteTable=transitGatewayRouteTable
                         /]
 
@@ -282,7 +282,7 @@
                             [@createTransitGatewayRoute
                                     id=vpcRouteId
                                     transitGatewayRouteTable=transitGatewayRouteTable
-                                    transitGatewayAttachment=getReference(transitGatewayAttachementId)
+                                    transitGatewayAttachment=getReference(transitGatewayAttachmentId)
                                     destinationCidr=souceCidr
                             /]
                         [/#list]
@@ -445,7 +445,7 @@
                                                             destinationType="gateway"
                                                             destinationAttribute=getReference(IGWId)
                                                             destinationCidr=cidr
-                                                            dependencies=IGWAttachementId
+                                                            dependencies=IGWAttachmentId
                                                         /]
                                                     [/#list]
                                                 [#else]
@@ -466,7 +466,7 @@
                                                         destinationType="transit"
                                                         destinationAttribute=transitGateway
                                                         destinationCidr=cidr
-                                                        dependencies=transitGatewayAttachementId
+                                                        dependencies=transitGatewayAttachmentId
                                                     /]
                                                 [/#list]
                                             [/#if]

--- a/aws/components/gateway/state.ftl
+++ b/aws/components/gateway/state.ftl
@@ -66,7 +66,7 @@
                         "Name" : core.FullName,
                         "Type" : AWS_VPC_IGW_RESOURCE_TYPE
                     },
-                    "internetGatewayAttachement" : {
+                    "internetGatewayAttachment" : {
                         "Id" : formatId(AWS_VPC_IGW_ATTACHMENT_TYPE, core.Id),
                         "Type" : AWS_VPC_IGW_ATTACHMENT_TYPE
                     }
@@ -76,14 +76,14 @@
 
         [#case "router" ]
 
-            [#local transitGatewayAttachementId = formatResourceId(
+            [#local transitGatewayAttachmentId = formatResourceId(
                             AWS_TRANSITGATEWAY_ATTACHMENT_RESOURCE_TYPE,
                             core.Id
                         )]
 
             [#local resources += {
-                "transitGatewayAttachement" : {
-                        "Id" : transitGatewayAttachementId,
+                "transitGatewayAttachment" : {
+                        "Id" : transitGatewayAttachmentId,
                         "Name" : core.FullName,
                         "Type" : AWS_TRANSITGATEWAY_ATTACHMENT_RESOURCE_TYPE
                 },
@@ -105,7 +105,7 @@
             }]
 
             [#local attributes += {
-                "TRANSIT_GATEWAY_ATTACHMENT" : getExistingReference(transitGatewayAttachementId)
+                "TRANSIT_GATEWAY_ATTACHMENT" : getExistingReference(transitGatewayAttachmentId)
             }]
             [#break]
 

--- a/aws/components/gateway/state.ftl
+++ b/aws/components/gateway/state.ftl
@@ -4,7 +4,8 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
     [#local engine = solution.Engine ]
-    [#local resources = {} ]
+    [#local resources = {}]
+    [#local attributes = {}]
     [#local zoneResources = {}]
 
     [#if multiAZ!false ]
@@ -74,12 +75,15 @@
             [#break]
 
         [#case "router" ]
-            [#local resources += {
-                "transitGatewayAttachement" : {
-                        "Id" : formatResourceId(
+
+            [#local transitGatewayAttachementId = formatResourceId(
                             AWS_TRANSITGATEWAY_ATTACHMENT_RESOURCE_TYPE,
                             core.Id
-                        ),
+                        )]
+
+            [#local resources += {
+                "transitGatewayAttachement" : {
+                        "Id" : transitGatewayAttachementId,
                         "Name" : core.FullName,
                         "Type" : AWS_TRANSITGATEWAY_ATTACHMENT_RESOURCE_TYPE
                 },
@@ -98,6 +102,10 @@
                     "Type" : AWS_TRANSITGATEWAY_ROUTETABLE_ASSOCIATION_TYPE
                 }
 
+            }]
+
+            [#local attributes += {
+                "TRANSIT_GATEWAY_ATTACHMENT" : getExistingReference(transitGatewayAttachementId)
             }]
             [#break]
 
@@ -195,8 +203,7 @@
                 {
                     "Zones" : zoneResources
                 },
-            "Attributes" : {
-            },
+            "Attributes" : attributes,
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {}

--- a/aws/components/router/id.ftl
+++ b/aws/components/router/id.ftl
@@ -34,3 +34,14 @@
             AWS_RESOURCE_ACCESS_SERVICE
         ]
 /]
+
+[@addResourceGroupInformation
+    type=NETWORK_ROUTER_STATIC_ROUTE_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_TRANSIT_GATEWAY_SERVICE
+        ]
+/]

--- a/aws/components/router/setup.ftl
+++ b/aws/components/router/setup.ftl
@@ -91,12 +91,11 @@
 
                                 [#local transitGatewayAttachment = (linkTargetAttributes["TRANSIT_GATEWAY_ATTACHMENT"])!""]
 
-                                [@debug message="Attachement" context=linkTargetAttributes enabled=true /]
                                 [#if ! transitGatewayAttachment?has_content ]
                                     [#if deploymentSubsetRequired(NETWORK_ROUTER_COMPONENT_TYPE, true)]
                                         [@fatal
                                             message="Could not find transit Gateway Attachment Id"
-                                            detail="Add setting TRANSIT_GATEWAY_ATTACHMENT as the transit gateawy attachement for the route"
+                                            detail="Add setting TRANSIT_GATEWAY_ATTACHMENT as the transit gateawy attachment for the route"
                                             enabled=false
                                         /]
                                     [/#if]

--- a/aws/components/router/setup.ftl
+++ b/aws/components/router/setup.ftl
@@ -59,4 +59,93 @@
             /]
         [/#if]
     [/#if]
+
+    [#list occurrence.Occurrences![] as subOccurrence]
+
+        [#local core = subOccurrence.Core ]
+        [#local solution = subOccurrence.Configuration.Solution ]
+        [#local resources = subOccurrence.State.Resources ]
+
+        [#local destinationCidrs = getGroupCIDRs(solution.IPAddressGroups, true, occurrence)]
+
+        [#switch solution.Action ]
+            [#case "forward" ]
+                [#list solution.Links?values as link]
+                    [#if link?is_hash]
+
+                        [#local linkTarget = getLinkTarget(occurrence, link) ]
+
+                        [@debug message="Link Target" context=linkTarget enabled=false /]
+
+                        [#if !linkTarget?has_content]
+                            [#continue]
+                        [/#if]
+
+                        [#local linkTargetCore = linkTarget.Core ]
+                        [#local linkTargetConfiguration = linkTarget.Configuration ]
+                        [#local linkTargetResources = linkTarget.State.Resources ]
+                        [#local linkTargetAttributes = linkTarget.State.Attributes ]
+
+                        [#switch linkTargetCore.Type]
+                            [#case EXTERNALSERVICE_COMPONENT_TYPE ]
+
+                                [#local transitGatewayAttachment = (linkTargetAttributes["TRANSIT_GATEWAY_ATTACHMENT"])!""]
+
+                                [@debug message="Attachement" context=linkTargetAttributes enabled=true /]
+                                [#if ! transitGatewayAttachment?has_content ]
+                                    [#if deploymentSubsetRequired(NETWORK_ROUTER_COMPONENT_TYPE, true)]
+                                        [@fatal
+                                            message="Could not find transit Gateway Attachment Id"
+                                            detail="Add setting TRANSIT_GATEWAY_ATTACHMENT as the transit gateawy attachement for the route"
+                                            enabled=false
+                                        /]
+                                    [/#if]
+                                [/#if]
+
+                                [#local routeTableAssociationId = resources["routeAssociations"][linkTargetCore.Id].Id]
+
+                                [#if deploymentSubsetRequired(NETWORK_ROUTER_COMPONENT_TYPE, true)]
+                                [@createTransitGatewayRouteTableAssociation
+                                    id=routeTableAssociationId
+                                    transitGatewayAttachment=transitGatewayAttachment
+                                    transitGatewayRouteTable=getReference(routeTableId)
+                                /]
+                                [/#if]
+
+                                [#list destinationCidrs as destinationCidr ]
+                                    [#local destinationCidrId = replaceAlphaNumericOnly(destinationCidr)]
+                                    [#local routeId = resources["routes"][linkTargetCore.Id][destinationCidrId].Id ]
+
+                                    [#if deploymentSubsetRequired(NETWORK_ROUTER_COMPONENT_TYPE, true)]
+                                        [@createTransitGatewayRoute
+                                                id=routeId
+                                                transitGatewayRouteTable=getReference(routeTableId)
+                                                transitGatewayAttachment=transitGatewayAttachment
+                                                destinationCidr=destinationCidr
+                                        /]
+                                    [/#if]
+                                [/#list]
+                                [#break]
+                        [/#switch]
+                    [/#if]
+                [/#list]
+                [#break]
+
+            [#case "blackhole" ]
+                [#list destinationCidrs as destinationCidr ]
+                    [#local destinationCidrId = replaceAlphaNumericOnly(destinationCidr)]
+                    [#local routeId = resources["routes"][destinationCidrId].Id ]
+
+                    [#if deploymentSubsetRequired(NETWORK_ROUTER_COMPONENT_TYPE, true)]
+                        [@createTransitGatewayRoute
+                                id=routeId
+                                transitGatewayRouteTable=getReference(routeTableId)
+                                blackhole=true
+                                destinationCidr=destinationCidr
+                        /]
+                    [/#if]
+                [/#list]
+                [#break]
+        [/#switch]
+    [/#list]
 [/#macro]

--- a/aws/components/router/state.ftl
+++ b/aws/components/router/state.ftl
@@ -39,3 +39,89 @@
         }
     ]
 [/#macro]
+
+
+[#macro aws_routerstaticroute_cf_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local resources = {}]
+
+    [#local destinationCidrs = getGroupCIDRs(solution.IPAddressGroups, true, occurrence)]
+
+    [#switch solution.Action]
+        [#case "forward" ]
+            [#local links = getLinkTargets(occurrence, solution.Links) ]
+            [#list links as id,link ]
+                [#switch link.Core.Type ]
+                    [#case EXTERNALSERVICE_COMPONENT_TYPE ]
+                        [#local resources = mergeObjects(resources,
+                                        {
+                                            "routeAssociations" : {
+                                                link.Core.Id : {
+                                                    "Id" : formatResourceId(
+                                                        AWS_TRANSITGATEWAY_ROUTETABLE_ASSOCIATION_TYPE,
+                                                        core.Id,
+                                                        link.Core.Id
+                                                    ),
+                                                    "Type" : AWS_TRANSITGATEWAY_ROUTETABLE_ASSOCIATION_TYPE
+                                                }
+                                            }
+                                        })]
+
+                        [#list destinationCidrs as destinationCidr ]
+                            [#local destinationCidrId = replaceAlphaNumericOnly(destinationCidr)]
+                            [#local resources = mergeObjects(resources,
+                                            {
+                                                "routes" : {
+                                                    link.Core.Id : {
+                                                        destinationCidrId : {
+                                                            "Id" : formatResourceId(
+                                                                AWS_TRANSITGATEWAY_ROUTE_RESOURCE_TYPE,
+                                                                core.Id,
+                                                                link.Core.Id,
+                                                                destinationCidrId
+                                                            ),
+                                                            "Type" : AWS_TRANSITGATEWAY_ROUTE_RESOURCE_TYPE
+                                                        }
+                                                    }
+                                                }
+                                            })]
+                        [/#list]
+                        [#break]
+                [/#switch]
+            [/#list]
+            [#break]
+
+        [#case "blackhole" ]
+            [#list destinationCidrs as destinationCidr ]
+                [#local destinationCidrId = replaceAlphaNumericOnly(destinationCidr)]
+                [#local resources = mergeObjects(resources,
+                                {
+                                    "routes" : {
+                                        destinationCidrId : {
+                                            "Id" : formatResourceId(
+                                                AWS_TRANSITGATEWAY_ROUTE_RESOURCE_TYPE,
+                                                core.Id,
+                                                destinationCidrId
+                                            ),
+                                            "Type" : AWS_TRANSITGATEWAY_ROUTE_RESOURCE_TYPE
+                                        }
+                                    }
+                                })]
+            [/#list]
+            [#break]
+
+    [/#switch]
+
+    [#assign componentState =
+        {
+            "Resources" : resources,
+            "Attributes" : {},
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]


### PR DESCRIPTION
## Description
Implements https://github.com/hamlet-io/engine/pull/1331 for AWS 

To implement this you need to create a couple of things 

In the client account:
- An external service with the transitGateway Id set as the TRANSIT_GATEWAY_ID attribute 
- A Gateway using the router engine with a link to this external service 

 This will attach the client VPC to the Transit Gateway 

In the owner account:
- A router component 
- An external service with the transitGateway Attachement from the client Id as TRANSIT_GATEWAY_ATTACHMENT attribute 
- An IP address group which represents the client VPC Network 
- A Static Router on the router which links to the external Service for the transit gateway attachment


## Motivation and Context
Allows for transit gateways shared between two AWS accounts, the account who has received the transit gateway can only create attachments,  routes, routeTables and propagation configuration can only be managed by the account which owns the gateway. 


## How Has This Been Tested?
Tested on local deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
