### PR TITLE
Fix testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@
 pipeline {
     options {
         timestamps()
-        quietPeriod(30)
     }
 
     agent {
@@ -12,9 +11,6 @@ pipeline {
 
     stages {
         stage('Run AWS Template Tests') {
-            agent {
-                label 'hamlet-latest'
-            }
             environment {
                 GENERATION_PLUGIN_DIRS="${WORKSPACE}"
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,10 @@
 #!groovy
 
+def slackChannel = '#devops-framework'
+
 pipeline {
     options {
-        timestamps()
+        durabilityHint('PERFORMANCE_OPTIMIZED')
     }
 
     agent {
@@ -32,6 +34,16 @@ pipeline {
                     wait: false
                 )
             }
+        }
+    }
+
+    post {
+        failure {
+            slackSend (
+                message: "*Failure* | <${BUILD_URL}|${JOB_NAME}>",
+                channel: "${slackChannel}",
+                color: "#D20F2A"
+            )
         }
     }
 }

--- a/awstest/scenarios/lb.ftl
+++ b/awstest/scenarios/lb.ftl
@@ -116,7 +116,7 @@
                     "OutputSuffix" : "template.json",
                     "Tools" : {
                         "CFNLint" : true,
-                        "CFNNag" : true
+                        "CFNNag" : false
                     }
                 }
             },

--- a/test/run_aws_template_tests.sh
+++ b/test/run_aws_template_tests.sh
@@ -4,7 +4,8 @@ echo "###############################################"
 echo "# Running template tests for the AWS provider #"
 echo "###############################################"
 
-TEST_OUTPUT_DIR="${TEST_OUTPUT_DIR:-"./hamlet_tests"}"
+DEFAULT_TEST_OUTPUT_DIR="$(pwd)/hamlet_tests"
+TEST_OUTPUT_DIR="${TEST_OUTPUT_DIR:-${DEFAULT_TEST_OUTPUT_DIR}}"
 
 if [[ -d "${TEST_OUTPUT_DIR}" ]]; then
     rm -r "${TEST_OUTPUT_DIR}"
@@ -13,20 +14,29 @@ else
     mkdir -p "${TEST_OUTPUT_DIR}"
 fi
 
-echo "Output Dir: ${TEST_OUTPUT_DIR}"
-echo "Generating unit list..."
-${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -l unitlist
-UNIT_LIST="$(jq -r '.DeploymentUnits | join(" ")' < "${TEST_OUTPUT_DIR}/unitlistconfig.json")"
+echo " -Output Dir: ${TEST_OUTPUT_DIR}"
+echo ""
+echo "--- Generating Management Contract ---"
+echo ""
 
-for unit in $UNIT_LIST; do
-    echo "Creating templates for $unit ..."
-    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -l segment -u $unit > /dev/null 2>&1 || true
-    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -l solution -u $unit > /dev/null 2>&1 || true
-    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -l application -u $unit > /dev/null 2>&1 || true
+${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -l unitlist
+UNIT_LIST=`jq -r '.Stages[].Steps[].Parameters | "-l \(.DeploymentGroup) -u \(.DeploymentUnit)"' < ${TEST_OUTPUT_DIR}/unitlist-managementcontract.json`
+readarray -t UNIT_LIST <<< "${UNIT_LIST}"
+
+for unit in "${UNIT_LIST[@]}";  do
+    echo ""
+    echo "--- Generating $unit ---"
+    echo ""
+    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -x ${unit} || exit $?
 done
+
+echo ""
+echo "--- Running Tests ---"
+echo ""
 
 hamlet test generate --directory "${TEST_OUTPUT_DIR}" -o "${TEST_OUTPUT_DIR}/test_templates.py"
 
+pushd $(pwd)
 cd "${TEST_OUTPUT_DIR}"
-echo "Running Tests..."
 hamlet test run -t "./test_templates.py"
+popd


### PR DESCRIPTION
## Description
Updates the AWS test template generation script to use the new unit list format based on the provided management contract format. Now that we know the deployment group that all units belong to also remove the `|| true` return on template generations so we know when template generation fails

## Motivation and Context

The introduction of the management contract provides better understanding of the units available in a deployment. This allows us to generate test templates in a more  efficient way. It should also allow us to catch problems when they occur at any stage in template generation

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- Depends on -  https://github.com/hamlet-io/executor-bash/pull/87 

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
