### PR TITLE
fix: s3 encrypted bucket policy for ssm

### DIFF
--- a/aws/services/ssm/policy.ftl
+++ b/aws/services/ssm/policy.ftl
@@ -40,6 +40,15 @@
                     "s3:GetEncryptionConfiguration"
                 ],
                 logBucketId
+            )+
+            getExistingReference(accountEncryptionKeyId)?has_content?then(
+                s3EncryptionAllPermission(
+                    accountEncryptionKeyId,
+                    logBucketId,
+                    logBucketPrefix,
+                    getExistingReference(logBucketId, REGION_ATTRIBUTE_TYPE)
+                ),
+                []
             ),
             []
         ) +


### PR DESCRIPTION
## Description
Minor fix on SSM policies which don't use a KMS key that we manage for S3 access logging

## Motivation and Context
Access was being denied for SSM sessions

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
