### PR TITLE
fix(gateway): remove local route check for adding VPC routes

### DIFF
--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -516,18 +516,16 @@
                                             [#break]
 
                                         [#case "router"]
-                                            [#if localRouter ]
-                                                [#list cidrs as cidr ]
-                                                    [@createRoute
-                                                        id=formatRouteId(zoneRouteTableId, core.Id, cidr?index)
-                                                        routeTableId=zoneRouteTableId
-                                                        destinationType="transit"
-                                                        destinationAttribute=transitGateway
-                                                        destinationCidr=cidr
-                                                        dependencies=transitGatewayAttachmentId
-                                                    /]
-                                                [/#list]
-                                            [/#if]
+                                            [#list cidrs as cidr ]
+                                                [@createRoute
+                                                    id=formatRouteId(zoneRouteTableId, core.Id, cidr?index)
+                                                    routeTableId=zoneRouteTableId
+                                                    destinationType="transit"
+                                                    destinationAttribute=transitGateway
+                                                    destinationCidr=cidr
+                                                    dependencies=transitGatewayAttachmentId
+                                                /]
+                                            [/#list]
                                             [#break]
 
                                         [#case "private" ]


### PR DESCRIPTION
## Description
Minor fix to allow routes for shared transit gateways to be created when there is an external transit gateway

## Motivation and Context
I think this was a copy and paste issue while I was setting it up. Routes on the VPC should always be created

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
