### PR TITLE
fix: add descriptions to service linked roles

### DIFF
--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1840,11 +1840,13 @@
   "ServiceRoles" : {
     "autoscaling" : {
       "Enabled" : true,
-      "ServiceName" : "autoscaling.amazonaws.com"
+      "ServiceName" : "autoscaling.amazonaws.com",
+      "Description" : "Default Service-Linked Role enables access to AWS Services and Resources used or managed by Auto Scaling"
     },
     "ecs" : {
       "Enabled" : true,
-      "ServiceName" : "ecs.amazonaws.com"
+      "ServiceName" : "ecs.amazonaws.com",
+      "Description" : "Role to enable Amazon ECS to manage your cluster."
     },
     "es" : {
       "Enabled" : true,

--- a/aws/masterData.json
+++ b/aws/masterData.json
@@ -2433,11 +2433,13 @@
   "ServiceRoles" : {
     "autoscaling" : {
       "Enabled" : true,
-      "ServiceName" : "autoscaling.amazonaws.com"
+      "ServiceName" : "autoscaling.amazonaws.com",
+      "Description" : "Default Service-Linked Role enables access to AWS Services and Resources used or managed by Auto Scaling"
     },
     "ecs" : {
       "Enabled" : true,
-      "ServiceName" : "ecs.amazonaws.com"
+      "ServiceName" : "ecs.amazonaws.com",
+      "Description" : "Role to enable Amazon ECS to manage your cluster."
     },
     "es" : {
       "Enabled" : true,


### PR DESCRIPTION
## Description
Minor fix to set the description for service linked roles to align with the description assigned to the default service linked roles created by AWS. 

## Motivation and Context
This allows for cloudformation to "create" the service linked roles and to to take over roles which have already been created in an account. This is important as service linked roles in most cases are automatically created by AWS and can't be easily deleted. 

## How Has This Been Tested?
Tested locally and on active deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Depends on https://github.com/hamlet-io/engine/pull/1440

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
