### PR TITLE
Lambda external url

### DIFF
--- a/aws/modules/cloudwatchslack/module.ftl
+++ b/aws/modules/cloudwatchslack/module.ftl
@@ -1,0 +1,183 @@
+[#ftl]
+
+[@addModule
+    name="alarmslack"
+    description="Sends slack notifications based on cloudwatch alarms"
+    provider=AWS_PROVIDER
+    properties=[
+        {
+            "Names" : "slackChannel",
+            "Type" : STRING_TYPE,
+            "Description" : "The slack channel to send alerts to",
+            "Mandatory" : true
+        },
+        {
+            "Names" : "webHookUrl",
+            "Type" : STRING_TYPE,
+            "Description" : "The slack incoming webhook URL to use - Encryption is recommended",
+            "Mandatory" : true
+        },
+        {
+            "Names" : "alertSeverity",
+            "Type" : STRING_TYPE,
+            "Description" : "The lowest severity alerts to include in notifications",
+            "Default" : "info"
+        },
+        {
+            "Names" : "alertProfile",
+            "Type" : STRING_TYPE,
+            "Description" : "The alert profile id to use for enabling notifications",
+            "Default" : "default"
+        }
+        {
+            "Names" : "kmsPrefix",
+            "Type" : STRING_TYPE,
+            "Description" : "The KMS prefix used for encrypted values",
+            "Default" : "base64:"
+        },
+        {
+            "Names" : "lambdaSourceUrl",
+            "Type" : STRING_TYPE,
+            "Description" : "A URL to the lambda zip package for sending alerts",
+            "Default" : "https://github.com/hamlet-io/lambda-cloudwatch-slack/releases/download/v1.1.0/cloudwatch-slack.zip"
+        },
+        {
+            "Names" : "lambdaSourceHash",
+            "Type" : STRING_TYPE,
+            "Description" : "A sha1 hash of the lambda image to ensure its the right one",
+            "Default" : "8f194db4f6ed2b826387112df144f188451ba6db"
+        }
+        {
+            "Names" : "namePrefix",
+            "Type" : STRING_TYPE,
+            "Description" : "A prefix appended to component names and deployment units to ensure uniquness",
+            "Default" : "alarmslack"
+        },
+        {
+            "Names" : "tier",
+            "Type" : STRING_TYPE,
+            "Description" : "The tier to use to host the components",
+            "Default" : "mgmt"
+        }
+    ]
+/]
+
+[#macro aws_module_alarmslack
+            slackChannel
+            webHookUrl
+            kmsPrefix
+            lambdaSourceUrl
+            lambdaSourceHash
+            namePrefix
+            tier
+            alertSeverity
+            alertProfile ]
+
+    [#local topicName = formatName(namePrefix, "topic" )]
+    [#local lambdaName = formatName(namePrefix, "lambda" )]
+
+    [#local product = getActiveLayer(PRODUCT_LAYER_TYPE) ]
+    [#local environment = getActiveLayer(ENVIRONMENT_LAYER_TYPE)]
+    [#local segment = getActiveLayer(SEGMENT_LAYER_TYPE)]
+
+    [#local namespace = formatName(product["Name"], environment["Name"], segment["Name"])]
+    [#local lambdaSettingNamespace = formatName(namespace, lambdaName)]
+
+    [@loadModule
+        settingSets=[
+            {
+                "Type" : "Settings",
+                "Scope" : "Products",
+                "Namespace" : lambdaSettingNamespace,
+                "Settings" : {
+                    "SLACK_HOOK_URL" : webHookUrl,
+                    "KMS_PREFIX" : kmsPrefix,
+                    "SLACK_CHANNEL" : slackChannel,
+                    "ENVIRONMENT" : namespace
+                }
+            }
+        ]
+        blueprint={
+            "Tiers" : {
+                tier : {
+                    "Components" : {
+                        topicName : {
+                            "topic" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : [ topicName ]
+                                    }
+                                },
+                                "Subscriptions" : {
+                                    "slack" : {
+                                        "Links" : {
+                                            "lambda" : {
+                                                "Tier" : tier,
+                                                "Component" : lambdaName,
+                                                "Function" : "send"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        lambdaName : {
+                            "Lambda" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : [ lambdaName ]
+                                    }
+                                },
+                                "Functions" : {
+                                    "send" : {
+                                        "Handler" : "cloudwatch-slack/lambda_function.lambda_handler",
+                                        "RunTime" : "python3.6",
+                                        "MemorySize" : 128,
+                                        "Timeout" : 15,
+                                        "VPCAccess" : false,
+                                        "PredefineLogGroup" : true
+                                    }
+                                },
+                                "Links" : {
+                                    "alerts" : {
+                                        "Tier" : tier,
+                                        "Component" : topicName,
+                                        "Direction" : "inbound",
+                                        "Role" : "invoke"
+                                    }
+                                },
+                                "Image" : {
+                                    "Source" : "url",
+                                    "UrlSource" : {
+                                        "Url" : lambdaSourceUrl,
+                                        "ImageHash" : lambdaSourceHash
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "AlertRules" : {
+                "SlackNotify" : {
+                    "Severity" : alertSeverity,
+                    "Destinations" : {
+                        "Links" : {
+                            "alarm" : {
+                                "Tier" : tier,
+                                "Component" : topicName,
+                                "Instance" : "",
+                                "Version" : ""
+                            }
+                        }
+                    }
+                }
+            },
+            "AlertProfiles" : {
+                alertProfile : {
+                    "Rules" : ["SlackNotify" ]
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Description
AWS implementation of https://github.com/hamlet-io/engine/pull/1456 

Also includes a reference module `alarmslack` which uses this feature to provide a shared cloudwatch alarm -> slack notification service. This setup has been used across a number of products and can now be loaded as a module

Also includes a reference module 
## Motivation and Context
Allows for images built and hosted from external services to be included as part of the hamlet deployment process

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Requires: https://github.com/hamlet-io/engine/pull/1456 
- [X] Requires: https://github.com/hamlet-io/executor-bash/pull/126
- [X] Requires: https://github.com/hamlet-io/engine-plugin-aws/pull/160

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
