### PR TITLE
fix(vpc): support any protocol sec group rules

### DIFF
--- a/aws/services/vpc/resource.ftl
+++ b/aws/services/vpc/resource.ftl
@@ -1,44 +1,53 @@
 [#ftl]
 
 [#function getSecurityGroupPortRule port ]
-    [#return
-        port?is_number?then(
-        (port == 0)?then(
-            {
-                "IpProtocol": "tcp",
-                "FromPort": 32768,
-                "ToPort" : 65535
-            },
-            {
-                "IpProtocol": "tcp",
-                "FromPort": port,
-                "ToPort" : port
-            }
-        ),
-        {
-            "IpProtocol": ports[port]?has_content?then(
-                                (ports[port].IPProtocol == "all")?then(
-                                    "-1",
-                                    ports[port].IPProtocol
-                                ),
-                                -1),
+    [#if port?is_string &&
+            ( ((ports[port].IPProtocol)!"") == "all")  ]
 
-            "FromPort": ports[port]?has_content?then(
-                                ports[port].PortRange.Configured?then(
-                                        ports[port].PortRange.From,
+            [#return {
+                "IpProtocol" : "-1",
+                "FromPort" : -1,
+                "ToPort" : -1
+            }]
+
+    [#else]
+        [#return
+            port?is_number?then(
+            (port == 0)?then(
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 32768,
+                    "ToPort" : 65535
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": port,
+                    "ToPort" : port
+                }
+            ),
+            {
+                "IpProtocol": ports[port]?has_content?then(
+                                    ports[port].IPProtocol,
+                                    -1
+                                ),
+
+                "FromPort": ports[port]?has_content?then(
+                                    ports[port].PortRange.Configured?then(
+                                            ports[port].PortRange.From,
+                                            ports[port].Port
+                                    ),
+                                    1),
+
+                "ToPort": ports[port]?has_content?then(
+                                    ports[port].PortRange.Configured?then(
+                                        ports[port].PortRange.To,
                                         ports[port].Port
-                                ),
-                                1),
-
-            "ToPort": ports[port]?has_content?then(
-                                ports[port].PortRange.Configured?then(
-                                    ports[port].PortRange.To,
-                                    ports[port].Port
-                                ),
-                                65535)
-        }
-    )
-    ]
+                                    ),
+                                    65535)
+            }
+        )
+        ]
+    [/#if]
 [/#function]
 
 [#function getSecurityGroupRules port cidrs=[] groups=[] direction="ingress" description="" ]


### PR DESCRIPTION
## Description
Force the port range to the AWS required one when using the all protocol

## Motivation and Context
Our port objects require a port range, however if you use the all protocol AWS needs the range to be specified as -1 to -1. This change enforces it to align with our port objects

There also seems to be a weird bug in cloudformation where if you pass the IPProtocol as -1 and specify ports the rule is added then removed 

## How Has This Been Tested?
Tested locally on deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
