### PR TITLE
feat(lb): Support for Network load balancer TLS offload

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -530,7 +530,7 @@
                         attributes=tgAttributes
                         targetType=solution.Forward.TargetType
                         vpcId=vpcId
-                            /]
+                    /]
                 [/#if]
 
                 [#break]

--- a/aws/services/lb/resource.ftl
+++ b/aws/services/lb/resource.ftl
@@ -183,6 +183,12 @@
 
 [#macro createALBListener id port albId defaultTargetGroupId certificateId="" sslPolicy="" ]
 
+    [#if port.Protocol == "SSL" ]
+        [#local protocol = "TLS" ]
+    [#else]
+        [#local protocol = port.Protocol]
+    [/#if]
+
     [@cfResource
         id=id
         type="AWS::ElasticLoadBalancingV2::Listener"
@@ -196,7 +202,7 @@
                 ],
                 "LoadBalancerArn" : getReference(albId),
                 "Port" : port.Port,
-                "Protocol" : port.Protocol
+                "Protocol" : protocol
             } +
             valueIfTrue(
                 {


### PR DESCRIPTION
## Description
Adds support for TLS offload on Network load balancers. 

## Motivation and Context
This allows you to use a network load balancer for limited HTTPS communication along with TCP communication. Really helpful for services which are offered by a privateservice as they only support Network Load Balancers 

## How Has This Been Tested?
Tested on local deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
