### PR TITLE
feat(gateway): private dns configuration

### DIFF
--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -39,7 +39,24 @@
         [#local legacyIGW = (networkResources["legacyIGW"]!{})?has_content]
 
         [#local vpcId = networkResources["vpc"].Id ]
-        [#local vpcPrivateDNS = networkConfiguration.DNS.UseProvider && networkConfiguration.DNS.GenerateHostNames]
+
+        [#if gwSolution.DNSSupport?is_boolean ]
+            [#local vpcPrivateDNS = gwSolution.DNSSupport]
+        [#else]
+            [#switch gwSolution.DNSSupport ]
+                [#case "UseNetworkConfig" ]
+                    [#local vpcPrivateDNS = networkConfiguration.DNS.UseProvider && networkConfiguration.DNS.GenerateHostNames]
+                    [#break]
+
+                [#case "Enabled" ]
+                    [#local vpcPrivateDNS = true ]
+                    [#break]
+
+                [#case "Disabled" ]
+                    [#local vpcPrivateDNS = false]
+                    [#break]
+            [/#switch]
+        [/#if]
 
         [#local sourceIPAddressGroups = gwSolution.SourceIPAddressGroups ]
         [#local sourceCidrs = getGroupCIDRs(sourceIPAddressGroups, true, occurrence)]


### PR DESCRIPTION
## Description
Adds support for controlling DNS private zone creation on a per gateway basis ( implements https://github.com/hamlet-io/engine/pull/1333 )

## Motivation and Context
When using customer created vpc endpoints that require acceptance the DNS private zone cannot be created until the endpoint has been accepted. I guess its a security thing as this could potentially expose who or what a service is that you might not be allowed to access

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
