### PR TITLE
Ecs advanced features

### DIFF
--- a/aws/services/ecs/resource.ftl
+++ b/aws/services/ecs/resource.ftl
@@ -151,17 +151,18 @@
                                 },
                                 {}
                             ) +
-                            (volume.Driver != "local")?then(
-                                {
-                                    "Driver" : volume.Driver
-                                },
-                                {}
+                            attributeIfContent(
+                                "DriverOpts",
+                                (volume.DriverOpts)!{}
                             ) +
-                            (volume.DriverOpts?has_content)?then(
-                                {
-                                    "DriverOpts" : volume.DriverOpts
-                                },
-                                {}
+                            attributeIfTrue(
+                                "Driver",
+                                (volume.Driver != "local"),
+                                volume.Driver
+                            ) +
+                            attributeIfContent(
+                                "Scope",
+                                (volume.Scope)!""
                             )
                         ]
                 [/#switch]

--- a/aws/services/ecs/resource.ftl
+++ b/aws/services/ecs/resource.ftl
@@ -272,7 +272,8 @@
                 attributeIfContent("Links", container.ContainerNetworkLinks![] ) +
                 attributeIfContent("EntryPoint", container.EntryPoint![]) +
                 attributeIfContent("Command", container.Command![]) +
-                attributeIfContent("HealthCheck", container.HealthCheck!{})
+                attributeIfContent("HealthCheck", container.HealthCheck!{}) +
+                attributeIfContent("Hostname" , (container.Hostname)!"")
             ]
         ]
     [/#list]


### PR DESCRIPTION
## Description
AWS implementations of https://github.com/hamlet-io/engine/pull/1396 
- Adds support for setting the container hostname 
- Fixes the docker volume configuration to align with user control over the volume
- Adds support for [placement constraints](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html) Which allow you to restrict where a task is placed based on the labels assigned to either the ecs host or the task. For example `attribute:ecs.availability-zone == ap-southeast-2a` would only allow the task to be placed on an ec2 ecs host in ap-southeast-2a

## Motivation and Context
Provide greater control over ECS tasks definitions

## How Has This Been Tested?
Tested on active deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- https://github.com/hamlet-io/engine/pull/1396

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
