### PR TITLE
feat(lb): add LB target group monitoring dimensions

### DIFF
--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -173,6 +173,7 @@
     [#assign componentState =
         {
             "Resources" : {
+                "lb" : parentState.Resources["lb"],
                 "listener" : {
                     "Id" : listenerId,
                     "Type" : AWS_ALB_LISTENER_RESOURCE_TYPE

--- a/aws/services/lb/resource.ftl
+++ b/aws/services/lb/resource.ftl
@@ -99,6 +99,20 @@
                     "Output" : NAME_ATTRIBUTE_TYPE
                 }
             }
+        },
+        AWS_ALB_TARGET_GROUP_RESOURCE_TYPE : {
+            "Namespace" : "AWS/ApplicationELB",
+            "Dimensions" : {
+                "LoadBalancer" : {
+                    "OtherOutput" : {
+                        "Id" : "lb",
+                        "Property" : NAME_ATTRIBUTE_TYPE
+                    }
+                },
+                "TargetGroup" : {
+                    "Output" : NAME_ATTRIBUTE_TYPE
+                }
+            }
         }
     }
 ]


### PR DESCRIPTION
## Description
Adds support for monitoring and autoscaling using the LB Targetgroup

## Motivation and Context
A recommend metric for autoscaling web containers is `RequestCountPerTarget` which lets you see how many requests on average each target is seeing. In order to support this we need to make the metric dimensions avaialble

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
