### PR TITLE
Network Profiles and Ingress/Eggress Security Groups

### DIFF
--- a/aws/components/bastion/state.ftl
+++ b/aws/components/bastion/state.ftl
@@ -3,6 +3,8 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
+    [#local securityGroupToId = formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id )]
+
     [#assign componentState =
         {
             "Resources" : {
@@ -12,13 +14,8 @@
                     "Type" : AWS_EIP_RESOURCE_TYPE
                 },
                 "securityGroupTo" : {
-                    "Id" : formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id ),
+                    "Id" : securityGroupToId,
                     "Name" : core.FullName,
-                    "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
-                },
-                "securityGroupFrom" : {
-                    "Id" : formatSSHFromProxySecurityGroupId(),
-                    "Name" : formatName( formatSegmentFullName(), "all", core.Component.Name),
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 },
                 "role" : {
@@ -53,8 +50,19 @@
             "Attributes" : {
             },
             "Roles" : {
-                "Inbound" : {},
-                "Outbound" : {}
+                "Inbound" : {
+                    "networkacl" : {
+                        "SecurityGroups" : getExistingReference(securityGroupToId),
+                        "Description" : core.FullName
+                    }
+                },
+                "Outbound" : {
+                    "networkacl" : {
+                        "Ports": [ "ssh" ],
+                        "SecurityGroups" : getExistingReference(securityGroupToId),
+                        "Description" : core.FullName
+                    }
+                }
             }
         }
     ]

--- a/aws/components/computecluster/state.ftl
+++ b/aws/components/computecluster/state.ftl
@@ -6,6 +6,7 @@
     [#local buildReference = getOccurrenceBuildReference(occurrence) ]
 
     [#local autoScaleGroupId = formatResourceId( AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE, core.Id )]
+    [#local securityGroupId = formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id )]
 
     [#local autoScaling = {}]
     [#if solution.ScalingPolicies?has_content ]
@@ -39,7 +40,7 @@
         {
             "Resources" : {
                 "securityGroup" : {
-                    "Id" : formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id ),
+                    "Id" : securityGroupId,
                     "Name" : core.FullName,
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 },
@@ -86,8 +87,19 @@
             "Attributes" : {
             },
             "Roles" : {
-                "Inbound" : {},
-                "Outbound" : {}
+                "Inbound" : {
+                    "networkacl" : {
+                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "Description" : core.FullName
+                    }
+                },
+                "Outbound" : {
+                    "networkacl" : {
+                        "Ports" : [ "ssh" ],
+                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "Description" : core.FullName
+                    }
+                }
             }
         }
     ]

--- a/aws/components/datapipeline/state.ftl
+++ b/aws/components/datapipeline/state.ftl
@@ -5,6 +5,7 @@
     [#local solution = occurrence.Configuration.Solution ]
 
     [#local pipelineId = formatResourceId( AWS_DATA_PIPELINE_RESOURCE_TYPE, core.Id )]
+    [#local securityGroupId = formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id )]
 
     [#-- The ec2 Role and Instance profile must have the same name --]
     [#local resourceRoleName = formatName(core.FullName, "resource")]
@@ -35,7 +36,7 @@
                     "Type" : AWS_EC2_INSTANCE_PROFILE_RESOURCE_TYPE
                 },
                 "securityGroup" : {
-                    "Id" : formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id ),
+                    "Id" : securityGroupId,
                     "Name" : core.FullName,
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 }
@@ -44,8 +45,19 @@
                 "ID" : getExistingReference( pipelineId )
             },
             "Roles" : {
-                "Inbound" : {},
-                "Outbound" : {}
+                "Inbound" : {
+                    "networkacl" : {
+                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "Description" : core.FullName
+                    }
+                },
+                "Outbound" : {
+                    "networkacl" : {
+                        "Ports" : [ "ssh" ],
+                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "Description" : core.FullName
+                    }
+                }
             }
         }
     ]

--- a/aws/components/efs/setup.ftl
+++ b/aws/components/efs/setup.ftl
@@ -31,29 +31,71 @@
     [#local efsFullName            = resources["efs"].Name]
     [#local efsSecurityGroupId     = resources["sg"].Id]
     [#local efsSecurityGroupName   = resources["sg"].Name]
+    [#local efsSecurityGroupPorts  = resources["sg"].Ports]
 
     [#local efsSecurityGroupIngressId = formatDependentSecurityGroupIngressId(
                                             efsSecurityGroupId,
                                             efsPort)]
+
+    [#local networkProfile = getNetworkProfile(solution.Profiles.Network)]
 
     [#-- Baseline component lookup --]
     [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption"] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cmkKeyId = baselineComponentIds["Encryption" ]]
 
-    [#if deploymentSubsetRequired("efs", true) ]
+    [#list solution.Links?values as link]
+        [#if link?is_hash]
+            [#local linkTarget = getLinkTarget(occurrence, link) ]
+
+            [@debug message="Link Target" context=linkTarget enabled=false /]
+
+            [#if !linkTarget?has_content]
+                [#continue]
+            [/#if]
+
+            [#local linkTargetCore = linkTarget.Core ]
+            [#local linkTargetConfiguration = linkTarget.Configuration ]
+            [#local linkTargetResources = linkTarget.State.Resources ]
+            [#local linkTargetAttributes = linkTarget.State.Attributes ]
+
+            [#if deploymentSubsetRequired(EFS_COMPONENT_TYPE, true)]
+                [@createSecurityGroupRulesFromLink
+                    occurrence=occurrence
+                    groupId=efsSecurityGroupId
+                    linkTarget=linkTarget
+                    inboundPorts=[ port ]
+                /]
+            [/#if]
+
+        [/#if]
+    [/#list]
+
+    [#if deploymentSubsetRequired(EFS_COMPONENT_TYPE, true) ]
+
         [@createSecurityGroup
             id=efsSecurityGroupId
             name=efsSecurityGroupName
-            occurrence=occurrence
             vpcId=vpcId
+            occurrence=occurrence
         /]
 
-        [@createSecurityGroupIngress
-            id=efsSecurityGroupIngressId
-            port=efsPort
-            cidr="0.0.0.0/0"
+        [@createSecurityGroupRulesFromNetworkProfile
+            occurrence=occurrence
             groupId=efsSecurityGroupId
+            networkProfile=networkProfile
+            inboundPorts=efsSecurityGroupPorts
+        /]
+
+        [#local ingressNetworkRule = {
+                "Ports" : [ efsSecurityGroupPorts ],
+                "IPAddressGroups" : solution.IPAddressGroups
+        }]
+
+        [@createSecurityGroupIngressFromNetworkRule
+            occurrence=occurrence
+            groupId=efsSecurityGroupId
+            networkRule=ingressNetworkRule
         /]
 
         [@createEFS
@@ -72,7 +114,6 @@
                 subnet=getSubnets(core.Tier, networkResources, zone.Id, true, false)
                 efsId=efsId
                 securityGroups=efsSecurityGroupId
-                dependencies=[efsId,efsSecurityGroupId]
             /]
         [/#list]
     [/#if ]

--- a/aws/components/externalnetwork/state.ftl
+++ b/aws/components/externalnetwork/state.ftl
@@ -18,8 +18,19 @@
                 solution.BGP.ASN
             ),
             "Roles" : {
-                "Inbound" : {},
-                "Outbound" : {}
+                "Inbound" : {
+                    "networkacl" : {
+                        "IPAddressGroups" : solution.IPAddressGroups,
+                        "Description" : core.FullName
+                    }
+                },
+                "Outbound" : {
+                    "networkacl" : {
+                        "Ports" : solution.Ports,
+                        "IPAddressGroups" : solution.IPAddressGroups,
+                        "Description" : core.FullName
+                    }
+                }
             }
         }
     ]

--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1365,7 +1365,6 @@
       "Active": false,
       "IPAddressGroups": []
     },
-    "ConsoleOnly": false,
     "S3": {
       "IncludeTenant": false
     },
@@ -1742,6 +1741,22 @@
         "s3",
         "dynamodb"
       ]
+    }
+  },
+  "NetworkProfiles" :{
+    "default" : {
+      "BaseSecurityGroup" : {
+        "Links" : {
+          "sshBastion" : {
+            "Tier" : "mgmt",
+            "Component" : "ssh",
+            "Instance" : "",
+            "Version" : "",
+            "Direction" : "inbound",
+            "Role" : "networkacl"
+          }
+        }
+      }
     }
   },
   "BaselineProfiles": {

--- a/aws/masterData.json
+++ b/aws/masterData.json
@@ -1360,7 +1360,6 @@
       "Active": false,
       "IPAddressGroups": []
     },
-    "ConsoleOnly": false,
     "S3": {
       "IncludeTenant": false
     },
@@ -2144,6 +2143,22 @@
     },
     "_sns-failure": {
       "Pattern": "{ $.status = \"FAILURE\" }"
+    }
+  },
+  "NetworkProfiles" :{
+    "default" : {
+      "BaseSecurityGroup" : {
+        "Links" : {
+          "sshBastion" : {
+            "Tier" : "mgmt",
+            "Component" : "ssh",
+            "Instance" : "",
+            "Version" : "",
+            "Direction" : "inbound",
+            "Role" : "networkacl"
+          }
+        }
+      }
     }
   },
   "DeploymentProfiles": {

--- a/aws/services/rds/resource.ftl
+++ b/aws/services/rds/resource.ftl
@@ -122,12 +122,12 @@
         } +
         valueIfTrue(
             {
-                "AllocatedStorage": size,
+                "AllocatedStorage": size?c?string,
                 "StorageType" : "gp2",
                 "BackupRetentionPeriod" : retentionPeriod,
                 "DBInstanceIdentifier": name,
                 "VPCSecurityGroups": asArray( getReference(securityGroupId)),
-                "Port" : port,
+                "Port" : port?c?string,
                 "EngineVersion": engineVersion
             },
             ( !clusterMember ),

--- a/aws/services/vpc/id.ftl
+++ b/aws/services/vpc/id.ftl
@@ -18,6 +18,7 @@
 
 [#assign AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE = "securityGroup" ]
 [#assign AWS_VPC_SECURITY_GROUP_INGRESS_RESOURCE_TYPE = "securityGroupIngress" ]
+[#assign AWS_VPC_SECURITY_GROUP_EGRESS_RESOURCE_TYPE = "securityGroupEgress" ]
 
 [#assign AWS_VPC_IGW_RESOURCE_TYPE = "igw" ]
 [#assign AWS_VPC_IGW_ATTACHMENT_TYPE = formatId( AWS_VPC_IGW_RESOURCE_TYPE, "attachment") ]
@@ -67,12 +68,6 @@
         )]
 [/#function]
 
-[#function formatSecurityGroupIngressId ids...]
-    [#return formatResourceId(
-                AWS_VPC_SECURITY_GROUP_INGRESS_RESOURCE_TYPE,
-                ids)]
-[/#function]
-
 [#-- Use the associated security group where possible as the dependent --]
 [#-- resource. (It may well in turn be a dependent resource)           --]
 [#-- As nothing depends in ingress resources, Cloud Formation will     --]
@@ -80,6 +75,13 @@
 [#function formatDependentSecurityGroupIngressId resourceId extensions...]
     [#return formatDependentResourceId(
                 "ingress",
+                resourceId,
+                extensions)]
+[/#function]
+
+[#function formatDependentSecurityGroupEgressId resourceId extensions...]
+    [#return formatDependentResourceId(
+                AWS_VPC_SECURITY_GROUP_EGRESS_RESOURCE_TYPE,
                 resourceId,
                 extensions)]
 [/#function]


### PR DESCRIPTION
## Description
This PR implements network Profiles as outlined in https://github.com/hamlet-io/engine/pull/1346 and also provides solution level control of ingress and egress rules for components which have security groups and are part of a VPC 

All security groups are now created to explicitly deny inbound and outbound connections, by default AWS restricts inbound access but denies outbound access. 

To create rules in the security group there are 3 methods 
- Network profile - this sets global security group rules that are applied across all components configured to use a given profile. The default profile allows all outbound access and also allows inbound access to all services from the default bastion instance
- Links/Roles - All components with a security group now have an inbound and outbound `networkacl` role. This role provides other components with the network rule properties to permit access to this component. 
    The inbound role allows for a component to link to another component so that the linked component can access the linking component. 
    The outbound role allows for a component to link to another component and create egress rules on the linking component so that it can access the linked component. Ingress access on the linked component can either be defined through an inbound link or through the standard IP Address Groups defined on the linked component
- Solution Configuration - For components which offer inbound services ( load balancers, ec2 instances, rds, cachce ) etc. the component configuration has IPAddressGroup and Port configuration. This allows for broader access to be defined for inbound access instead of having to use links for all network level access. This is the only method we have had in the past for security group control 

## Motivation and Context
As mentioned in the core plugin PR, our current security group posture is the base level recommended standard and provides some access control while relying on other services ( network ACL's, route tables, etc) to provide their own layers of access control.  In highly secure environments this is not enough and instead defence in depth access control is required. In these cases both ingress and egress access control needs to be explicitly defined for each component 

## How Has This Been Tested?
Tested on each component including linking between components 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This should not break existing functionality, however this will result in changes to all templates which have security groups. Where possible Id's and names have been maintained to prevent replacement.

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
