### PR TITLE
fix: only alert on notifications in S3 template

### DIFF
--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -57,15 +57,17 @@
                                 [#local resourceId = linkTargetResources["queue"].Id ]
                                 [#local resourceType = linkTargetResources["queue"].Type ]
                                 [#if ! (notification["aws:QueuePermissionMigration"]) ]
-                                    [@fatal
-                                        message="Queue Permissions update required"
-                                        detail=[
-                                            "SQS policies have been migrated to the queue component",
-                                            "For each S3 bucket add an inbound-invoke link from the Queue to the bucket",
-                                            "When this is completed update the configuration of this notification to QueuePermissionMigration : true"
-                                        ]
-                                        context=notification
-                                    /]
+                                    [#if deploymentSubsetRequired(S3_COMPONENT_TYPE, true)]
+                                        [@fatal
+                                            message="Queue Permissions update required"
+                                            detail=[
+                                                "SQS policies have been migrated to the queue component",
+                                                "For each S3 bucket add an inbound-invoke link from the Queue to the bucket",
+                                                "When this is completed update the configuration of this notification to QueuePermissionMigration : true"
+                                            ]
+                                            context=notification
+                                        /]
+                                    [/#if]
                                 [/#if]
                                 [#break]
 


### PR DESCRIPTION
## Description
Fix alerting for notification configuration to only happen in the template

## Motivation and Context
We should alert on a pass that you can fix it on 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
