### PR TITLE
efs support for chroot and mount creation

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -135,6 +135,20 @@
                 /]
             [/#if]
 
+
+            [#switch linkTargetCore.Type]
+                [#case EFS_COMPONENT_TYPE ]
+                [#case EFS_MOUNT_COMPONENT_TYPE]
+                    [#local configSets +=
+                        getInitConfigEFSMount(
+                            linkTargetCore.Id,
+                            linkTargetAttributes.EFS,
+                            linkTargetAttributes.DIRECTORY,
+                            linkId,
+                            (linkTargetAttributes.ACCESS_POINT_ID)!""
+                        )]
+                    [#break]
+            [/#switch]
         [/#list]
 
         [#if deploymentSubsetRequired("iam", true) &&

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -261,13 +261,16 @@
                         [#break]
                     [/#switch]
                 [#break]
+
+            [#case EFS_COMPONENT_TYPE ]
             [#case EFS_MOUNT_COMPONENT_TYPE]
                 [#local configSets +=
                     getInitConfigEFSMount(
                         linkTargetCore.Id,
                         linkTargetAttributes.EFS,
                         linkTargetAttributes.DIRECTORY,
-                        link.Id
+                        link.Id,
+                        (linkTargetAttributes.ACCESS_POINT_ID)!""
                     )]
                 [#break]
         [/#switch]

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -152,7 +152,7 @@
         [#if deploymentSubsetRequired(EC2_COMPONENT_TYPE, true)]
             [@createSecurityGroupRulesFromLink
                 occurrence=occurrence
-                groupId=computeClusterSecurityGroupId
+                groupId=ec2SecurityGroupId
                 linkTarget=linkTarget
                 inboundPorts=ec2SecurityGroupPorts
                 networkProfile=networkProfile
@@ -192,13 +192,15 @@
                         [#break]
                     [/#switch]
                 [#break]
+            [#case EFS_COMPONENT_TYPE ]
             [#case EFS_MOUNT_COMPONENT_TYPE]
                 [#local configSets +=
                     getInitConfigEFSMount(
                         linkTargetCore.Id,
-                        linkTargetAttributes["EFS"],
-                        linkTargetAttributes["DIRECTORY"],
-                        link.Id
+                        linkTargetAttributes.EFS,
+                        linkTargetAttributes.DIRECTORY,
+                        link.Id,
+                        (linkTargetAttributes.ACCESS_POINT_ID)!""
                     )]
                 [#break]
 
@@ -472,7 +474,7 @@
                     outputs={}
                 /]
 
-                [#if fixedIP]
+                [#if fixedIP || publicRouteTable]
                     [@createEIP
                         id=zoneEc2EIPId
                         dependencies=[zoneEc2ENIId]

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -248,14 +248,15 @@
             /]
 
             [#switch linkTargetCore.Type]
-
+                [#case EFS_COMPONENT_TYPE ]
                 [#case EFS_MOUNT_COMPONENT_TYPE]
                     [#local configSets +=
                         getInitConfigEFSMount(
                             linkTargetCore.Id,
-                            linkTargetAttributes["EFS"],
-                            linkTargetAttributes["DIRECTORY"],
-                            linkId
+                            linkTargetAttributes.EFS,
+                            linkTargetAttributes.DIRECTORY,
+                            link.Id,
+                            (linkTargetAttributes.ACCESS_POINT_ID)!""
                         )]
                     [#break]
             [/#switch]

--- a/aws/components/efs/id.ftl
+++ b/aws/components/efs/id.ftl
@@ -1,7 +1,14 @@
 [#ftl]
 [@addResourceGroupInformation
     type=EFS_COMPONENT_TYPE
-    attributes=[]
+    attributes=[
+        {
+            "Names" : "IAMRequired",
+            "Description" : "Require IAM Access to EFS",
+            "Type" : BOOLEAN_TYPE,
+            "Default" : false
+        }
+    ]
     provider=AWS_PROVIDER
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -351,7 +351,13 @@
     ]
 [/#function]
 
-[#function getInitConfigEFSMount mountId efsId directory osMount ignoreErrors=false priority=4 ]
+[#function getInitConfigEFSMount mountId efsId directory osMount accessPointId="" iamEnabled=true  ignoreErrors=false priority=4 ]
+
+    [#local createMount = true]
+    [#if directory == "/" ]
+        [#local createMount = false ]
+    [/#if]
+
     [#return
         {
             "${priority}_EFSMount_" + mountId : {
@@ -361,7 +367,10 @@
                         "env" : {
                             "EFS_FILE_SYSTEM_ID" : efsId,
                             "EFS_MOUNT_PATH" : directory,
-                            "EFS_OS_MOUNT_PATH" : "/mnt/clusterstorage/" + osMount
+                            "EFS_OS_MOUNT_PATH" : "/mnt/clusterstorage/" + osMount,
+                            "EFS_ACCESS_POINT_ID" : accessPointId,
+                            "EFS_IAM_ENABLED" : iamEnabled,
+                            "EFS_CREATE_MOUNT" : createMount
                         },
                         "ignoreErrors" : ignoreErrors
                     }

--- a/aws/services/efs/id.ftl
+++ b/aws/services/efs/id.ftl
@@ -2,7 +2,8 @@
 
 [#-- Resources --]
 [#assign AWS_EFS_RESOURCE_TYPE = "efs" ]
-[#assign AWS_EFS_MOUNTTARGET_RESOURCE_TYPE = "efsMountTarget" ]
+[#assign AWS_EFS_MOUNT_TARGET_RESOURCE_TYPE = "efsMountTarget" ]
+[#assign AWS_EFS_ACCESS_POINT_RESOURCE_TYPE = "efsAccessPoint" ]
 
 [#function formatEFSId tier component extensions...]
     [#return formatComponentResourceId(
@@ -14,8 +15,7 @@
 
 [#function formatDependentEFSMountTargetId resourceId extensions...]
     [#return formatDependentResourceId(
-                AWS_EFS_MOUNTTARGET_RESOURCE_TYPE
+                AWS_EFS_MOUNT_TARGET_RESOURCE_TYPE
                 resourceId,
                 extensions)]
 [/#function]
-

--- a/aws/services/efs/policy.ftl
+++ b/aws/services/efs/policy.ftl
@@ -1,0 +1,93 @@
+[#ftl]
+
+[#function getEfsStatement actions id="" accessPointId="" principals="" conditions=""]
+    [#local result = [] ]
+
+    [#local conditions =
+        {
+            "Bool": {
+                "aws:SecureTransport": "true"
+            }
+        }
+    ]
+
+    [#if accessPointId?has_content ]
+        [#local conditions +=
+            {
+                "StringEquals": {
+                    "elasticfilesystem:AccessPointArn" : getReference(accessPointId, ARN_ATTRIBUTE_TYPE)
+                }
+            }
+        ]
+    [/#if]
+
+    [#if id?has_content]
+        [#local result +=
+            [
+                getPolicyStatement(
+                    actions,
+                    formatRegionalArn("elasticfilesystem", formatRelativePath("file-system", getReference(id))),
+                    principals,
+                    conditions)
+            ]
+        ]
+    [#else]
+        [#local result +=
+            [
+                getPolicyStatement(
+                    actions,
+                    "",
+                    principals
+                    conditions
+                )
+            ]
+        ]
+    [/#if]
+
+    [return result]
+[/#function]
+
+[#function efsReadPermission id="" accessPointId="" principals="" conditions="" ]
+    [#return
+        getEfsStatement(
+            [
+                "elasticfilesystem:ClientMount"
+            ],
+            id,
+            accessPointId,
+            principals,
+            conditions
+        )
+    ]
+[/#function]
+
+[#function efsWritePermission id="" accessPointId="" principals="" conditions=""]
+    [#return
+        getEfsStatement(
+            [
+                "elasticfilesystem:ClientMount",
+                "elasticfilesystem:ClientWrite"
+            ],
+            id,
+            accessPointId,
+            principals,
+            conditions
+        )
+    ]
+[/#function]
+
+[#function efsFullPermission id="" accessPointId="" principals="" conditions=""]
+    [#return
+        getEfsStatement(
+            [
+                "elasticfilesystem:ClientMount",
+                "elasticfilesystem:ClientWrite",
+                "elasticfilesystem:ClientRootAccess"
+            ],
+            id,
+            accessPointId,
+            principals,
+            conditions
+        )
+    ]
+[/#function]


### PR DESCRIPTION
## Description
Implements chroot for mounts and adds new security features to EFS mounting
- Adds support for creating efs access points based on efs component mounts
- Adds IAM support for efs mounts 
- Adds support for EFS mounting to bastion components for serverless deployment troubleshooting 


## Motivation and Context
This allows you to create additional entry points to an EFS share and to control the permissions and provisioning of directories within the access point. This is useful for container based mounting where you can't pre provision directories you want to use an EFS share for multiple clients
Allows you use IAM roles to control, read, write and root level access to EFS data. This is available for normal EFS mounts and for access point based mounts 

## How Has This Been Tested?
Tested  on local deployment using both Ec2 and Bastion components

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
