### PR TITLE
fix: formatting of definition file

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -880,9 +880,16 @@
                         "$\{CONFIG}",
                         "openapi.json"
                     ) +
+                    [
+                        "DEFINITION_FILE=$( get_openapi_definition_filename " +
+                                "\"" + core.Name + "\"" + " " +
+                                "\"" + accountId + "\"" + " " +
+                                "\"" + region + "\"" + " )",
+                        "#"
+                    ] +
                     getLocalFileScript(
                         "referenceFiles",
-                        "$\{DEFINITION}",
+                        "$\{DEFINITION_FILE}",
                         "openapi-definition.json"
                     )
             /]


### PR DESCRIPTION

## Description
Use the utility method that formats the definition filename to copy the definition file for authorizers.


## Motivation and Context
This is to ensure consistency with where it is stored in the cmdb.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
