### PR TITLE
fix: don't delete authorizer openapi.json file

### DIFF
--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -535,6 +535,17 @@
         /]
     [/#if]
 
+    [#-- Always exclude any reference files copied by other deployments      --]
+    [#-- An example use case is the api gateway copying an openapi.json file --]
+    [#-- for a lambda authoriser                                             --]
+    [#local syncExclusions =
+        ["reference/*"] +
+        arrayIfTrue(
+            "config/*",
+            solution.Environment.AsFile
+        )
+    ]
+
     [#if deploymentSubsetRequired("epilogue", false)]
         [#-- Assume stack update was successful so delete other files --]
         [#local asFiles = getAsFileSettings(fn.Configuration.Settings.Product) ]
@@ -548,7 +559,8 @@
                         regionId,
                         operationsBucket,
                         getOccurrenceSettingValue(fn, "SETTINGS_PREFIX"),
-                        true
+                        true,
+                        syncExclusions
                     ) /]
         [/#if]
         [#if solution.Environment.AsFile]


### PR DESCRIPTION
## Description
When syncing asFiles to S3, ignore any reference files provided by other deployments.

## Motivation and Context
The initial use case is to permit the openapi.json file provided by the api gateway to not be affected by redeployments of the lambda authorizer.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
