### PR TITLE
fix: security group references for security groups

### DIFF
--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -298,7 +298,7 @@
                             destinationPort
                         )
                     port=destinationPort
-                    cidr=group
+                    group=group
                     groupId=computeClusterSecurityGroupId
                 /]
             [/#list]

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -248,7 +248,7 @@
                             destinationPort
                         )
                     port=destinationPort
-                    cidr=group
+                    group=group
                     groupId=ec2SecurityGroupId
                 /]
             [/#list]

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -885,7 +885,7 @@
                                             )
                                         )
                                     port=portMapping.DynamicHostPort?then(0, portMapping.HostPort)
-                                    cidr=group
+                                    group=group
                                     groupId=ecsSecurityGroupId
                                 /]
                             [/#list]


### PR DESCRIPTION
## Description
A minor fix for passing the groupId to ingress rule creation

## Motivation and Context
With the recent changes in #73 we have now split the groupId references and the CIDR ranges to separate parameters. This wasn't caught in some of the places we use the ingress rule macro 

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
