### PR TITLE
fix(apigateway): fix new deployments without stage

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -541,7 +541,7 @@
                     } +
                     attributeIfContent("Stage", value["basepathmapping"].Stage)
                 outputs={}
-                dependencies=value["domain"].Id
+                dependencies=[ value["domain"].Id, stageId ]
             /]
         [/#list]
 


### PR DESCRIPTION
## Description
Makes the base path mapping deployment in an apigateway depend on the base stage deployment

## Motivation and Context
When deploying a complex stage which includes access logging setups and extra required resources the basepath mapping will be deployed before the stage is deployed. This causes an error during the deployment. 

## How Has This Been Tested?
Tested on local template generation

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
