### PR TITLE
feat: sync authorizer openapi spec with api

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -118,7 +118,8 @@
                                 link.Name : {
                                     "Name" : link.Name,
                                     "StageVariable" : stageVariableName,
-                                    "Default" : true
+                                    "Default" : true,
+                                    "SettingsPrefix" : getOccurrenceSettingValue(linkTarget, "SETTINGS_PREFIX")
                                 }
                             } ]
                     [/#if]
@@ -865,5 +866,32 @@
                     true
                 )
         /]
+
+        [#-- If using an authoriser, give it a copy of the openapi spec --]
+        [#if lambdaAuthorizers?has_content]
+            [#-- Copy the config file to a standard filename --]
+            [@addToDefaultBashScriptOutput
+                content=
+                    getLocalFileScript(
+                        "referenceFiles",
+                        "$\{CONFIG}",
+                        "openapi.json"
+                    )
+            /]
+            [#list lambdaAuthorizers?values as lambdaAuthorizer]
+                [@addToDefaultBashScriptOutput
+                    content=
+                        syncFilesToBucketScript(
+                            "referenceFiles",
+                            regionId,
+                            operationsBucket,
+                            formatRelativePath(
+                                lambdaAuthorizer.SettingsPrefix,
+                                "reference"),
+                            false
+                        )
+                /]
+            [/#list]
+        [/#if]
     [/#if]
 [/#macro]


### PR DESCRIPTION
## Description
Copy the api specification to a subpath of the settings for any lambda authorizers used.


## Motivation and Context
The authorizer relies on a copy of the openapi specification to determine various attributes of methods such as scopes and acr.

It thus needs a new copy of the api spec each time it is changed by the api. To achieve this, copy the spec to a specific subpath of the authorizer settings as part of the api deployment.. A subpath ensures other mechanisms such as asFile or config do not interfere with the copied spec.

## How Has This Been Tested?
Customer deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [ ] Ensure the authorizer deployment happens after the corresponding api. Note that during stack creation, the api will not detect the authorizer, so the api and authorizer deployments should be run twice initially.
- [ ] For continuous deployment environments, ensure the authorizer is redeployed whenever the api is rebuilt.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
