### PR TITLE
fix: set destination ports for default private service

### DIFF
--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1175,6 +1175,7 @@
           ],
           "gateway": {
             "Engine": "privateservice",
+            "DestinationPorts" : [ "http", "https" ],
             "Destinations": {
               "default": {
                 "NetworkEndpointGroups": [


### PR DESCRIPTION
## Description
Sets the default vpcendpoint port list to http and https

## Motivation and Context
Minor hardening fix to set the ports for the default vpcendpoint to http and https only. This also applies a workaround to a recent change to the security group ids which meant that the ingress rule for any port was removed 

## How Has This Been Tested?
tested on local deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
