### PR TITLE
Fixes: bastion and RDS

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -26,6 +26,8 @@
     [#local bastionType = occurrence.Core.Type]
     [#local configSetName = bastionType]
 
+    [#local publicRouteTable = false ]
+
     [#-- Baseline component lookup --]
     [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
@@ -184,13 +186,6 @@
                         ALLOCATION_ATTRIBUTE_TYPE
                     ))]
         [/#if]
-
-        [#local configSets +=
-            getInitConfigEIPAllocation(
-                getReference(
-                    bastionEIPId,
-                    ALLOCATION_ATTRIBUTE_TYPE
-                ))]
 
         [#if deploymentSubsetRequired("lg", true) &&
                 isPartOfCurrentDeploymentUnit(bastionLgId) ]

--- a/aws/services/rds/resource.ftl
+++ b/aws/services/rds/resource.ftl
@@ -122,7 +122,10 @@
         } +
         valueIfTrue(
             {
-                "AllocatedStorage": size?c?string,
+                "AllocatedStorage": size?is_string?then(
+                                        size,
+                                        size?c?string
+                                    ),
                 "StorageType" : "gp2",
                 "BackupRetentionPeriod" : retentionPeriod,
                 "DBInstanceIdentifier": name,


### PR DESCRIPTION
## Description
A couple of minor fixes in bastion component and rds service 

- bastion: set a default for publicRouteTable so that it works in all subsets
- bastion: remove duplicate allocation of EIP script 
- rds service: support string or in in RDS size setting

## Motivation and Context
Minor fixes to support subsets and quality of life settings

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
