### PR TITLE
fix(sqs): move policy management for a queue into the component

### DIFF
--- a/aws/components/s3/id.ftl
+++ b/aws/components/s3/id.ftl
@@ -7,7 +7,6 @@
     services=
         [
             AWS_SIMPLE_STORAGE_SERVICE,
-            AWS_SIMPLE_QUEUEING_SERVICE,
             AWS_SIMPLE_NOTIFICATION_SERVICE,
             AWS_LAMBDA_SERVICE,
             AWS_IDENTITY_SERVICE

--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -56,22 +56,17 @@
                             [#case SQS_COMPONENT_TYPE ]
                                 [#local resourceId = linkTargetResources["queue"].Id ]
                                 [#local resourceType = linkTargetResources["queue"].Type ]
-
-                                [#local policyId =
-                                    formatS3NotificationPolicyId(
-                                        s3Id,
-                                        resourceId) ]
-
-                                [#local dependencies += [policyId] ]
-
-                                [#if deploymentSubsetRequired("s3", true)]
-                                    [@createSQSPolicy
-                                        id=policyId
-                                        queues=resourceId
-                                        statements=sqsS3WritePermission(resourceId, s3Name)
+                                [#if ! (notification["aws:QueuePermissionMigration"]) ]
+                                    [@fatal
+                                        message="Queue Permissions update required"
+                                        detail=[
+                                            "SQS policies have been migrated to the queue component",
+                                            "For each S3 bucket add an inbound-invoke link from the Queue to the bucket",
+                                            "When this is completed update the configuration of this notification to QueuePermissionMigration : true"
+                                        ]
+                                        context=notification
                                     /]
                                 [/#if]
-
                                 [#break]
 
                             [#case LAMBDA_FUNCTION_COMPONENT_TYPE ]

--- a/aws/components/sqs/state.ftl
+++ b/aws/components/sqs/state.ftl
@@ -48,6 +48,10 @@
                         "Name" : name,
                         "Type" : AWS_SQS_RESOURCE_TYPE,
                         "Monitored" : true
+                    },
+                    "queuePolicy" : {
+                        "Id" : formatResourceId(AWS_SQS_POLICY_RESOURCE_TYPE, core.Id),
+                        "Type" : AWS_SQS_POLICY_RESOURCE_TYPE
                     }
                 } +
                 dlqRequired?then(

--- a/aws/services/sqs/id.ftl
+++ b/aws/services/sqs/id.ftl
@@ -2,3 +2,4 @@
 
 [#-- Resources --]
 [#assign AWS_SQS_RESOURCE_TYPE = "sqs" ]
+[#assign AWS_SQS_POLICY_RESOURCE_TYPE  = "sqsPolicy" ]


### PR DESCRIPTION
## Description
A collection of fixes for SQS and S3 Notifications
- Moves all resource policies for SQS into the queue, we had some policies created by other components, mostly S3 notifications 
- creates a single resource creation for the SQS policy containing all statements 
- Some subset fixes for creating S3 notifications on baseline S3 buckets

This introduces a breaking change, when using S3 notifications to an SQS queue either from baseline or the s3 component the queue you are linking the notification to needs to have an inbound link configured to allow the S3 bucket to send messages to the queue.

To manage the change a configuration parameter must be set on each notification  `aws:QueuePermissionMigration` to acknowledge that the queue policy has been applied

E.g. 

**Bucket**
```
                "quarantine-s3" : {
                    "s3" : {
                        "Instances" : {
                            "default" : {
                                "DeploymentUnits" : [ "quarantine-s3"]
                            }
                        },
                        "Notifications" : {
                            "submissions" : {
                                "Links" : {
                                    "quarantine" : {
                                        "Tier" : "msg",
                                        "Component" : "queue",
                                        "Instance" : "processed"
                                    }
                                },
                                "Events" : [
                                    "create"
                                ],
                                "aws:QueuePermissionMigration" : true
                            }
                        },
                        "CORSBehaviours" : [ "S3Read"]
                    }
                }
```

**Queue**
```
                "queue" : {
                    "sqs" : {
                        "Instances" : {
                            "avscanning" : {
                                "DeploymentUnits" : [ "avscanning-queue"],
                                "Links" : {
                                    "uploadsS3" : {
                                        "Tier" : "db",
                                        "Component" : "uploads-s3",
                                        "Instance" : "",
                                        "Version" : "",
                                        "Direction" : "inbound",
                                        "Role" : "invoke"
                                    }
                                }
                            },
                            "processed" : {
                                "DeploymentUnits" : [ "processed-queue"],
                                "Links" : {
                                    "quarantineS3" : {
                                        "Tier" : "db",
                                        "Component" : "quarantine-s3",
                                        "Instance" : "",
                                        "Version" : "",
                                        "Direction" : "inbound",
                                        "Role" : "invoke"
                                    },
                                    "storageS3" : {
                                        "Tier" : "db",
                                        "Component" : "storage-s3",
                                        "Instance" : "",
                                        "Version" : "",
                                        "Direction" : "inbound",
                                        "Role" : "invoke"
                                    }
                                }
                            }
                        }
                    }
                }
```

## Motivation and Context
While there is a SQSPolicy cloudformation resource you can only apply one policy to a given queue ( the policy can be used by multiple queues. If you apply multiple policies to a queue that content of the last one applies to the queue. When there are multiple sources of queue items ( e.g. multiple S3 buckets ) then only one bucket will receive the policy. 


## How Has This Been Tested?

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] All Queues with S3 notifications configured must have an inbound link added to allow the S3 bucket to send to the queue

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
