### PR TITLE
feat(userpool): disable oauth on clients

### DIFF
--- a/aws/components/userpool/setup.ftl
+++ b/aws/components/userpool/setup.ftl
@@ -682,7 +682,7 @@
                     tokenValidity=subSolution.ClientTokenValidity
                     oAuthFlows=subSolution.OAuth.Flows
                     oAuthScopes=oAuthScopes
-                    oAuthEnabled=true
+                    oAuthEnabled=subSolution.OAuth.Enabled
                     identityProviders=identityProviders
                     callbackUrls=callbackUrls
                     logoutUrls=logoutUrls

--- a/aws/services/cognito/resource.ftl
+++ b/aws/services/cognito/resource.ftl
@@ -493,13 +493,17 @@
                 "AllowedOAuthFlowsUserPoolClient" : oAuthEnabled,
                 "PreventUserExistenceErrors" : "ENABLED"
             } +
-            attributeIfContent(
-                "AllowedOAuthFlows",
-                oAuthFlows
-            ) +
-            attributeIfContent(
-                "AllowedOAuthScopes",
-                oAuthScopes
+            oAuthEnabled?then(
+                {} +
+                attributeIfContent(
+                    "AllowedOAuthFlows",
+                    oAuthFlows
+                ) +
+                attributeIfContent(
+                    "AllowedOAuthScopes",
+                    oAuthScopes
+                ),
+                {}
             ) +
             attributeIfContent(
                 "SupportedIdentityProviders",


### PR DESCRIPTION
## Description
AWS implementation of https://github.com/hamlet-io/engine/pull/1380 to allow for control over OAuth on user pool app clients


## Motivation and Context
When configuring an identity pool you must provide at least one client, this allows you to create a client for the identity pool without having to specify oauth configuration 

## How Has This Been Tested?
Tested on local deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
