### PR TITLE
fix(vpc): Check network rule array items for content

### DIFF
--- a/aws/services/vpc/resource.ftl
+++ b/aws/services/vpc/resource.ftl
@@ -164,8 +164,6 @@
         [#if link?is_hash]
             [#local linkTarget = getLinkTarget(occurrence, link) ]
 
-            [@debug message="Link Target" context=linkTarget enabled=false /]
-
             [#if !linkTarget?has_content]
                 [#continue]
             [/#if]
@@ -185,8 +183,8 @@
     [#-- validate provide rule against configuration --]
     [#local networkRule = getCompositeObject(networkRuleChildConfiguration, networkRule) ]
     [#list networkRule.Ports as port ]
-        [#if networkRule.IPAddressGroups?has_content ]
-            [#list getGroupCIDRs(networkRule.IPAddressGroups, true, occurrence ) as cidr ]
+        [#if (networkRule.IPAddressGroups)?has_content ]
+            [#list (getGroupCIDRs(networkRule.IPAddressGroups, true, occurrence ))?filter(cidr -> cidr?has_content) as cidr ]
                 [@createSecurityGroupIngress
                     id=formatDependentSecurityGroupIngressId(groupId, port, replaceAlphaNumericOnly(cidr))
                     groupId=groupId
@@ -197,8 +195,8 @@
             [/#list]
         [/#if]
 
-        [#if networkRule.SecurityGroups?has_content ]
-            [#list networkRule.SecurityGroups as securityGroup ]
+        [#if (networkRule.SecurityGroups)?has_content ]
+            [#list (networkRule.SecurityGroups)?filter(group -> group?has_content) as securityGroup ]
                 [@createSecurityGroupIngress
                     id=formatDependentSecurityGroupIngressId(groupId, port, replaceAlphaNumericOnly(securityGroup))
                     groupId=groupId
@@ -230,8 +228,8 @@
     [#local networkRule = getCompositeObject(networkRuleChildConfiguration, networkRule) ]
 
     [#list networkRule.Ports as port ]
-        [#if networkRule.IPAddressGroups?has_content ]
-            [#list getGroupCIDRs(networkRule.IPAddressGroups, true, occurrence ) as cidr ]
+        [#if (networkRule.IPAddressGroups)?has_content ]
+            [#list (getGroupCIDRs(networkRule.IPAddressGroups, true, occurrence ))?filter(cidr -> cidr?has_content) as cidr ]
                 [@createSecurityGroupEgress
                     id=formatDependentSecurityGroupEgressId(groupId, port, replaceAlphaNumericOnly(cidr))
                     groupId=groupId
@@ -242,8 +240,8 @@
             [/#list]
         [/#if]
 
-        [#if networkRule.SecurityGroups?has_content ]
-            [#list networkRule.SecurityGroups as securityGroup ]
+        [#if (networkRule.SecurityGroups)?has_content ]
+            [#list (networkRule.SecurityGroups)?filter(group -> group?has_content) as securityGroup ]
                 [@createSecurityGroupEgress
                     id=formatDependentSecurityGroupEgressId(groupId, port, replaceAlphaNumericOnly(securityGroup))
                     groupId=groupId


### PR DESCRIPTION
## Description
Minor fix to filter empty content from Security group and CIDR Arrays

## Motivation and Context
When linking to a component which hasn't been deployed you can still access the role information. This role information could contain an empty string as most roles are populated with getExistingReference 


## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
