### PR TITLE
Cognito email sender address configuration

### DIFF
--- a/aws/services/cognito/resource.ftl
+++ b/aws/services/cognito/resource.ftl
@@ -264,6 +264,20 @@
     ]
 [/#function]
 
+[#function getUserPoolEmailConfiguration fromId from replyTo="" ]
+    [#return
+        {
+            "EmailSendingAccount" : "DEVELOPER",
+            "SourceArn" : getArn(fromId),
+            "From" : from
+        } +
+        attributeIfContent(
+            "ReployToEmailAddress",
+            replyTo
+        )
+    ]
+[/#function]
+
 [#macro createUserPool id name
     mfa
     adminCreatesUser
@@ -275,6 +289,7 @@
     smsVerificationMessage=""
     emailVerificationMessage=""
     emailVerificationSubject=""
+    emailConfiguration={}
     verificationMessageTemplate={}
     smsInviteMessage=""
     emailInviteMessage=""
@@ -405,6 +420,10 @@
             attributeIfContent (
                 "EmailVerificationSubject",
                 emailVerificationSubject
+             ) +
+            attributeIfContent (
+                "EmailConfiguration",
+                emailConfiguration
              ) +
              attributeIfContent (
                 "SmsVerificationMessage",


### PR DESCRIPTION
## Description
Support the configuration of a custom sender email address for cognito.

## Motivation and Context
There is a hard limit of 50 validation emails a day using Cognito's own email address. To go beyond this, a customer domain must be used.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
