### PR TITLE
feat(lb): static targets

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -473,7 +473,6 @@
                             [#local endpointAddresses += getHostsFromNetwork(endpointCIDR) ]
                         [/#list]
 
-                        [@debug message="IPs" context={ "endpointCIDRS" : endpointCIDRS, "endpointAddresses" : endpointAddresses} enabled=true /]
                         [#list endpointAddresses as endpointAddress ]
                             [#local staticTargets += getTargetGroupTarget("ip", endpointAddress, endpointPort, true)]
                         [/#list]


### PR DESCRIPTION
## Description
Implements routing to static endpoints defined in https://github.com/hamlet-io/engine/pull/1334

When a LB Port links to an external service endpoint it uses the IPAddressGroups and Port defined on the endpoint to create a fixed target in the load balancer Target group. This is support for both application and network load balancers

CIDR ranges will be converted to individual hosts - this can be useful if you have floating addresses, you will get quite a few failed endpoints though 

## Motivation and Context
When using Private Services you might want to offer an on-premis service to other Networks. This allows you to define this external service as a target in the Network load balancer used to offer the the private service. This removes the need for a proxy service deployed in the VPC which proxies this traffic.

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
