### PR TITLE
fix(efs): networkacl lookup from parent

### DIFF
--- a/aws/components/efs/state.ftl
+++ b/aws/components/efs/state.ftl
@@ -76,10 +76,10 @@
             },
             "Roles" : {
                 "Inbound" : {
-                    "networkacl" : parentRoles["networkacl"]
+                    "networkacl" : parentRoles.Inbound["networkacl"]
                 },
                 "Outbound" : {
-                    "networkacl" : parentRoles["networkacl"]
+                    "networkacl" : parentRoles.Outbound["networkacl"]
                 }
             }
         }


### PR DESCRIPTION
## Description
Minor fix in EFS mounts to lookup the networkacl roles from the parent.

## Motivation and Context
It was borked

## How Has This Been Tested?
Tested locally on deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
