### PR TITLE
fix: Force lambda@edge to have no environment

### DIFF
--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -168,7 +168,11 @@
     [#if deploymentType == "EDGE" ]
             [#assign _context += {
             "DefaultEnvironment" : {},
-            "Environment" : {}
+            "Environment" : {},
+            "DefaultCoreVariables" : false,
+            "DefaultEnvironmentVariables" : false,
+            "DefaultLinkVariables" : false,
+            "DefaultBaselineVariables" : false
         }]
     [/#if]
 
@@ -248,11 +252,10 @@
     [#if isPresent(solution.FixedCodeVersion) ]
         [#local versionId = resources["version"].Id  ]
         [#local versionResourceId = resources["version"].ResourceId ]
-        [#local codeHash = _context.CodeHash!solution.FixedCodeVersion.CodeHash ]
 
         [#if !(core.Version?has_content)]
             [@fatal
-                message="A version must be defined for Fixed Code Version deployments"
+                message="A component version must be defined for Fixed Code Version deployments"
                 context=core
             /]
         [/#if]
@@ -330,7 +333,7 @@
                 [@fatal
                     message="EDGE based deployments must be deployed as Fixed code version deployments"
                     context=_context
-                    detail="Lambda@Edge deployments are based on a snapshot of lambda code and a specific codeontap version is requried "
+                    detail="Lambda@Edge deployments are based on a snapshot of lambda code and a specific hamlet version is required "
                 /]
             [/#if]
 


### PR DESCRIPTION
## Description
Ensure that no environment variables are added to a lambda@edge function.

Make the text of a couple of error messages more explicit.

## Motivation and Context
If all the macros controlling output of environment variables weren't explicitly set in the lambda@edge function fragment, some variables could still be set.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
