### PR TITLE
fix(lb): ensure lb name meets aws requirements

### DIFF
--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -55,13 +55,10 @@
             [#local resourceType = "COTFatal: Unknown LB Engine" ]
     [/#switch]
 
-    [#local lbShortName = (core.FullName?length < 32)?then(
-                                core.FullName,
-                                (core.ShortFullName?length < 32)?then(
-                                        core.ShortFullName,
-                                        core.ShortFullName?truncate_c(32, '')
-                                )
-    )]
+    [#local lbShortName = (core.ShortFullName?length < 32)?then(
+                                    core.ShortFullName,
+                                    core.ShortFullName?truncate_c(32, '')
+                                )]
 
     [#assign componentState =
         {

--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -55,13 +55,21 @@
             [#local resourceType = "COTFatal: Unknown LB Engine" ]
     [/#switch]
 
+    [#local lbShortName = (core.FullName?length < 32)?then(
+                                core.FullName,
+                                (core.ShortFullName?length < 32)?then(
+                                        core.ShortFullName,
+                                        core.ShortFullName?truncate_c(32, '')
+                                )
+    )]
+
     [#assign componentState =
         {
             "Resources" : {
                 "lb" : {
                     "Id" : id,
                     "Name" : core.FullName,
-                    "ShortName" : core.ShortFullName,
+                    "ShortName" : lbShortName,
                     "Type" : resourceType,
                     "Monitored" : true
                 }

--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -55,18 +55,13 @@
             [#local resourceType = "COTFatal: Unknown LB Engine" ]
     [/#switch]
 
-    [#local lbShortName = (core.ShortFullName?length < 32)?then(
-                                    core.ShortFullName,
-                                    core.ShortFullName?truncate_c(32, '')
-                                )]
-
     [#assign componentState =
         {
             "Resources" : {
                 "lb" : {
                     "Id" : id,
                     "Name" : core.FullName,
-                    "ShortName" : lbShortName,
+                    "ShortName" : (core.ShortFullName)?truncate_c(32, ''),
                     "Type" : resourceType,
                     "Monitored" : true
                 }


### PR DESCRIPTION
## Description
Truncate the name for the load balancer if it doesn't meet the AWS requirements

## Motivation and Context
AWS load balancer names are currently limited to 32 characters, since we form names based on the full occurrence structure and the name has to be unique to region and account this can be hard to know as a requirement until you deploy the load balancer and it fails. If you need to shorten the name you sometimes end up redeploying the whole segment since the name might need to be shortened 

Load balancers still support tagging so you can use a proper name here, this is just the name property

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
