### PR TITLE
Feat - Baseline DataBucket Replication

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -63,12 +63,17 @@
         [#local subSolution = subOccurrence.Configuration.Solution ]
         [#local subResources = subOccurrence.State.Resources ]
 
+        [#local replicationEnabled = false]
+        [#local replicationConfiguration = {} ]
+        [#local replicationBucket = "" ]
+
         [#-- Storage bucket --]
         [#if subCore.Type == BASELINE_DATA_COMPONENT_TYPE ]
             [#local bucketId = subResources["bucket"].Id ]
             [#local bucketName = subResources["bucket"].Name ]
             [#local bucketPolicyId = subResources["bucketpolicy"].Id ]
             [#local legacyS3 = subResources["bucket"].LegacyS3 ]
+            [#local replicationRoleId = subResources["role"].Id]
 
             [#if ( deploymentSubsetRequired(BASELINE_COMPONENT_TYPE, true) && legacyS3 == false ) ||
                 ( deploymentSubsetRequired("s3") && legacyS3 == true) ]
@@ -192,9 +197,70 @@
                                     [#local cfAccessCanonicalIds += [ getReference( (linkTargetResources["originAccessId"].Id), CANONICAL_ID_ATTRIBUTE_TYPE )] ]
                                 [/#if]
                                 [#break]
+
+                            [#case S3_COMPONENT_TYPE]
+
+                                [#switch linkTarget.Role ]
+                                    [#case "replicadestination" ]
+                                        [#local replicationEnabled = true]
+                                        [#if !replicationBucket?has_content ]
+                                            [#local replicationBucket = linkTargetAttributes["ARN"]]
+                                            [#local linkPolicies = [linkTarget.Role] ]
+                                        [#else]
+                                            [@fatal
+                                                message="Only one replication destination is supported"
+                                                context=links
+                                            /]
+                                        [/#if]
+                                        [#break]
+                                [/#switch]
+                                [#break]
+
                         [/#switch]
                     [/#if]
                 [/#list]
+
+                [#-- Add Replication Rules --]
+                [#if replicationEnabled ]
+                    [#-- Only handle data replication after destination bucket exists --]
+                    [#if (subSolution.Replication!{})?has_content]
+                        [#local replicationRules = [] ]
+                        [#list subSolution.Replication.Prefixes as prefix ]
+                            [#local replicationRules +=
+                                [ getS3ReplicationRule(
+                                    replicationBucket,
+                                    subSolution.Replication.Enabled,
+                                    prefix,
+                                    false
+                                )]]
+                        [/#list]
+
+                        [#local replicationConfiguration = 
+                            getS3ReplicationConfiguration(replicationRoleId, replicationRules)]
+
+                        [#local rolePolicies =
+                                arrayIfContent(
+                                    [getPolicyDocument(linkPolicies, "links")],
+                                    linkPolicies) +
+                                arrayIfContent(
+                                    getPolicyDocument(
+                                        s3ReplicaSourcePermission(bucketId) +
+                                        s3ReplicationConfigurationPermission(bucketId),
+                                        "replication"),
+                                    replicationConfiguration
+                                )]
+
+                        [#if rolePolicies?has_content ]
+                            [@createRole
+                                id=replicationRoleId
+                                trustedServices=["s3.amazonaws.com"]
+                                policies=rolePolicies
+                            /]
+                        [/#if]
+           
+
+                    [/#if]
+                [/#if]
 
                 [@createS3Bucket
                     id=bucketId
@@ -204,6 +270,7 @@
                     notifications=notifications
                     encrypted=subSolution.Encryption.Enabled
                     encryptionSource=subSolution.Encryption.EncryptionSource
+                    replicationConfiguration=replicationConfiguration
                     kmsKeyId=cmkId
                     dependencies=bucketDependencies
                 /]

--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -74,6 +74,8 @@
             [#local bucketPolicyId = subResources["bucketpolicy"].Id ]
             [#local legacyS3 = subResources["bucket"].LegacyS3 ]
             [#local replicationRoleId = subResources["role"].Id]
+            [#local links = getLinkTargets(subOccurrence)]
+            [#local versioningEnabled = (subSolution.Replication!{})?has_content?then(true, subSolution.Versioning)]
 
             [#if ( deploymentSubsetRequired(BASELINE_COMPONENT_TYPE, true) && legacyS3 == false ) ||
                 ( deploymentSubsetRequired("s3") && legacyS3 == true) ]
@@ -205,7 +207,7 @@
                                         [#local replicationEnabled = true]
                                         [#if !replicationBucket?has_content ]
                                             [#local replicationBucket = linkTargetAttributes["ARN"]]
-                                            [#local linkPolicies = [linkTarget.Role] ]
+                                            [#local linkPolicies = getLinkTargetsOutboundRoles(links) ]
                                         [#else]
                                             [@fatal
                                                 message="Only one replication destination is supported"
@@ -265,7 +267,7 @@
                 [@createS3Bucket
                     id=bucketId
                     name=bucketName
-                    versioning=subSolution.Versioning
+                    versioning=versioningEnabled
                     lifecycleRules=lifecycleRules
                     notifications=notifications
                     encrypted=subSolution.Encryption.Enabled

--- a/aws/components/baseline/state.ftl
+++ b/aws/components/baseline/state.ftl
@@ -48,7 +48,7 @@
     [#local legacyS3 = false]
 
     [#local bucketId = formatOccurrenceS3Id( occurrence) ]
-    [#local bucketName = formatOccurrenceBucketName( occurrence )]]
+    [#local bucketName = formatOccurrenceBucketName( occurrence )]
 
     [#switch core.SubComponent.Id ]
         [#case "appdata" ]
@@ -86,6 +86,11 @@
                 "bucketpolicy" : {
                     "Id" : bucketPolicyId,
                     "Type" : AWS_S3_BUCKET_POLICY_RESOURCE_TYPE
+                },
+                "role" : {
+                    "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, core.Id ),
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false 
                 }
             },
             "Attributes" : {

--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -164,7 +164,6 @@
         [#if link?is_hash]
 
             [#local linkTarget = getLinkTarget(occurrence, link, false) ]
-
             [@debug message="Link Target" context=linkTarget enabled=false /]
 
             [#if !linkTarget?has_content]
@@ -203,21 +202,11 @@
                     [/#if]
                     [#break]
 
+                [#case "baselinedata"]
                 [#case S3_COMPONENT_TYPE ]
                     [#switch linkTarget.Role ]
                         [#case  "replicadestination" ]
                             [#local replicationEnabled = true]
-                            [#if linkTargetAttributes["REGION"] == regionId ]
-                                [@fatal
-                                    dmessageescription="Replication buckets must be in different regions"
-                                    context=
-                                        {
-                                            "SourceBucket" : regionId,
-                                            "DestinationBucket" : linkTargetAttributes["REGION"]
-                                        }
-                                /]
-                            [/#if]
-
                             [#local versioningEnabled = true]
 
                             [#if !replicationBucket?has_content ]

--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -202,7 +202,6 @@
                     [/#if]
                     [#break]
 
-                [#case "baselinedata"]
                 [#case S3_COMPONENT_TYPE ]
                     [#switch linkTarget.Role ]
                         [#case  "replicadestination" ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enables replication of the baselinedata buckets to a linked s3 component. 
Also removes an error if both buckets are in the same region as AWS have removed this requirement.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is sometimes desirable to be able to backup or consolidate the data types that are intended for these buckets.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation and deployment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.

* Change will require schema's to be regenerated.
