### PR TITLE
feat: private bastion

### DIFF
--- a/aws/modules/privatebastion/module.ftl
+++ b/aws/modules/privatebastion/module.ftl
@@ -1,0 +1,91 @@
+[#ftl]
+
+[@addModule
+    name="privatebastion"
+    description="Bastion access via SSM only"
+    provider=AWS_PROVIDER
+    properties=[
+        {
+            "Names" : "tier",
+            "Type" : STRING_TYPE,
+            "Description" : "The tier to use to host the private bastion",
+            "Default" : "msg"
+        },
+        {
+            "Names" : "component",
+            "Type" : STRING_TYPE,
+            "Description" : "The component to use to host the private bastion",
+            "Default" : "ssh"
+        },
+        {
+            "Names" : "deploymentUnit",
+            "Type" : STRING_TYPE,
+            "Description" : "The deployment unit for the private bastion",
+            "Default" : "ssh"
+        },
+        {
+            "Names" : "multiAZ",
+            "Type" : BOOLEAN_TYPE,
+            "Description" : "Multi-AZ support on the private bastion",
+            "Default" : true
+        }
+    ]
+/]
+
+[#macro aws_module_privatebastion
+            tier
+            component
+            deploymentUnit
+            multiAZ ]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                tier : {
+                    "Components" : {
+                        component: {
+                            "DeploymentUnits": [
+                                deploymentUnit
+                            ],
+                            "MultiAZ": multiAZ,
+                            "bastion": {
+                                "AutoScaling": {
+                                    "DetailedMetrics": false,
+                                    "ActivityCooldown": 180,
+                                    "MinUpdateInstances": 0,
+                                    "AlwaysReplaceOnUpdate": false
+                                },
+                                "Permissions": {
+                                    "Decrypt": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "mgmt" : {
+                    "Components" : {
+                        "ssh": {
+                            "Enabled": false
+                        }
+                    }
+                }
+            },
+            "NetworkProfiles": {
+                "default": {
+                    "BaseSecurityGroup": {
+                        "Links": {
+                            "sshBastion": {
+                                "Tier": tier,
+                                "Component": component,
+                                "Instance": "",
+                                "Version": "",
+                                "Direction": "inbound",
+                                "Role": "networkacl"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Description
Create a bastion that is only accessible via SSM.

## Motivation and Context
If no possibility of access from outside the vpc is desired, this module disables the bastion that is included in the masterdata and replaces it with a private bastion. The tier specified needs to be private.

## How Has This Been Tested?
Local deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
