### PR TITLE
feat: S3 Bucket encryption

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -53,9 +53,8 @@
     [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption" ], false, false )]
 
     [#local cmkResources = baselineLinks["Encryption"].State.Resources ]
+    [#local cmkId = cmkResources["cmk"].Id ]
     [#local cmkAlias = cmkResources["cmkAlias"].Name ]
-
-    [@debug message={ "KeyAlias" : cmkAlias } enabled=true /]
 
     [#-- Subcomponents --]
     [#list occurrence.Occurrences![] as subOccurrence]
@@ -214,6 +213,9 @@
                     versioning=subSolution.Versioning
                     lifecycleRules=lifecycleRules
                     notifications=notifications
+                    encrypted=subSolution.Encryption.Enabled
+                    encryptionSource=subSolution.Encryption.EncryptionSource
+                    kmsKeyId=cmkId
                     dependencies=bucketDependencies
                 /]
 
@@ -320,6 +322,16 @@
                                         {
                                             "AWS": formatAccountPrincipalArn()
                                         }
+                                    ),
+                                    getPolicyStatement(
+                                        "kms:GenerateDataKey",
+                                        "*"
+                                        {
+                                            "Service" : "delivery.logs.amazonaws.com"
+                                        },
+                                        "",
+                                        true,
+                                        "Allow CloudFront Flow Logs to use the key"
                                     )
                                 ]
                             outputId=cmkId

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -167,8 +167,18 @@
                                 getRegistryPrefix("scripts", occurrence)
                             )
                         ) +
+                        s3AccountEncryptionReadPermission(
+                            registryBucket,
+                            getRegistryPrefix("scripts", occurrence),
+                            registryBucketRegion
+                        ) +
                         s3ListPermission(codeBucket) +
                         s3ReadPermission(codeBucket) +
+                        s3AccountEncryptionReadPermission(
+                            codeBucket,
+                            "*",
+                            codeBucketRegion
+                        ) +
                         s3ListPermission(operationsBucket) +
                         s3WritePermission(operationsBucket, "DOCKERLogs") +
                         s3WritePermission(operationsBucket, "Backups") +

--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -154,7 +154,7 @@
                     [
                         getPolicyDocument(
                             encrypted?then(
-                                s3EncryptionPermission(
+                                s3EncryptionKinesisPermission(
                                         cmkKeyId,
                                         dataBucket,
                                         dataBucketPrefix,

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -261,6 +261,11 @@
                     getPolicyDocument(
                         s3ListPermission(codeBucket) +
                         s3ReadPermission(codeBucket) +
+                        s3AccountEncryptionReadPermission(
+                            codeBucket,
+                            "*",
+                            codeBucketRegion
+                        ) +
                         s3ListPermission(operationsBucket) +
                         s3WritePermission(operationsBucket, "DOCKERLogs") +
                         s3WritePermission(operationsBucket, "Backups") +

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -150,11 +150,21 @@
                     getPolicyDocument(
                             s3ListPermission(codeBucket) +
                             s3ReadPermission(credentialsBucket, accountId + "/alm/docker") +
+                            s3AccountEncryptionReadPermission(
+                                credentialsBucket,
+                                "*",
+                                credentialsBucketRegion
+                            ) +
                             fixedIP?then(
                                 ec2IPAddressUpdatePermission(),
                                 []
                             ) +
                             s3ReadPermission(codeBucket) +
+                            s3AccountEncryptionReadPermission(
+                                codeBucket,
+                                "*",
+                                codeBucketRegion
+                            ) +
                             s3ListPermission(operationsBucket) +
                             s3WritePermission(operationsBucket, getSegmentBackupsFilePrefix()) +
                             s3WritePermission(operationsBucket, "DOCKERLogs") +

--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -25,9 +25,11 @@
     [#local replicationBucket = ""]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(occurrence, [ "CDNOriginKey" ])]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "CDNOriginKey", "Encryption" ])]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local cfAccessId  = getExistingReference(baselineComponentIds["CDNOriginKey"]!"", CANONICAL_ID_ATTRIBUTE_TYPE) ]
+
+    [#local kmsKeyId = baselineComponentIds["Encryption"]]
 
     [#local dependencies = [] ]
 
@@ -320,6 +322,9 @@
             versioning=versioningEnabled
             CORSBehaviours=solution.CORSBehaviours
             replicationConfiguration=replicationConfiguration
+            encrypted=solution.Encryption.Enabled
+            encryptionSource=solution.Encryption.EncryptionSource
+            kmsKeyId=kmsKeyId
             dependencies=dependencies
         /]
     [/#if]

--- a/aws/components/s3/state.ftl
+++ b/aws/components/s3/state.ftl
@@ -14,6 +14,29 @@
         [/#if]
     [/#list]
 
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption" ])]
+    [#local baselineIds = getBaselineComponentIds(baselineLinks)]
+
+    [#local s3AllEncryptionPolicy = []]
+    [#local s3ReadEncryptionPolicy = []]
+    [#if solution.Encryption.Enabled &&
+           solution.Encryption.EncryptionSource == "EncryptionService" ]
+
+        [#local s3AllEncryptionPolicy  = s3EncryptionAllPermission(
+                baselineIds["Encryption"],
+                name,
+                "*",
+                getExistingReference(id, REGION_ATTRIBUTE_TYPE)
+            )]
+
+        [#local s3ReadEncryptionPolicy  = s3EncryptionReadPermission(
+                baselineIds["Encryption"],
+                name,
+                "*",
+                getExistingReference(id, REGION_ATTRIBUTE_TYPE)
+            )]
+    [/#if]
+
     [#assign componentState =
         {
             "Resources" : {
@@ -51,10 +74,10 @@
                     }
                 },
                 "Outbound" : {
-                    "all" : s3AllPermission(id),
-                    "produce" : s3ProducePermission(id),
-                    "consume" : s3ConsumePermission(id),
-                    "replicadestination" : s3ReplicaDestinationPermission(id),
+                    "all" : s3AllPermission(id) + s3AllEncryptionPolicy,
+                    "produce" : s3ProducePermission(id) + s3AllEncryptionPolicy,
+                    "consume" : s3ConsumePermission(id) + s3ReadEncryptionPolicy,
+                    "replicadestination" : s3ReplicaDestinationPermission(id) + s3ReadEncryptionPolicy,
                     "replicasource" : {},
                     "datafeed" : s3KinesesStreamPermission(id)
                }

--- a/aws/services/kms/policy.ftl
+++ b/aws/services/kms/policy.ftl
@@ -10,14 +10,68 @@
     ]
 [/#function]
 
-[#function s3EncryptionPermission keyId bucketName bucketPrefix bucketRegion ]
-    [#return
-        [
-            getPolicyStatement(
+[#function s3AccountEncryptionReadPermission bucketName bucketPrefix bucketRegion ]
+    [#local accountEncryptionKeyId = formatAccountCMKTemplateId() ]
+
+    [#if getExistingReference(accountEncryptionKeyId)?has_content ]
+        [#return s3EncryptionReadPermission(
+                    accountEncryptionKeyId,
+                    bucketName,
+                    bucketPrefix,
+                    bucketRegion
+        )]
+    [#else]
+        [#return []]
+    [/#if]
+[/#function]
+
+[#function s3EncryptionAllPermission keyId bucketName bucketPrefix bucketRegion ]
+    [#return s3EncryptionStatement(
+                [
+                    "kms:Decrypt",
+                    "kms:DescribeKey",
+                    "kms:Encrypt",
+                    "kms:GenerateDataKey*",
+                    "kms:ReEncrypt*"
+                ],
+                keyId,
+                bucketName,
+                bucketPrefix,
+                bucketRegion
+    )]
+[/#function]
+
+[#function s3EncryptionReadPermission keyId bucketName bucketPrefix bucketRegion ]
+    [#return s3EncryptionStatement(
+                [
+                    "kms:Decrypt",
+                    "kms:DescribeKey"
+                ],
+                keyId,
+                bucketName,
+                bucketPrefix,
+                bucketRegion
+    )]
+[/#function]
+
+[#function s3EncryptionKinesisPermission keyId bucketName bucketPrefix bucketRegion ]
+    [#return s3EncryptionStatement(
                 [
                     "kms:Decrypt",
                     "kms:GenerateDataKey"
                 ],
+                keyId,
+                bucketName,
+                bucketPrefix,
+                bucketRegion
+    )]
+[/#function]
+
+[#function s3EncryptionStatement actions keyId bucketName bucketPrefix bucketRegion ]
+    [#return
+        [
+            getPolicyStatement(
+                asArray(actions),
                 getReference(keyId, ARN_ATTRIBUTE_TYPE),
                 "",
                 {
@@ -25,7 +79,7 @@
                         "kms:ViaService" : formatDomainName( "s3", bucketRegion, "amazonaws.com" )
                     },
                     "StringLike" : {
-                        "kms:EncryptionContext:aws:s3:arn" : "arn:aws:s3:::" + formatRelativePath(bucketName, bucketPrefix, "*")
+                        "kms:EncryptionContext:aws:s3:arn" : "arn:aws:s3:::" + formatRelativePath(bucketName, bucketPrefix?ensure_ends_with("*") )
                     }
                 }
             )


### PR DESCRIPTION
## Description
AWS provider specific implementation of https://github.com/hamlet-io/engine/pull/1347 

Adds support for enabling S3 encryption on baseline data buckets, and s3 components 
Updates s3 link policies and baseline policies to provide the appropriate permissions required by clients to access the KMS key for CMK based encryption

## Motivation and Context
This supports security hardening best practices which is to enable encryption at rest on services where possible

## How Has This Been Tested?
Tested locally on a new deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
