### PR TITLE
refactor: align setup macros with layer data changes

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -238,8 +238,6 @@
                         "Ports" : [ "ssh" ],
                         "IPAddressGroups" :
                             sshEnabled?then(
-                                (segmentObject.SSH.IPAddressGroups)!
-                                (segmentObject.IPAddressGroups)!
                                 (segmentObject.Bastion.IPAddressGroups)![],
                                 []
                             ),

--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -238,7 +238,7 @@
                         "Ports" : [ "ssh" ],
                         "IPAddressGroups" :
                             sshEnabled?then(
-                                (segmentObject.Bastion.IPAddressGroups)![],
+                                (segmentObject.Bastion.IPAddressGroups)!(segmentObject.IPAddressGroups)![],
                                 []
                             ),
                         "Description" : "Bastion Access Groups"

--- a/aws/components/network/state.ftl
+++ b/aws/components/network/state.ftl
@@ -29,9 +29,9 @@
         solution.Logging.EnableFlowLogs
     )]
 
-    [#local networkCIDR = (network.CIDR)?has_content?then(
-                    network.CIDR.Address + "/" + network.CIDR.Mask,
-                    solution.Address.CIDR )]
+    [#local networkCIDR = isPresent(network.CIDR)?then(
+        network.CIDR.Address + "/" + network.CIDR.Mask,
+        solution.Address.CIDR )]
 
     [#local subnetCIDRMask = getSubnetMaskFromSizes(
                                 networkCIDR,


### PR DESCRIPTION
## Description
Update setup macro lookups which use layer data to support configuration data provided by composite object building added in https://github.com/hamlet-io/engine/pull/1448 

## Motivation and Context
Layers are now defined using the composite object process for documentation and validation

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Requires:  https://github.com/hamlet-io/engine/pull/1448 

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
