### PR TITLE
feat: copy openapi definition file to authorizers

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -685,7 +685,7 @@
                                     "case $\{STACK_OPERATION} in",
                                     "  create|update)",
                                     "info \"Sending API Specification to " + id + "-" + publisherLinkTargetCore.FullName + "\"",
-                                    " cp \"$\{tmpdir}/" + openapiFileName + "\" \"$\{tmpdir}/" + fileName + "\" ",
+                                    " cp \"$\{tmpdir}/" + openapiFileName + "\" \"$\{tmpdir}/" + fileName + "\" || return $?",
                                     "  copy_contentnode_file \"$\{tmpdir}/" + fileName + "\" " +
                                     "\"" +    publisherLinkTargetAttributes.ENGINE + "\" " +
                                     "\"" +    publisherLinkTargetAttributes.REPOSITORY + "\" " +
@@ -868,6 +868,9 @@
         /]
 
         [#-- If using an authoriser, give it a copy of the openapi spec --]
+        [#-- Also include the definition because authorizers can't have --]
+        [#-- scopes but the authorizer relies on them. Thus give it the --]
+        [#-- definition file rather than the extended file              --]
         [#if lambdaAuthorizers?has_content]
             [#-- Copy the config file to a standard filename --]
             [@addToDefaultBashScriptOutput
@@ -876,6 +879,11 @@
                         "referenceFiles",
                         "$\{CONFIG}",
                         "openapi.json"
+                    ) +
+                    getLocalFileScript(
+                        "referenceFiles",
+                        "$\{DEFINITION}",
+                        "openapi-definition.json"
                     )
             /]
             [#list lambdaAuthorizers?values as lambdaAuthorizer]


### PR DESCRIPTION
## Description
Thus copy the definition and the extended versions of the api spec to the authorizer reference area.

Also improve error detection when publishing specs.

## Motivation and Context
The authorizer needs to know the scopes on methods, but the extended spec needs these removed to comply with AWS constraints.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Need to merge https://github.com/hamlet-io/executor-bash/pull/114 before this PR.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
