### PR TITLE
feat(ecs): support ingress links for security groups

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -964,6 +964,16 @@
                         [/#list]
                     [/#if]
 
+                    [#if container.LinkIngressRules?has_content ]
+                        [#list container.LinkIngressRules as linkIngressRule ]
+                            [@createSecurityGroupIngressFromNetworkRule
+                                occurrence=subOccurrence
+                                groupId=ecsSecurityGroupId
+                                networkRule=linkIngressRule
+                            /]
+                        [/#list]
+                    [/#if]
+
                     [#if !(networkProfile.BaseSecurityGroup.Outbound.GlobalAllow)
                             && container.EgressRules?has_content ]
                         [#list container.EgressRules as egressRule ]


### PR DESCRIPTION
## Description
Adds support for link based ingress rules on ECS tasks and services

## Motivation and Context
For containers which aren't deployed with a load balancer you might want to allow direct access to the container. This allows you to do this using link based rules

## How Has This Been Tested?
Tested with local template generation

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- engine: https://github.com/hamlet-io/engine/pull/1370
- engine-plugin-aws: https://github.com/hamlet-io/engine-plugin-aws/pull/110

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
