### PR TITLE
feat(ecs): use deployment group filters on ecs subcomponents

### DIFF
--- a/aws/components/dataset/state.ftl
+++ b/aws/components/dataset/state.ftl
@@ -8,7 +8,7 @@
     [#local solution = occurrence.Configuration.Solution ]
     [#local buildReference = getOccurrenceBuildReference(occurrence, true ) ]
 
-    [#local dataSetDeploymentUnit = (solution.DeploymentUnits[0])!"" ]
+    [#local dataSetDeploymentUnit = getOccurrenceDeploymentUnit(occurrence)!"" ]
 
     [#local attributes = {
             "DATASET_ENGINE" : solution.Engine

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -664,7 +664,7 @@
     [#list requiredOccurrences(
             occurrence.Occurrences![],
             getDeploymentUnit(),
-            deploymentGroup.Name) as subOccurrence]
+            getDeploymentGroup()) as subOccurrence]
 
         [@debug message="Suboccurrence" context=subOccurrence enabled=false /]
 

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -663,7 +663,8 @@
 
     [#list requiredOccurrences(
             occurrence.Occurrences![],
-            getDeploymentUnit()) as subOccurrence]
+            getDeploymentUnit(),
+            deploymentGroup.Name) as subOccurrence]
 
         [@debug message="Suboccurrence" context=subOccurrence enabled=false /]
 

--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1768,82 +1768,71 @@
       "CDNOriginKey": "oai"
     }
   },
-    "DeploymentGroups" : {
+  "DeploymentGroups" : {
     "account" : {
-      "Deployment" : {
-        "Level" : "",
-        "ResourceSets" : {
-          "iam" : {
-            "DeploymentUnit" : "iam",
-            "ResourceLabels" : [ "iam" ]
-          },
-          "lg" : {
-            "DeploymentUnit" : "lg",
-            "ResourceLabels" : [ "lg" ]
-          }
+      "Level" : "",
+      "Priority" : 10,
+      "ResourceSets" : {
+        "iam" : {
+          "deployment:Unit" : "iam",
+          "ResourceLabels" : [ "iam" ]
+        },
+        "lg" : {
+          "deployment:Unit" : "lg",
+          "ResourceLabels" : [ "lg" ]
         }
       },
       "CompositeTemplate" : "accountList"
     },
     "segment" : {
-      "Deployment" : {
-        "Level" : "segment",
-        "ResourceSets" : {
-          "iam" : {
-            "Enabled" : false,
-            "DeploymentUnit" : "iam",
-            "ResourceLabels" : [ "iam" ]
-          },
-          "lg" : {
-            "DeploymentUnit" : "lg",
-            "ResourceLabels" : [ "lg" ]
-          },
-          "eip" : {
-            "DeploymentUnit" : "eip",
-            "ResourceLabels" : [ "eip" ]
-          },
-          "s3" : {
-            "DeploymentUnit" : "s3",
-            "ResourceLabels" : [ "s3" ]
-          },
-          "cmk" : {
-            "DeploymentUnit" : "cmk",
-            "ResourceLabels" : [ "cmk" ]
-          }
+      "ResourceSets" : {
+        "iam" : {
+          "deployment:Unit" : "iam",
+          "ResourceLabels" : [ "iam" ]
+        },
+        "lg" : {
+          "deployment:Unit" : "lg",
+          "ResourceLabels" : [ "lg" ]
+        },
+        "eip" : {
+          "deployment:Unit" : "eip",
+          "ResourceLabels" : [ "eip" ]
+        },
+        "s3" : {
+          "deployment:Unit" : "s3",
+          "ResourceLabels" : [ "s3" ]
+        },
+        "cmk" : {
+          "deployment:Unit" : "cmk",
+          "ResourceLabels" : [ "cmk" ]
         }
       }
     },
     "solution" : {
-      "Deployment" : {
-        "Level" : "solution",
-        "ResourceSets" : {
-          "eip" : {
-            "DeploymentUnit" : "eip",
-            "ResourceLabels" : [ "eip" ]
-          },
-          "iam" : {
-            "DeploymentUnit" : "iam",
-            "ResourceLabels" : [ "iam" ]
-          },
-          "lg" : {
-            "DeploymentUnit" : "lg",
-            "ResourceLabels" : [ "lg" ]
-          }
+      "ResourceSets" : {
+        "eip" : {
+          "deployment:Unit" : "eip",
+          "ResourceLabels" : [ "eip" ]
+        },
+        "iam" : {
+          "deployment:Unit" : "iam",
+          "ResourceLabels" : [ "iam" ]
+        },
+        "lg" : {
+          "deployment:Unit" : "lg",
+          "ResourceLabels" : [ "lg" ]
         }
       }
     },
     "application" : {
-      "Deployment" : {
-        "Level" : "application",
-        "ResourceSets" : {
-          "iam" : {
-            "DeploymentUnit" : "iam",
-            "ResourceLabels" : [ "iam" ]
-          },
-          "lg" : {
-            "DeploymentUnit" : "lg",
-            "ResourceLabels" : [ "lg" ]
-          }
+      "ResourceSets" : {
+        "iam" : {
+          "deployment:Unit" : "iam",
+          "ResourceLabels" : [ "iam" ]
+        },
+        "lg" : {
+          "deployment:Unit" : "lg",
+          "ResourceLabels" : [ "lg" ]
         }
       }
     }

--- a/aws/masterData.json
+++ b/aws/masterData.json
@@ -2363,79 +2363,69 @@
   },
   "DeploymentGroups" : {
     "account" : {
-      "Deployment" : {
-        "Level" : "",
-        "ResourceSets" : {
-          "iam" : {
-            "DeploymentUnit" : "iam",
-            "ResourceLabels" : [ "iam" ]
-          },
-          "lg" : {
-            "DeploymentUnit" : "lg",
-            "ResourceLabels" : [ "lg" ]
-          }
+      "Level" : "",
+      "Priority" : 10,
+      "ResourceSets" : {
+        "iam" : {
+          "deployment:Unit" : "iam",
+          "ResourceLabels" : [ "iam" ]
+        },
+        "lg" : {
+          "deployment:Unit" : "lg",
+          "ResourceLabels" : [ "lg" ]
         }
       },
       "CompositeTemplate" : "accountList"
     },
     "segment" : {
-      "Deployment" : {
-        "Level" : "segment",
-        "ResourceSets" : {
-          "iam" : {
-            "DeploymentUnit" : "iam",
-            "ResourceLabels" : [ "iam" ]
-          },
-          "lg" : {
-            "DeploymentUnit" : "lg",
-            "ResourceLabels" : [ "lg" ]
-          },
-          "eip" : {
-            "DeploymentUnit" : "eip",
-            "ResourceLabels" : [ "eip" ]
-          },
-          "s3" : {
-            "DeploymentUnit" : "s3",
-            "ResourceLabels" : [ "s3" ]
-          },
-          "cmk" : {
-            "DeploymentUnit" : "cmk",
-            "ResourceLabels" : [ "cmk" ]
-          }
+      "ResourceSets" : {
+        "iam" : {
+          "deployment:Unit" : "iam",
+          "ResourceLabels" : [ "iam" ]
+        },
+        "lg" : {
+          "deployment:Unit" : "lg",
+          "ResourceLabels" : [ "lg" ]
+        },
+        "eip" : {
+          "deployment:Unit" : "eip",
+          "ResourceLabels" : [ "eip" ]
+        },
+        "s3" : {
+          "deployment:Unit" : "s3",
+          "ResourceLabels" : [ "s3" ]
+        },
+        "cmk" : {
+          "deployment:Unit" : "cmk",
+          "ResourceLabels" : [ "cmk" ]
         }
       }
     },
     "solution" : {
-      "Deployment" : {
-        "Level" : "solution",
-        "ResourceSets" : {
-          "eip" : {
-            "DeploymentUnit" : "eip",
-            "ResourceLabels" : [ "eip" ]
-          },
-          "iam" : {
-            "DeploymentUnit" : "iam",
-            "ResourceLabels" : [ "iam" ]
-          },
-          "lg" : {
-            "DeploymentUnit" : "lg",
-            "ResourceLabels" : [ "lg" ]
-          }
+      "ResourceSets" : {
+        "eip" : {
+          "deployment:Unit" : "eip",
+          "ResourceLabels" : [ "eip" ]
+        },
+        "iam" : {
+          "deployment:Unit" : "iam",
+          "ResourceLabels" : [ "iam" ]
+        },
+        "lg" : {
+          "deployment:Unit" : "lg",
+          "ResourceLabels" : [ "lg" ]
         }
       }
     },
     "application" : {
-      "Deployment" : {
-        "Level" : "application",
-        "ResourceSets" : {
-          "iam" : {
-            "DeploymentUnit" : "iam",
-            "ResourceLabels" : [ "iam" ]
-          },
-          "lg" : {
-            "DeploymentUnit" : "lg",
-            "ResourceLabels" : [ "lg" ]
-          }
+      "ResourceSets" : {
+        "iam" : {
+          "deployment:Unit" : "iam",
+          "ResourceLabels" : [ "iam" ]
+        },
+        "lg" : {
+          "deployment:Unit" : "lg",
+          "ResourceLabels" : [ "lg" ]
         }
       }
     }


### PR DESCRIPTION
## Description
AWS Implementation of https://github.com/hamlet-io/engine/pull/1381
Includes the deployment group as part of the occurrence filtering on ecs subcomponents

## Motivation and Context
Allows for user controlled deployment groups to handle ordering deployments 
 
## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- Requires : https://github.com/hamlet-io/engine/pull/1381

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
