### PR TITLE
fix(networkacl): use the id instead of existing ref for lookups

### DIFF
--- a/aws/components/bastion/state.ftl
+++ b/aws/components/bastion/state.ftl
@@ -52,14 +52,14 @@
             "Roles" : {
                 "Inbound" : {
                     "networkacl" : {
-                        "SecurityGroups" : getExistingReference(securityGroupToId),
+                        "SecurityGroups" : securityGroupToId,
                         "Description" : core.FullName
                     }
                 },
                 "Outbound" : {
                     "networkacl" : {
                         "Ports": [ "ssh" ],
-                        "SecurityGroups" : getExistingReference(securityGroupToId),
+                        "SecurityGroups" : securityGroupToId,
                         "Description" : core.FullName
                     }
                 }

--- a/aws/components/cache/state.ftl
+++ b/aws/components/cache/state.ftl
@@ -89,14 +89,14 @@
             "Roles" : {
                 "Inbound" : {
                     "networkacl" : {
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 },
                 "Outbound" : {
                     "networkacl" : {
                         "Ports" : [ port ],
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 }

--- a/aws/components/computecluster/state.ftl
+++ b/aws/components/computecluster/state.ftl
@@ -89,14 +89,14 @@
             "Roles" : {
                 "Inbound" : {
                     "networkacl" : {
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 },
                 "Outbound" : {
                     "networkacl" : {
                         "Ports" : [ "ssh" ],
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 }

--- a/aws/components/datapipeline/state.ftl
+++ b/aws/components/datapipeline/state.ftl
@@ -47,14 +47,14 @@
             "Roles" : {
                 "Inbound" : {
                     "networkacl" : {
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 },
                 "Outbound" : {
                     "networkacl" : {
                         "Ports" : [ "ssh" ],
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 }

--- a/aws/components/db/state.ftl
+++ b/aws/components/db/state.ftl
@@ -239,14 +239,14 @@
             "Roles" : {
                 "Inbound" : {
                     "networkacl" : {
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 },
                 "Outbound" : {
                     "networkacl" : {
                         "Ports" : [ port ],
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 }

--- a/aws/components/ec2/state.ftl
+++ b/aws/components/ec2/state.ftl
@@ -72,14 +72,14 @@
             "Roles" : {
                 "Inbound" : {
                     "networkacl" : {
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 },
                 "Outbound" : {
                     "networkacl" : {
                         "Ports" : [ availablePorts ],
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 }

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -734,6 +734,15 @@
                                                 (container.InboundPorts)![],
                                                 UNIQUE_COMBINE_BEHAVIOUR
                                             )]
+                    [#list container.Links as id,link ]
+                        [@createSecurityGroupRulesFromLink
+                            occurrence=subOccurrence
+                            groupId=ecsSecurityGroupId
+                            inboundPorts=container.InboundPorts
+                            linkTarget=link
+                            networkProfile=networkProfile
+                        /]
+                    [/#list]
                 [/#list]
 
                 [@createSecurityGroupRulesFromNetworkProfile

--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -155,14 +155,14 @@
             "Roles" : {
                 "Inbound" : {
                     "networkacl" : {
-                        "SecurityGroups" : getExistingReference(sgGroupId),
+                        "SecurityGroups" : sgGroupId,
                         "Description" : core.FullName
                     }
                 },
                 "Outbound" : {
                     "networkacl" : {
                         "Ports" : [ "ssh" ],
-                        "SecurityGroups" : getExistingReference(sgGroupId),
+                        "SecurityGroups" : sgGroupId,
                         "Description" : core.FullName
                     }
                 }
@@ -300,14 +300,14 @@
                         "LogGroupIds" : [ lgId ]
                     },
                     "networkacl" : {
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 },
                 "Outbound" : {
                     "networkacl" : {
                         "Ports" : [ availablePorts ],
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 }
@@ -471,14 +471,14 @@
                         "LogGroupIds" : [ lgId ]
                     },
                     "networkacl" : {
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 },
                 "Outbound" : {
                     "networkacl" : {
                         "Ports" : [ availablePorts ],
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     },
                     "run" :

--- a/aws/components/efs/state.ftl
+++ b/aws/components/efs/state.ftl
@@ -45,7 +45,7 @@
             "Roles" : {
                 "Inbound" : {
                     "networkacl" : {
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 },
@@ -56,7 +56,7 @@
                     "root" : efsFullPermission(id),
                     "networkacl" : {
                         "Ports" : [ availablePorts ],
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 }

--- a/aws/components/es/state.ftl
+++ b/aws/components/es/state.ftl
@@ -125,7 +125,7 @@
                         solution.VPCAccess,
                         {
                             "Ports" : [ availablePorts ],
-                            "SecurityGroups" : getExistingReference(securityGroupId),
+                            "SecurityGroups" : securityGroupId,
                             "Description" : core.FullName
                         }
                     ),
@@ -135,7 +135,7 @@
                         "networkacl",
                         solution.VPCAccess,
                         {
-                            "SecurityGroups" : getExistingReference(securityGroupId),
+                            "SecurityGroups" : securityGroupId,
                             "Description" : core.FullName
                         }
                     )

--- a/aws/components/filetransfer/state.ftl
+++ b/aws/components/filetransfer/state.ftl
@@ -84,14 +84,14 @@
             "Roles" : {
                 "Inbound" : {
                     "networkacl" : {
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 },
                 "Outbound" : {
                     "networkacl" : {
                         "Ports" : [ availablePorts ],
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 }

--- a/aws/components/lambda/state.ftl
+++ b/aws/components/lambda/state.ftl
@@ -120,7 +120,7 @@
                     "networkacl",
                     solution.VPCAccess,
                     {
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 ),

--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -226,7 +226,7 @@
                     "networkacl",
                     securityGroupRequired,
                     {
-                        "SecurityGroups" : getExistingReference(securityGroupId),
+                        "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }
                 ),
@@ -238,7 +238,7 @@
                     attributeIfTrue(
                         "SecurityGroups",
                         securityGroupRequired
-                        getExistingReference(securityGroupId)
+                        securityGroupId
                     ) +
                     attributeIfTrue(
                         "IPAddressGroups",


### PR DESCRIPTION
## Description
Changes the reference value provided for security groups provided the networkacl role. The security group will now be provided as the resource Id instead of the evaluated output provided by getExistingReference

## Motivation and Context
When linking between two components in the same deployment unit the references returned were of the groupId for an existing deployment. As a result of this the deployment would fail if the group ids changed during a deployment or wouldn't return correctly in a new deployment

## How Has This Been Tested?
Tested locally on a development deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
