### PR TITLE
feat: WAF logs lifecycle rule

### DIFF
--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1024,6 +1024,11 @@
                     "Prefix": "DOCKERLogs",
                     "Expiration": "_operations",
                     "Offline": "_operations"
+                  },
+                  "waf": {
+                    "Prefix": "WAF",
+                    "Expiration": "_operations",
+                    "Offline": "_operations"
                   }
                 },
                 "Links": {

--- a/aws/masterData.json
+++ b/aws/masterData.json
@@ -1020,6 +1020,11 @@
                     "Prefix": "DOCKERLogs",
                     "Expiration": "_operations",
                     "Offline": "_operations"
+                  },
+                  "waf": {
+                    "Prefix": "WAF",
+                    "Expiration": "_operations",
+                    "Offline": "_operations"
                   }
                 },
                 "Links": {


### PR DESCRIPTION

## Description
Add a lifecycle rule for WAF logs in line with other logs in the operations bucket.

## Motivation and Context
By default, WAF logs are now stored in the ops bucket so they need to be lifecycled like other operational logs.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
