### PR TITLE
Support for entrances and flows in AWS Provider

### DIFF
--- a/aws/components/adaptor/setup.ftl
+++ b/aws/components/adaptor/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_adaptor_cf_generationcontract_application occurrence ]
+[#macro aws_adaptor_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets=["prologue", "config", "epilogue" ] /]
 [/#macro]
 
-[#macro aws_adaptor_cf_setup_application occurrence ]
+[#macro aws_adaptor_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -1,10 +1,10 @@
 [#ftl]
 
-[#macro aws_apigateway_cf_generationcontract_application occurrence ]
+[#macro aws_apigateway_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets=["pregeneration", "prologue", "template", "epilogue", "config", "cli" ] /]
 [/#macro]
 
-[#macro aws_apigateway_cf_setup_application occurrence ]
+[#macro aws_apigateway_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/apiusageplan/setup.ftl
+++ b/aws/components/apiusageplan/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_apiusageplan_cf_generationcontract_application occurrence ]
+[#macro aws_apiusageplan_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_apiusageplan_cf_setup_application occurrence ]
+[#macro aws_apiusageplan_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_baseline_cf_generationcontract_segment occurrence ]
+[#macro aws_baseline_cf_deployment_generationcontract_segment occurrence ]
     [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue"] /]
 [/#macro]
 
-[#macro aws_baseline_cf_setup_segment occurrence ]
+[#macro aws_baseline_cf_deployment_segment occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_bastion_cf_generationcontract_segment occurrence ]
+[#macro aws_bastion_cf_deployment_generationcontract_segment occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_bastion_cf_setup_segment occurrence ]
+[#macro aws_bastion_cf_deployment_segment occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/cache/setup.ftl
+++ b/aws/components/cache/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_cache_cf_generationcontract_solution occurrence ]
+[#macro aws_cache_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_cache_cf_setup_solution occurrence ]
+[#macro aws_cache_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_cdn_cf_generationcontract_solution occurrence ]
+[#macro aws_cdn_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=["template", "epilogue", "cli" ] /]
 [/#macro]
 
-[#macro aws_cdn_cf_setup_solution occurrence ]
+[#macro aws_cdn_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_computecluster_cf_generationcontract_application occurrence ]
+[#macro aws_computecluster_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_computecluster_cf_setup_application occurrence ]
+[#macro aws_computecluster_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/configstore/setup.ftl
+++ b/aws/components/configstore/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_configstore_cf_generationcontract_solution occurrence ]
+[#macro aws_configstore_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=["template", "epilogue", "cli"] /]
 [/#macro]
 
-[#macro aws_configstore_cf_setup_solution occurrence ]
+[#macro aws_configstore_cf_deployment occurrence_solution ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local parentCore = occurrence.Core]

--- a/aws/components/contenthub/setup.ftl
+++ b/aws/components/contenthub/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_contenthub_cf_generationcontract_solution occurrence ]
+[#macro aws_contenthub_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets="prologue" /]
 [/#macro]
 
-[#macro aws_contenthub_cf_setup_solution occurrence ]
+[#macro aws_contenthub_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/components/contentnode/setup.ftl
+++ b/aws/components/contentnode/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_contentnode_cf_generationcontract_application occurrence ]
+[#macro aws_contentnode_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets="prologue" /]
 [/#macro]
 
-[#macro aws_contentnode_cf_setup_application occurrence ]
+[#macro aws_contentnode_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_datafeed_cf_generationcontract_solution occurrence ]
+[#macro aws_datafeed_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_datafeed_cf_setup_solution occurrence ]
+[#macro aws_datafeed_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/components/datapipeline/setup.ftl
+++ b/aws/components/datapipeline/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_datapipeline_cf_generationcontract_application occurrence ]
+[#macro aws_datapipeline_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue", "cli", "config"] /]
 [/#macro]
 
-[#macro aws_datapipeline_cf_setup_application occurrence ]
+[#macro aws_datapipeline_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/dataset/setup.ftl
+++ b/aws/components/dataset/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_dataset_cf_generationcontract_application occurrence ]
+[#macro aws_dataset_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets=[ "prologue" ] /]
 [/#macro]
 
-[#macro aws_dataset_cf_setup_application occurrence ]
+[#macro aws_dataset_cf_deployment_application occurrence ]
     [#if deploymentSubsetRequired("prologue", false)]
         [@addToDefaultBashScriptOutput
             [

--- a/aws/components/datavolume/setup.ftl
+++ b/aws/components/datavolume/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_datavolume_cf_generationcontract_solution occurrence ]
+[#macro aws_datavolume_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=["template", "epilogue"] /]
 [/#macro]
 
-[#macro aws_datavolume_cf_setup_solution occurrence ]
+[#macro aws_datavolume_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -1,12 +1,12 @@
 [#ftl]
-[#macro aws_db_cf_generationcontract_solution occurrence ]
+[#macro aws_db_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract
         subsets=["prologue", "template", "epilogue"]
         alternatives=["primary", "replace1", "replace2"]
     /]
 [/#macro]
 
-[#macro aws_db_cf_setup_solution occurrence ]
+[#macro aws_db_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_ec2_cf_generationcontract_solution occurrence ]
+[#macro aws_ec2_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_ec2_cf_setup_solution occurrence ]
+[#macro aws_ec2_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_ecs_cf_generationcontract_solution occurrence ]
+[#macro aws_ecs_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=[ "template", "cli", "epilogue" ] /]
 [/#macro]
 
-[#macro aws_ecs_cf_setup_solution occurrence ]
+[#macro aws_ecs_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]
@@ -622,11 +622,11 @@
 
 [/#macro]
 
-[#macro aws_ecs_cf_generationcontract_application occurrence ]
+[#macro aws_ecs_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue", "cli"] /]å
 [/#macro]
 
-[#macro aws_ecs_cf_setup_application occurrence ]
+[#macro aws_ecs_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local parentResources = occurrence.State.Resources]

--- a/aws/components/efs/setup.ftl
+++ b/aws/components/efs/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_efs_cf_generationcontract_solution occurrence ]
+[#macro aws_efs_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_efs_cf_setup_solution occurrence ]
+[#macro aws_efs_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/components/es/setup.ftl
+++ b/aws/components/es/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_es_cf_generationcontract_solution occurrence ]
+[#macro aws_es_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=["template", "epilogue" ] /]
 [/#macro]
 
-[#macro aws_es_cf_setup_solution occurrence ]
+[#macro aws_es_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/components/externalnetwork/setup.ftl
+++ b/aws/components/externalnetwork/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_externalnetwork_cf_generationcontract_segment occurrence ]
+[#macro aws_externalnetwork_cf_deployment_generationcontract_segment occurrence ]
     [@addDefaultGenerationContract subsets=[ "template", "cli", "epilogue" ] /]
 [/#macro]
 
-[#macro aws_externalnetwork_cf_setup_segment occurrence ]
+[#macro aws_externalnetwork_cf_deployment_segment occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local parentCore = occurrence.Core ]

--- a/aws/components/federatedrole/setup.ftl
+++ b/aws/components/federatedrole/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_federatedrole_cf_generationcontract_solution occurrence ]
+[#macro aws_federatedrole_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_federatedrole_cf_setup_solution occurrence ]
+[#macro aws_federatedrole_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/components/filetransfer/setup.ftl
+++ b/aws/components/filetransfer/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_filetransfer_cf_generationcontract_solution occurrence ]
+[#macro aws_filetransfer_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=[ "prologue", "template", "epilogue" ] /]
 [/#macro]
 
-[#macro aws_filetransfer_cf_setup_solution occurrence ]
+[#macro aws_filetransfer_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_gateway_cf_generationcontract_segment occurrence ]
+[#macro aws_gateway_cf_deployment_generationcontract_segment occurrence ]
     [@addDefaultGenerationContract subsets=["template", "cli", "epilogue"] /]
 [/#macro]
 
-[#macro aws_gateway_cf_setup_segment occurrence ]
+[#macro aws_gateway_cf_deployment_segment occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local gwCore = occurrence.Core ]

--- a/aws/components/globaldb/setup.ftl
+++ b/aws/components/globaldb/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_globaldb_cf_generationcontract_solution occurrence ]
+[#macro aws_globaldb_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=["template" ] /]
 [/#macro]
 
-[#macro aws_globaldb_cf_setup_solution occurrence ]
+[#macro aws_globaldb_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_lambda_cf_generationcontract_application occurrence ]
+[#macro aws_lambda_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets=["prologue", "template", "config", "epilogue"] /]
 [/#macro]
 
-[#macro aws_lambda_cf_setup_application occurrence ]
+[#macro aws_lambda_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#list occurrence.Occurrences as fn]
@@ -12,7 +12,7 @@
 [/#macro]
 
 [#-- Rename once we switch to the context model for processing --]
-[#macro aws_functionxx_cf_application occurrence ]
+[#macro aws_functionxx_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#if deploymentSubsetRequired("generationcontract", false)]

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_lb_cf_generationcontract_solution occurrence ]
+[#macro aws_lb_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=["prologue", "template", "cli", "epilogue" ] /]
 [/#macro]
 
-[#macro aws_lb_cf_setup_solution occurrence ]
+[#macro aws_lb_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/mobileapp/setup.ftl
+++ b/aws/components/mobileapp/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_mobileapp_cf_generationcontract_application occurrence ]
+[#macro aws_mobileapp_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets=["prologue", "config"] /]
 [/#macro]
 
-[#macro aws_mobileapp_cf_setup_application occurrence ]
+[#macro aws_mobileapp_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/mobilenotifier/setup.ftl
+++ b/aws/components/mobilenotifier/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_mobilenotifier_cf_generationcontract_solution occurrence ]
+[#macro aws_mobilenotifier_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue", "cli"] /]
 [/#macro]
 
-[#macro aws_mobilenotifier_cf_setup_solution occurrence ]
+[#macro aws_mobilenotifier_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/components/network/setup.ftl
+++ b/aws/components/network/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_network_cf_generationcontract_segment occurrence ]
+[#macro aws_network_cf_deployment_generationcontract_segment occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_network_cf_setup_segment occurrence ]
+[#macro aws_network_cf_deployment_segment occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/objectsql/setup.ftl
+++ b/aws/components/objectsql/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_objectsql_cf_generationcontract_solution occurrence ]
+[#macro aws_objectsql_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=["cli", "prologue"] /]
 [/#macro]
 
-[#macro aws_objectsql_cf_setup_solution occurrence ]
+[#macro aws_objectsql_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=true /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/privateservice/setup.ftl
+++ b/aws/components/privateservice/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_privateservice_cf_generationcontract_solution occurrence ]
+[#macro aws_privateservice_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_privateservice_cf_setup_solution occurrence ]
+[#macro aws_privateservice_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/router/setup.ftl
+++ b/aws/components/router/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_router_cf_generationcontract_segment occurrence ]
+[#macro aws_router_cf_deployment_generationcontract_segment occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_router_cf_setup_segment occurrence ]
+[#macro aws_router_cf_deployment_segment occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_s3_cf_generationcontract_solution occurrence ]
+[#macro aws_s3_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_s3_cf_setup_solution occurrence ]
+[#macro aws_s3_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/segment/segment_cert.ftl
+++ b/aws/components/segment/segment_cert.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_cert_cf_generationcontract_segment occurrence ]
+[#macro aws_cert_cf_deployment_generationcontract_segment occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_cert_cf_setup_segment occurrence ]
+[#macro aws_cert_cf_deployment_segment occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#if deploymentSubsetRequired("cert", true)]

--- a/aws/components/segment/segment_dashboard.ftl
+++ b/aws/components/segment/segment_dashboard.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_dashboard_cf_generationcontract_segment occurrence ]
+[#macro aws_dashboard_cf_deployment_generationcontract_segment occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_dashboard_cf_setup_segment occurrence ]
+[#macro aws_dashboard_cf_deployment_segment occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#if deploymentSubsetRequired("dashboard", true)]

--- a/aws/components/segment/segment_dns.ftl
+++ b/aws/components/segment/segment_dns.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_dns_cf_generationcontract_segment occurrence ]
+[#macro aws_dns_cf_deployment_generationcontract_segment occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_dns_cf_setup_segment occurrence ]
+[#macro aws_dns_cf_deployment_segment occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#if deploymentSubsetRequired("dns", true)]

--- a/aws/components/serviceregistry/setup.ftl
+++ b/aws/components/serviceregistry/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_serviceregistry_cf_generationcontract_solution occurrence ]
+[#macro aws_serviceregistry_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_serviceregistry_cf_setup_solution occurrence ]
+[#macro aws_serviceregistry_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/solution/solution_lg.ftl
+++ b/aws/components/solution/solution_lg.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_lg_cf_generationcontract_solution occurrence ]
+[#macro aws_lg_cf_deployment_generationcontract_solution occurrence ]
      [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_lg_cf_setup_solution occurrence ]
+[#macro aws_lg_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local componentLogGroupId = formatComponentLogGroupId(tier, component)]

--- a/aws/components/spa/setup.ftl
+++ b/aws/components/spa/setup.ftl
@@ -1,5 +1,5 @@
 [#ftl]
-[#macro aws_spa_cf_generationcontract_solution occurrence ]
+[#macro aws_spa_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=[] /]
     [@error
         message="Solution SPA Deprecation"
@@ -7,11 +7,11 @@
     /]
 [/#macro]
 
-[#macro aws_spa_cf_generationcontract_application occurrence  ]
+[#macro aws_spa_cf_deployment_generationcontract_application occurrence  ]
     [@addDefaultGenerationContract subsets=["prologue", "config", "epilogue" ] /]
 [/#macro]
 
-[#macro aws_spa_cf_setup_application occurrence  ]
+[#macro aws_spa_cf_deployment_application occurrence  ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/sqs/setup.ftl
+++ b/aws/components/sqs/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_sqs_cf_generationcontract_solution occurrence ]
+[#macro aws_sqs_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_sqs_cf_setup_solution occurrence ]
+[#macro aws_sqs_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#if deploymentSubsetRequired("sqs", true)]

--- a/aws/components/template/setup.ftl
+++ b/aws/components/template/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_template_cf_generationcontract_application occurrence ]
+[#macro aws_template_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets=[ "prologue", "template" ] /]
 [/#macro]
 
-[#macro aws_template_cf_setup_application occurrence ]
+[#macro aws_template_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/topic/setup.ftl
+++ b/aws/components/topic/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_topic_cf_generationcontract_solution occurrence ]
+[#macro aws_topic_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets="template" /]
 [/#macro]
 
-[#macro aws_topic_cf_setup_solution occurrence ]
+[#macro aws_topic_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/components/user/setup.ftl
+++ b/aws/components/user/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_user_cf_generationcontract_application occurrence ]
+[#macro aws_user_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue"] /]
 [/#macro]
 
-[#macro aws_user_cf_setup_application occurrence ]
+[#macro aws_user_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core ]

--- a/aws/components/userpool/setup.ftl
+++ b/aws/components/userpool/setup.ftl
@@ -1,9 +1,9 @@
 [#ftl]
-[#macro aws_userpool_cf_generationcontract_solution occurrence ]
+[#macro aws_userpool_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract subsets=["template", "epilogue" ] /]
 [/#macro]
 
-[#macro aws_userpool_cf_setup_solution occurrence ]
+[#macro aws_userpool_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
     [#local core = occurrence.Core]

--- a/aws/deploymentframeworks/cf/output.ftl
+++ b/aws/deploymentframeworks/cf/output.ftl
@@ -225,7 +225,12 @@
     [#if include?has_content]
         [#include include?ensure_starts_with("/")]
     [#else]
-        [@processComponents level /]
+        [@processModelFlow
+            level=level
+            framework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
+            model=commandLineOptions.Deployment.Framework.Model
+            flow=commandLineOptions.Deployment.Framework.Flow
+        /]
     [/#if]
 
     [#if getOutputContent("resources")?has_content || logMessages?has_content]

--- a/aws/deploymentframeworks/cf/output.ftl
+++ b/aws/deploymentframeworks/cf/output.ftl
@@ -225,11 +225,10 @@
     [#if include?has_content]
         [#include include?ensure_starts_with("/")]
     [#else]
-        [@processModelFlow
+        [@processFlows
             level=level
             framework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
-            model=commandLineOptions.Deployment.Framework.Model
-            flow=commandLineOptions.Deployment.Framework.Flow
+            flows=commandLineOptions.Flow.Names
         /]
     [/#if]
 

--- a/awstest/inputsources/mock/blueprint.ftl
+++ b/awstest/inputsources/mock/blueprint.ftl
@@ -1,0 +1,53 @@
+[#ftl]
+
+[#-- Intial seeding of settings data based on input data --]
+[#macro awstest_input_mock_blueprint_seed ]
+    [@addBlueprint
+        blueprint={
+            "DeploymentGroups" : {
+                "segment" : {
+                    "ResourceSets" : {
+                        "iam" : {
+                            "Enabled" : false
+                        },
+                        "lg" : {
+                            "Enabled" : false
+                        },
+                        "eip" : {
+                            "Enabled" : false
+                        },
+                        "s3" : {
+                            "Enabled" : false
+                        },
+                        "cmk" : {
+                            "Enabled" : false
+                        }
+                    }
+                },
+                "solution" : {
+                    "ResourceSets" : {
+                        "eip" : {
+                            "Enabled" : false
+                        },
+                        "iam" : {
+                            "Enabled" : false
+                        },
+                        "lg" : {
+                            "Enabled" : false
+                        }
+                    }
+                },
+                "application" : {
+                    "ResourceSets" : {
+                        "iam" : {
+                            "Enabled" : false
+                        },
+                        "lg" : {
+                            "Enabled" : false
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/test/run_aws_template_tests.sh
+++ b/test/run_aws_template_tests.sh
@@ -19,7 +19,7 @@ echo ""
 echo "--- Generating Management Contract ---"
 echo ""
 
-${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -l unitlist
+${GENERATION_DIR}/createTemplate.sh -e unitlist -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}"
 UNIT_LIST=`jq -r '.Stages[].Steps[].Parameters | "-l \(.DeploymentGroup) -u \(.DeploymentUnit)"' < ${TEST_OUTPUT_DIR}/unitlist-managementcontract.json`
 readarray -t UNIT_LIST <<< "${UNIT_LIST}"
 
@@ -27,7 +27,8 @@ for unit in "${UNIT_LIST[@]}";  do
     echo ""
     echo "--- Generating $unit ---"
     echo ""
-    ${GENERATION_DIR}/createTemplate.sh -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -x ${unit} || exit $?
+    ${GENERATION_DIR}/createTemplate.sh -e deployment -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -x ${unit} || exit $?
+    ${GENERATION_DIR}/createTemplate.sh -e deploymenttest -i mock -p aws -p awstest -o "${TEST_OUTPUT_DIR}" -x ${unit} || exit $?
 done
 
 echo ""


### PR DESCRIPTION
## Description
Updates the AWS provider to support the entrances and flows changes introduced in https://github.com/hamlet-io/engine/pull/1407 

Disables resource sets from template testing to make it easier to follow from a testing perspective

## Motivation and Context
Provides support for broader output types based on the hamlet structure

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [ ] engine - https://github.com/hamlet-io/engine/pull/1407
- [ ] executor-bash - https://github.com/hamlet-io/executor-bash/pull/105
- [ ] engine-plugin-aws - https://github.com/hamlet-io/engine-plugin-aws/pull/132
- [ ] engine-plugin-azure - https://github.com/hamlet-io/engine-plugin-azure/pull/204 

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
