### PR TITLE
feat(ecs): add support for efs volume mounts to tasks

### DIFF
--- a/aws/components/ecs/id.ftl
+++ b/aws/components/ecs/id.ftl
@@ -16,3 +16,33 @@
             AWS_SYSTEMS_MANAGER_SERVICE
         ]
 /]
+
+[@addResourceGroupInformation
+    type=ECS_SERVICE_COMPONENT_TYPE
+    attributes=[
+        {
+            "Names" : "FargatePlatform",
+            "Description" : "The version of the fargate platform to use",
+            "Type" : STRING_TYPE,
+            "Default" : "LATEST"
+        }
+    ]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=[]
+/]
+
+[@addResourceGroupInformation
+    type=ECS_TASK_COMPONENT_TYPE
+    attributes=[
+        {
+            "Names" : "FargatePlatform",
+            "Description" : "The version of the fargate platform to use",
+            "Type" : STRING_TYPE,
+            "Default" : "LATEST"
+        }
+    ]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=[]
+/]

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -1185,6 +1185,7 @@
                     networkMode=networkMode
                     networkConfiguration=aswVpcNetworkConfiguration!{}
                     placement=solution.Placement
+                    platformVersion=solution["aws:FargatePlatform"]
                     dependencies=dependencies
                 /]
             [/#if]
@@ -1316,7 +1317,8 @@
 
                     [#if engine == "fargate" ]
                         [#local ecsParameters += {
-                            "LaunchType" : "FARGATE"
+                            "LaunchType" : "FARGATE",
+                            "PlatformVersion" : solution["aws:FargatePlatform"]
                         }]
                     [/#if]
 


### PR DESCRIPTION
## Description
- Adds support for setting the Fargate Platform version on ECS tasks and Services 
- Adds support for ECS tasks to mount efs filesystems and access points as volumes

## Motivation and Context
Allows for persistent, shared storage on ecs containers using volumes rather than relying on the host bind mounts providing access to efs mounts 
This is useful for isolation between shared storage on ec2 instances and to support fargate  based tasks which don't allow host mounting 

Adding support to set the Fargate platform version provides access to efs mounts which is only available in platform version 1.4.0. The LATEST alias that we currently use as the default is more a stable tag and as a result this hasn't been updated to support the latest platform version

## How Has This Been Tested?
Tested on local deployment 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- engine - https://github.com/hamlet-io/engine/pull/1379 
- engine-plugin-aws - https://github.com/hamlet-io/engine-plugin-aws/pull/118
- executor-bash - https://github.com/hamlet-io/executor-bash/pull/80

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
