### PR TITLE
fix(s3): fix for buckets without encryption

### DIFF
--- a/aws/services/s3/resource.ftl
+++ b/aws/services/s3/resource.ftl
@@ -348,8 +348,9 @@
             }]
     [/#list]
 
+    [#local bucketEncryptionConfig = {} ]
     [#if encrypted ]
-        [#local bucketEncryption = {
+        [#local bucketEncryptionConfig = {
             "ServerSideEncryptionConfiguration" : [
                 {
                     "ServerSideEncryptionByDefault" : {
@@ -412,7 +413,7 @@
             attributeIfTrue(
                 "BucketEncryption",
                 encrypted,
-                bucketEncryption
+                bucketEncryptionConfig
             )
         tags=getCfTemplateCoreTags("", tier, component, "", false, false, 7)
         outputs=S3_OUTPUT_MAPPINGS


### PR DESCRIPTION
## Description
Minor fix to the generation of the bucket encryption configuration on S3 

## Motivation and Context
Buckets were failing to generate without encryption as the variable wasn't available for the bucketencryption config

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
