### PR TITLE
fix(privateservice): only error during subset

### DIFF
--- a/aws/components/privateservice/setup.ftl
+++ b/aws/components/privateservice/setup.ftl
@@ -52,18 +52,17 @@
         [/#if]
     [/#list]
 
-    [#if ! loadBalancerIds?has_content ]
-
-        [@fatal
-            message="No Network Load Balancers found - at least one link to a network load balancer required"
-            context={
-                "Links" : solution.Links
-            }
-        /]
-
-    [/#if]
-
     [#if deploymentSubsetRequired(PRIVATE_SERVICE_COMPONENT_TYPE, true)]
+        [#if ! loadBalancerIds?has_content ]
+
+            [@fatal
+                message="No Network Load Balancers found - at least one link to a network load balancer required"
+                context={
+                    "Links" : solution.Links
+                }
+            /]
+
+        [/#if]
 
         [@createVPCEndpointService
             id=vpcEndpointServiceId


### PR DESCRIPTION
## Description
Minor fix to only check for load balancers during the private service subset

## Motivation and Context
Allows for iam and lg subsets to work when components haven't been deployed

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
