### PR TITLE
fix: enable segment iam resource set

### DIFF
--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1790,7 +1790,7 @@
         "Level" : "segment",
         "ResourceSets" : {
           "iam" : {
-            "Enabled" : false,
+            "Enabled" : true,
             "DeploymentUnit" : "iam",
             "ResourceLabels" : [ "iam" ]
           },


### PR DESCRIPTION
## Description
Minor bug fix to enable the iam segment resource set. 

## Motivation and Context
It was disabled during testing and I forgot to turn it back on 

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
