### PR TITLE
feat(cdn): support links to load balancers

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -307,14 +307,30 @@
                 [#local routeBehaviours += configCacheBehaviour ]
                 [#break]
 
+
+
+
+            [#case LB_COMPONENT_TYPE ]
             [#case LB_PORT_COMPONENT_TYPE ]
+
+                [#switch originLinkTargetCore.Type ]
+                    [#case LB_COMPONENT_TYPE ]
+                        [#local originHostName = originLinkTargetAttributes["INTERNAL_FQDN"] ]
+                        [#local originPath = formatAbsolutePath( "", subSolution.Origin.BasePath ) ]
+                        [#break]
+
+                    [#case LB_PORT_COMPONENT_TYPE ]
+                        [#local originHostName = originLinkTargetAttributes["FQDN"] ]
+                        [#local originPath = formatAbsolutePath( originLinkTargetAttributes["PATH"], subSolution.Origin.BasePath ) ]
+                        [#break]
+                [/#switch]
 
                 [#local origin =
                             getCFHTTPOrigin(
                                 originId,
-                                originLinkTargetAttributes["FQDN"],
+                                originHostName,
                                 _context.CustomOriginHeaders,
-                                formatAbsolutePath( originLinkTargetAttributes["PATH"], subSolution.Origin.BasePath )
+                                originPath
                             )]
                 [#local origins += origin ]
 


### PR DESCRIPTION
## Description
Adds support for a CDN To use a load balancer instead of a load balancer port as an origin

## Motivation and Context
When linking to a load balancer port you can't pass through the same host name from the CDN to the load balancer as the forwarding rules won't line up and the DNS names would point to the same location

When using the load balancer as the origin the internal AWS hostname is used allowing you to forward through to any port rule that has been applied

## How Has This Been Tested?
Tested on active deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
