### PR TITLE
feat: add compute provider support to ecs host

### DIFF
--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -26,6 +26,7 @@
     [#local solution = occurrence.Configuration.Solution ]
 
     [#local clusterId = formatResourceId(AWS_ECS_RESOURCE_TYPE, core.Id)]
+    [#local clusterName = core.FullName ]
 
     [#local lgId = formatLogGroupId(core.Id) ]
     [#local lgName = core.FullAbsolutePath ]
@@ -87,24 +88,13 @@
         [/#list]
     [/#if]
 
-    [#local computeProvider = {}]
-    [#if solution.ComputeProvider == "ec2OnDemand" ]
-        [#local computeProvider += {
-                "ecsCapacityProviderOnDemand" : {
-                    "Id" : formatResourceId(AWS_ECS_CAPACIITY_PROVIDER_RESOURCE_TYPE, core.Id, 'OnDemand'),
-                    "Type" : AWS_ECS_CAPACIITY_PROVIDER_RESOURCE_TYPE
-                }
-            }
-        ]
-    [/#if]
-
     [#-- TODO(mfl): Use formatDependentRoleId() for roles --]
     [#assign componentState =
         {
             "Resources" : {
                 "cluster" : {
                     "Id" : clusterId,
-                    "Name" : core.FullName,
+                    "Name" : clusterName,
                     "Type" : AWS_ECS_RESOURCE_TYPE,
                     "Monitored" : true
                 },
@@ -144,11 +134,14 @@
                     "Name" : lgInstanceLogName,
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
                     "IncludeInDeploymentState" : false
+                },
+                "ecsASGCapacityProvider" : {
+                    "Id" : formatResourceId(AWS_ECS_CAPACIITY_PROVIDER_RESOURCE_TYPE, core.Id, "asg" ),
+                    "Type" : AWS_ECS_CAPACIITY_PROVIDER_RESOURCE_TYPE
                 }
             } +
             attributeIfContent("logMetrics", logMetrics) +
-            autoScaling +
-            computeProvider,
+            autoScaling,
             "Attributes" : {
                 "ARN" : getExistingReference(clusterId, ARN_ATTRIBUTE_TYPE)
             },

--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1310,6 +1310,45 @@
       }
     }
   },
+  "ComputeProviders" : {
+    "default" : {
+      "Containers" : {
+        "Default" : {
+          "Provider" : "_autoscalegroup",
+          "Base" : 1
+        }
+      }
+    },
+    "fargate" : {
+      "Containers" : {
+        "Default" : {
+          "Provider" : "aws:fargate",
+          "Base" : 1
+        }
+      }
+    },
+    "fargate-add-spot" : {
+      "Containers" : {
+        "Default" : {
+          "Provider" : "aws:fargate",
+          "Base" : 1
+        },
+        "Additional" : {
+          "spot" : {
+            "Provider" : "aws:fargatespot"
+          }
+        }
+      }
+    },
+    "fargatespot" : {
+      "Containers" : {
+        "Default" : {
+          "Provider" : "aws:fargatespot",
+          "Base" : 1
+        }
+      }
+    }
+  },
   "Product": {
     "cfredirect-v1": {
       "Region": "us-east-1"

--- a/aws/masterData.json
+++ b/aws/masterData.json
@@ -1305,6 +1305,45 @@
       }
     }
   },
+  "ComputeProviders" : {
+    "default" : {
+      "Containers" : {
+        "Default" : {
+          "Provider" : "_autoscalegroup",
+          "Base" : 1
+        }
+      }
+    },
+    "fargate" : {
+      "Containers" : {
+        "Default" : {
+          "Provider" : "aws:fargate",
+          "Base" : 1
+        }
+      }
+    },
+    "fargate-add-spot" : {
+      "Containers" : {
+        "Default" : {
+          "Provider" : "aws:fargate",
+          "Base" : 1
+        },
+        "Additional" : {
+          "spot" : {
+            "Provider" : "aws:fargatespot"
+          }
+        }
+      }
+    },
+    "fargatespot" : {
+      "Containers" : {
+        "Default" : {
+          "Provider" : "aws:fargatespot",
+          "Base" : 1
+        }
+      }
+    }
+  },
   "Product": {
     "cfredirect-v1": {
       "Region": "us-east-1"

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -431,7 +431,11 @@
                     "03ConfigureCluster" : {
                         "command" : "/opt/codeontap/bootstrap/ecs.sh",
                         "env" : {
-                            "ECS_CLUSTER" : getReference(ecsId),
+                            "ECS_CLUSTER" : valueIfContent(
+                                                    getExistingReference(ecsId),
+                                                    getExistingReference(ecsId),
+                                                    getReference(ecsId)
+                                            ),
                             "ECS_LOG_DRIVER" : defaultLogDriver
                         } +
                         attributeIfContent(
@@ -773,6 +777,7 @@
     multiAZ
     tags
     networkResources
+    scaleInProtection=false
     hibernate=false
     loadBalancers=[]
     targetGroups=[]
@@ -857,6 +862,11 @@
                 "TargetGroupARNs",
                 targetGroups,
                 targetGroups
+            ) +
+            attributeIfTrue(
+                "NewInstancesProtectedFromScaleIn",
+                scaleInProtection,
+                true
             )
         tags=tags
         outputs=AWS_EC2_AUTO_SCALE_GROUP_OUTPUT_MAPPINGS


### PR DESCRIPTION
## Description

Adds initial support for compute providers as part of the ecs host in line with https://github.com/hamlet-io/engine/pull/1442 

This initial support only sets the default capacity provider for an ECS host which is used when a capacity provider or launch type have not been explicitly set, which should maintain compatibility with our existing deployments 

By default all ECS clusters will have 3 capacity providers available, FARGATE, FARGATE_SPOT and one based on the EC2 Autoscale group which is provisioned as part of the component. 

The default ComputeProvider uses the EC2 Autoscale group for container placements, this is inline with the standard behaviour we have now. Some extra ComputeProvider profiles have been included ( fargate, fargate-add-spot, fargatespot ) have been added to show different strategies that you might want to use 

Due to some circular dependency issues two template passes are required to complete the full setup. There is an issue where you need to pass the ECS Cluster name to the ASG for registration, but the ECS Cluster needs to know the Capacity Provider details, which need to know the ASG Name. This is being tracked in https://github.com/aws/containers-roadmap/issues/631 which has some details on the issue

## Motivation and Context
The main motivation to implement this in the AWS ecs provider is to be able to take advantage of the FARGATE_SPOT offering which allows for significant cost savings on services which can handle interruptions 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Depends on https://github.com/hamlet-io/engine/pull/1442

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
