### PR TITLE
fix(segment): network deployment state lookup

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -47,7 +47,9 @@
         [#local networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
 
         [#if ! networkLinkTarget?has_content ]
-            [@fatal message="Network could not be found" context=networkLink /]
+            [#if deploymentSubsetRequired(BASTION_COMPONENT_TYPE, false)]
+                [@fatal message="Network could not be found" context=networkLink /]
+            [/#if]
             [#return]
         [/#if]
 

--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -334,7 +334,6 @@
 
     [#local networkLinkTarget = getLinkTarget(parent, networkLink ) ]
     [#if ! networkLinkTarget?has_content ]
-        [@fatal message="Network could not be found" context=networkLink /]
         [#return]
     [/#if]
 

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -33,7 +33,11 @@
 
         [#local networkLinkTarget = getLinkTarget(occurrence, networkLink, false) ]
         [#if ! networkLinkTarget?has_content ]
-            [@fatal message="Network could not be found" context=networkLink /]
+
+            [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, false)]
+                [@fatal message="Network could not be found" context=networkLink /]
+            [/#if]
+
             [#return]
         [/#if]
 


### PR DESCRIPTION
## Description
Only error on network not existing when deploying the resources which require a network

## Motivation and Context
Currently we throw an error if the network doesn't exist for an overall component. The network not be available is only a problem when you deploy resources which require it. If you try to do subset deployments while these components are defined in a solution but there isn't a network the subset will fail to generate

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
