### PR TITLE
fix: enable concurrent builds and remove build wait

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,11 +3,12 @@
 pipeline {
     options {
         timestamps()
-        disableConcurrentBuilds()
         quietPeriod(30)
     }
 
-    agent none
+    agent {
+        label 'hamlet-latest'
+    }
 
     stages {
         stage('Run AWS Template Tests') {
@@ -27,12 +28,12 @@ pipeline {
         stage('Trigger Docker Build') {
             when {
                 branch 'master'
-                beforeAgent true
             }
-            agent none
+
             steps {
                 build (
-                    job: '../docker-hamlet/master'
+                    job: '../docker-hamlet/master',
+                    wait: false
                 )
             }
         }


### PR DESCRIPTION
## Description
Enabled concurrent builds and removed wait trigger on triggering docker build 

## Motivation and Context
in the downstream job we now cancel existing jobs when a new one is triggered. This means we can always trigger the latest builds of master plugins and the docker build will restart and use the latest commit

## How Has This Been Tested?
Will test in deplloyment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
