### PR TITLE
fix: spa state handles no baseline

### DIFF
--- a/aws/components/spa/state.ftl
+++ b/aws/components/spa/state.ftl
@@ -1,16 +1,19 @@
 [#ftl]
 
 [#macro aws_spa_cf_state occurrence parent={} ]
+
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
     [#local cfId  = formatComponentCFDistributionId(core.Tier, core.Component, occurrence)]
 
     [#-- Baseline component lookup --]
-    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData" ] )]
+    [#-- Allow for possibility buckets haven't been created yet --]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData" ], true, false )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
-    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+    [#local operationsBucketId = baselineComponentIds["OpsData"]!"" ]
+    [#local operationsBucket = getExistingReference(operationsBucketId) ]
 
     [#local configFilePath = formatRelativePath(
                                 getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),


### PR DESCRIPTION
## Description
Ensure the spa state routine can handle the situation where the baseline component has not yet been deployed.

## Motivation and Context
With changes to the way units are grouped, all unit state routines are called as part of component flow. Thus their state routines need to be able to cope with their dependencies not yet being created.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
