### PR TITLE
feat(lb): add networkacl support for network engine

### DIFF
--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -229,16 +229,22 @@
                         "Description" : core.FullName
                     }
                 ),
-                "Outbound" : {} +
-                attributeIfTrue(
-                    "networkacl",
-                    securityGroupRequired,
-                    {
+                "Outbound" : {
+                    "networkacl" : {
                         "Ports" : [ source ],
-                        "SecurityGroups" : getExistingReference(securityGroupId),
                         "Description" : core.FullName
-                    }
-                )
+                    } +
+                    attributeIfTrue(
+                        "SecurityGroups",
+                        securityGroupRequired
+                        getExistingReference(securityGroupId)
+                    ) +
+                    attributeIfTrue(
+                        "IPAddressGroups",
+                        (engine == "network"),
+                        [ "_tier:" + core.Tier.Id ]
+                    )
+                }
             }
         }
     ]


### PR DESCRIPTION
## Description
Adds a network acl role for the lb network engine based on the tier based subnet lookup added in https://github.com/hamlet-io/engine/pull/1359 

## Motivation and Context
AWS Network load balancers don't support the standard security group references in network security group rules which permit access to the load balancer. So instead for egress rules we need to provide the subnets the load balancer lives on for access

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
