### PR TITLE
fix: diagram mapping for ecs

### DIFF
--- a/awsdiagrams/services/ecs/id.ftl
+++ b/awsdiagrams/services/ecs/id.ftl
@@ -3,6 +3,6 @@
 [#-- Service Mapping --]
 [@addDiagramServiceMapping
     provider=AWS_PROVIDER
-    service=AWS_ELASTIC_COMPUTE_SERVICE
+    service=AWS_ELASTIC_CONTAINER_SERVICE
     diagramsClass="diagrams.aws.compute.ElasticContainerService"
 /]


### PR DESCRIPTION
## Description
Minor fix to the diagram service mapping for the ECS component type 

## Motivation and Context
Was set to the EC2 component which meant that ecs component types wern't being mapped to the ecs service diagram class and the ec2 components were using the wrong class 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
