### PR TITLE
Outbound Network Profile control

### DIFF
--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -227,6 +227,7 @@
                 groupId=computeClusterSecurityGroupId
                 linkTarget=linkTarget
                 inboundPorts=[ "ssh" ]
+                networkProfile=networkProfile
             /]
         [/#if]
 

--- a/aws/components/datapipeline/setup.ftl
+++ b/aws/components/datapipeline/setup.ftl
@@ -120,6 +120,7 @@
                 groupId=securityGroupId
                 linkTarget=linkTarget
                 inboundPorts=[ "ssh" ]
+                networkProfile=networkProfile
             /]
         [/#if]
 

--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -210,6 +210,7 @@
                     groupId=securityGroupId
                     linkTarget=linkTarget
                     inboundPorts=[ port ]
+                    networkProfile=networkProfile
                 /]
             [/#if]
 

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -154,6 +154,7 @@
                 groupId=computeClusterSecurityGroupId
                 linkTarget=linkTarget
                 inboundPorts=ec2SecurityGroupPorts
+                networkProfile=networkProfile
             /]
         [/#if]
 

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -242,6 +242,7 @@
                 groupId=ecsSecurityGroupId
                 linkTarget=linkTarget
                 inboundPorts=[ "ssh" ]
+                networkProfile=networkProfile
             /]
 
             [#switch linkTargetCore.Type]
@@ -960,7 +961,8 @@
                         [/#list]
                     [/#if]
 
-                    [#if container.EgressRules?has_content ]
+                    [#if !(networkProfile.BaseSecurityGroup.Outbound.GlobalAllow)
+                            && container.EgressRules?has_content ]
                         [#list container.EgressRules as egressRule ]
                             [@createSecurityGroupEgressFromNetworkRule
                                 occurrence=subOccurrence

--- a/aws/components/efs/setup.ftl
+++ b/aws/components/efs/setup.ftl
@@ -65,6 +65,7 @@
                     groupId=efsSecurityGroupId
                     linkTarget=linkTarget
                     inboundPorts=[ port ]
+                    networkProfile=networkProfile
                 /]
             [/#if]
 

--- a/aws/components/es/setup.ftl
+++ b/aws/components/es/setup.ftl
@@ -242,6 +242,7 @@
                     groupId=sgId
                     linkTarget=linkTarget
                     inboundPorts=[ ports ]
+                    networkProfile=networkProfile
                 /]
             [/#if]
 

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -252,6 +252,7 @@
                         groupId=securityGroupId
                         linkTarget=linkTarget
                         inboundPorts=destinationPorts
+                        networkProfile=networkProfile
                     /]
                 [/#if]
 

--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -117,6 +117,7 @@
                     groupId=securityGroupId
                     linkTarget=linkTarget
                     inboundPorts=[]
+                    networkProfile=networkProfile
                 /]
             [/#if]
 

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -385,6 +385,7 @@
                         groupId=securityGroupId
                         linkTarget=linkTarget
                         inboundPorts=[ securityGroupPorts ]
+                        networkProfile=networkProfile
                     /]
                 [/#if]
 
@@ -502,6 +503,7 @@
                         groupId=securityGroupId
                         linkTarget=linkTarget
                         inboundPorts=[ securityGroupPorts ]
+                        networkProfile=networkProfile
                     /]
                 [/#if]
 

--- a/aws/services/vpc/resource.ftl
+++ b/aws/services/vpc/resource.ftl
@@ -5,9 +5,7 @@
             ( ((ports[port].IPProtocol)!"") == "all")  ]
 
             [#return {
-                "IpProtocol" : "-1",
-                "FromPort" : -1,
-                "ToPort" : -1
+                "IpProtocol" : "-1"
             }]
 
     [#else]


### PR DESCRIPTION
## Description
Implements https://github.com/hamlet-io/engine/pull/1351 to provide a way to disable egress rule creation and instead rely on the implicit rules added by AWS ( allow any/any ) 

## Motivation and Context
There is some strange behaviour in AWS with Cloudformation Egress rules 
- Create an egress rule with explicit rules ( IP, Port etc ) 
- AWS will remove the default egress rule they automatically add ( 0.0.0.0/0 any ) 
- Add an explicit egress rule which allows all outbound access ( 0.0.0.0/0 any ) 
- Add another rule as an extra egress rule to the group
- The explicit egress global rule for global outbound access will be removed 

This kind of makes sense since the 0.0.0.0/0 rule wins over all the other rules, and since this is provided by default why would you want add this explicitly with other egress rules ( Sec groups are allow only ). This behaviour isn't expected though and also is hard to track down. Disabling egress rule control makes this more controllable

## How Has This Been Tested?
tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [] If you have already run deployments which have created egress rules
       - Update all stacks that modify security groups to remove the egress rules created 
       - Check to see if the default outbound rule ( 0.0.0.0/0 any and ::0 for Ipv6 have been added ) 
       - If one of them hasn't been added, edit the security group and make the default single rule source any ( this will add the IPv4 and IPV6 rules 

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
