### PR TITLE
feat(waf): enable log waf logging for waf enabled services

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 [#macro aws_cdn_cf_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["template", "epilogue"] /]
+    [@addDefaultGenerationContract subsets=["template", "epilogue", "cli" ] /]
 [/#macro]
 
 [#macro aws_cdn_cf_setup_solution occurrence ]
@@ -475,14 +475,26 @@
             wafAclId=valueIfTrue(wafAclId, wafPresent)
         /]
 
-        [#if wafPresent ]
+    [/#if]
+
+    [#if wafPresent ]
+        [#local wafLoggingProfile = getLoggingProfile(solution.WAF.Profiles.Logging) ]
+        [@createWAFLoggingFromProfile
+            occurrence=occurrence
+            wafaclId=wafAclId
+            loggingProfile=wafLoggingProfile
+            regional=false
+        /]
+
+        [#if deploymentSubsetRequired(CDN_COMPONENT_TYPE, true)]
             [@createWAFAclFromSecurityProfile
                 id=wafAclId
                 name=wafAclName
                 metric=wafAclName
                 wafSolution=solution.WAF
                 securityProfile=securityProfile
-                occurrence=occurrence /]
+                occurrence=occurrence
+            /]
         [/#if]
     [/#if]
 

--- a/aws/components/datafeed/id.ftl
+++ b/aws/components/datafeed/id.ftl
@@ -1,7 +1,14 @@
 [#ftl]
 [@addResourceGroupInformation
     type=DATAFEED_COMPONENT_TYPE
-    attributes=[]
+    attributes=[
+        {
+            "Names" : "WAFLogFeed",
+            "Description" : "Set up this datafeed to capture WAF Logs",
+            "Type" : BOOLEAN_TYPE,
+            "Default" : false
+        }
+    ]
     provider=AWS_PROVIDER
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=

--- a/aws/components/datafeed/state.ftl
+++ b/aws/components/datafeed/state.ftl
@@ -5,7 +5,12 @@
     [#local solution = occurrence.Configuration.Solution]
 
     [#local streamId = formatResourceId(AWS_KINESIS_FIREHOSE_STREAM_RESOURCE_TYPE, core.Id)]
-    [#local streamName = core.FullName]
+
+    [#if solution["aws:WAFLogFeed"]]
+        [#local streamName = formatName( "aws-waf-logs", core.FullName )]
+    [#else]
+        [#local streamName = core.FullName ]
+    [/#if]
 
     [#local lgId = formatLogGroupId(core.Id)]
     [#assign componentState =

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 [#macro aws_lb_cf_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["prologue", "template"] /]
+    [@addDefaultGenerationContract subsets=["prologue", "template", "cli", "epilogue" ] /]
 [/#macro]
 
 [#macro aws_lb_cf_setup_solution occurrence ]
@@ -720,9 +720,18 @@
 
     [#switch engine ]
         [#case "application"]
-            [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
-                [#-- Create a WAF ACL if required --]
-                [#if wafAclResources?has_content ]
+            [#if wafAclResources?has_content ]
+
+                [#local wafLoggingProfile = getLoggingProfile(wafSolution.Profiles.Logging) ]
+                [@createWAFLoggingFromProfile
+                    occurrence=occurrence
+                    wafaclId=wafAclResources.acl.Id
+                    loggingProfile=wafLoggingProfile
+                    regional=true
+                /]
+
+                [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
+                    [#-- Create a WAF ACL if required --]
                     [@createWAFAclFromSecurityProfile
                         id=wafAclResources.acl.Id
                         name=wafAclResources.acl.Name


### PR DESCRIPTION
## Description
Implementation of https://github.com/hamlet-io/engine/pull/1366  which enables log forwarding for WAF enabled services

To setup WAF logging you need 
- A datafeed component deployed with a backend configured ( for s3 no lambda transfromation is required, for Elasticsearch this may be required ) 
  - The datafeed also needs to be configured as a WAFLogFeed using the `aws:WAFLogFeed` configuration attribute. This changes the name of the deployed firehose to align with WAF setup requireemnts 
- A logging profile which links to this datafeed component 
   - Assign this logging profile under the WAF configuration `WAF.Profiles.Logging` 

**note:** if using the same datafeed for multiple WAF endpoints the log files will be stored together, they include a GUID in their file name so this should be safe

if using S3 you can use the following guide from AWS on setting up athena to query the logs
https://docs.aws.amazon.com/athena/latest/ug/waf-logs.html


## Motivation and Context

AWS WAF doesn't provide information out of the box about what caused a given request to fail. Instead they require you to setup a log forwarding solution to analyse the logs with an appropriate tool 

## How Has This Been Tested?
Tested locally across all components

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- Core - https://github.com/hamlet-io/engine/pull/1366
- AWS - https://github.com/hamlet-io/engine-plugin-aws/pull/105
- Bash Executor -  https://github.com/hamlet-io/executor-bash/pull/71

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
