### PR TITLE
fix: naming fixes for large deployments

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -1055,7 +1055,7 @@
                                     [@createAlarm
                                         id=formatDependentAlarmId(scalingPolicyId, monitoredResource.Id )
                                         severity="Scaling"
-                                        resourceName=scalingTargetCore.FullName
+                                        resourceName=concatenate( [ core.FullName, scalingTargetCore.FullName], "|" )
                                         alertName=scalingMetricTrigger.Name
                                         actions=getReference( scalingPolicyId )
                                         reportOK=false

--- a/aws/components/s3/state.ftl
+++ b/aws/components/s3/state.ftl
@@ -5,7 +5,8 @@
     [#local solution = occurrence.Configuration.Solution]
 
     [#local id = formatOccurrenceS3Id(occurrence)]
-    [#local name = formatOccurrenceBucketName(occurrence) ]
+    [#local name = (formatOccurrenceBucketName(occurrence))?truncate_c(63, '') ]
+
     [#local publicAccessEnabled = false ]
     [#list solution.PublicAccess?values as publicPrefixConfiguration]
         [#if publicPrefixConfiguration.Enabled]

--- a/aws/services/cw/resource.ftl
+++ b/aws/services/cw/resource.ftl
@@ -285,7 +285,7 @@
         properties=
             {
                 "AlarmDescription" : description?has_content?then(description,name),
-                "AlarmName" : severity?upper_case + "-" + resourceName + "-" + alertName,
+                "AlarmName" : concatenate( [ severity?upper_case,resourceName, alertName ], "|"),
                 "ComparisonOperator" : operator,
                 "EvaluationPeriods" : evaluationPeriods,
                 "MetricName" : metric,


### PR DESCRIPTION
## Description
Some fixes for naming in ecs and S3 components 

## Motivation and Context
- S3 - Only allows s3 buckets to be 63 characters long - since we append the segment seed to the end of the bucket we have some room to truncate bucket names so they fit into this while still being unique 
- Cloud watch alarms 
  - change formatting a little to try and make the alarm names easier to follow 
  - When creating a scaling alarm include the name of the resource that is being scaled along with the resource that its tracking. This ensures alarm names are unique 


## How Has This Been Tested?
Tested on active deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
