### PR TITLE
feat(gateway): add support for destination port configuration

### DIFF
--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -127,6 +127,7 @@
             [#break]
 
             [#case "vpcendpoint"]
+            [#case "privateservice"]
             [#break]
 
             [#case "router"]
@@ -178,8 +179,11 @@
 
         [#switch gwSolution.Engine ]
             [#case "vpcendpoint" ]
+            [#case "privateservice"]
                 [#local securityGroupId = gwResources["sg"].Id]
                 [#local securityGroupName = gwResources["sg"].Name ]
+
+                [#local destinationPorts = gwSolution.DestinationPorts ]
 
                 [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, true)]
                     [@createSecurityGroup
@@ -187,20 +191,23 @@
                         name=securityGroupName
                         occurrence=occurrence
                         vpcId=vpcId
-                        /]
-
-                    [#list sourceCidrs as cidr ]
-
-                        [@createSecurityGroupIngress
-                            id=
-                                formatDependentSecurityGroupIngressId(
-                                    securityGroupId,
-                                    replaceAlphaNumericOnly(cidr)
-                                )
-                            port=""
-                            cidr=cidr
-                            groupId=securityGroupId
                     /]
+
+                    [#list destinationPorts as destinationPort ]
+
+                        [#list sourceCidrs as cidr ]
+                            [@createSecurityGroupIngress
+                                id=
+                                    formatDependentSecurityGroupIngressId(
+                                        securityGroupId,
+                                        destinationPort,
+                                        replaceAlphaNumericOnly(cidr)
+                                    )
+                                port=destinationPort
+                                cidr=cidr
+                                groupId=securityGroupId
+                            /]
+                        [/#list]
                     [/#list]
                 [/#if]
                 [#break]
@@ -555,6 +562,7 @@
 
             [#switch gwSolution.Engine ]
                 [#case "vpcendpoint" ]
+                [#case "privateservice" ]
                     [#local vpcEndpointResources = resources["vpcEndpoints"]!{} ]
                     [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, true)]
 

--- a/aws/components/gateway/state.ftl
+++ b/aws/components/gateway/state.ftl
@@ -110,6 +110,7 @@
             [#break]
 
         [#case "vpcendpoint"]
+        [#case "privateservice"]
                 [#local resources += {
                     "sg" : {
                         "Id" : formatDependentSecurityGroupId(core.Id),
@@ -220,7 +221,7 @@
     [#local parentSolution = parent.Configuration.Solution ]
     [#local engine = parentSolution.Engine ]
 
-    [#if multiAZ!false || engine == "vpcendpoint" ]
+    [#if multiAZ!false || ( engine == "vpcendpoint" || engine == "privateservice" ) ]
         [#local resourceZones = zones ]
     [#else]
         [#local resourceZones = [zones[0]] ]
@@ -237,6 +238,7 @@
             [#break]
 
         [#case "vpcendpoint"]
+        [#case "privateservice"]
 
             [#local endpointZones = {} ]
             [#list resourceZones as zone]

--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1174,7 +1174,7 @@
             "vpcendpoint"
           ],
           "gateway": {
-            "Engine": "vpcendpoint",
+            "Engine": "privateservice",
             "Destinations": {
               "default": {
                 "NetworkEndpointGroups": [

--- a/aws/masterData.json
+++ b/aws/masterData.json
@@ -1170,7 +1170,7 @@
             "vpcendpoint"
           ],
           "gateway": {
-            "Engine": "vpcendpoint",
+            "Engine": "privateservice",
             "Destinations": {
               "default": {
                 "NetworkEndpointGroups": [


### PR DESCRIPTION
## Description
Implements https://github.com/hamlet-io/engine/pull/1335 for aws 
- Support for both the vpcendpoint and privatesevice engines 
- Prefer using privateservice instead of vpcendpoint
- Create security groups ingress rules for private services based on the specified destination ports 

## Motivation and Context
- More understandable naming of gateway engine type
- Security focussed control of security groups

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
