### PR TITLE
fix(cache): remove networkprofile param from security group

### DIFF
--- a/aws/components/cache/setup.ftl
+++ b/aws/components/cache/setup.ftl
@@ -88,7 +88,6 @@
             id=cacheSecurityGroupId
             name=cacheSecurityGroupName
             vpcId=vpcId
-            networkProfile=networkProfile
             occurrence=occurrence
         /]
 


### PR DESCRIPTION
## Description
Minor fix on cache security group to remove the networkProfile parameter

## Motivation and Context
Shouldn't be specified, this is a bug from #73 

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
