### PR TITLE
feat: patching via init script

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -77,9 +77,18 @@
                 "DesiredCount" : sshActive?then(1,0)
     }]
 
+    [#local osPatching = mergeObjects(solution.OSPatching, environmentObject.OSPatching )]
+
     [#local configSets =
             getInitConfigDirectories() +
-            getInitConfigBootstrap(occurrence, operationsBucket, dataBucket)]
+            getInitConfigBootstrap(occurrence, operationsBucket, dataBucket) +
+            osPatching.Enabled?then(
+                getInitConfigOSPatching(
+                    osPatching.Schedule,
+                    osPatching.SecurityOnly
+                ),
+                {}
+            )]
 
     [#local fragment = getOccurrenceFragmentBase(occurrence) ]
 

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -91,9 +91,17 @@
         [/#if]
     [/#list]
 
+    [#local osPatching = mergeObjects(solution.OSPatching, environmentObject.OSPatching )]
     [#local configSets =
             getInitConfigDirectories() +
-            getInitConfigBootstrap(occurrence, operationsBucket, dataBucket) ]
+            getInitConfigBootstrap(occurrence, operationsBucket, dataBucket) +
+            osPatching.Enabled?then(
+                getInitConfigOSPatching(
+                    osPatching.Schedule,
+                    osPatching.SecurityOnly
+                ),
+                {}
+            ) ]
 
     [#local scriptsPath =
             formatRelativePath(

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -63,10 +63,19 @@
     [#local environmentVariables = {}]
 
     [#local configSetName = occurrence.Core.Type]
+
+    [#local osPatching = mergeObjects(solution.OSPatching, environmentObject.OSPatching )]
     [#local configSets =
             getInitConfigDirectories() +
             getInitConfigBootstrap(occurrence, operationsBucket, dataBucket) +
-            getInitConfigPuppet() ]
+            getInitConfigPuppet() +
+            osPatching.Enabled?then(
+                getInitConfigOSPatching(
+                    osPatching.Schedule,
+                    osPatching.SecurityOnly
+                ),
+                {}
+            ) ]
 
     [#local efsMountPoints = {}]
 

--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1461,6 +1461,10 @@
     }
   },
   "LogFiles": {
+    "/var/log/update.log": {
+      "FilePath": "/var/log/update.log",
+      "TimeFormat": "%b %d %H:%M:%S"
+    },
     "/var/log/cfn-init.log": {
       "FilePath": "/var/log/cfn-init.log",
       "TimeFormat": "%b %d %H:%M:%S"
@@ -1504,6 +1508,7 @@
     },
     "aws-system": {
       "LogFiles": [
+        "/var/log/update.log",
         "/var/log/cfn-init.log",
         "/var/log/cfn-init-cmd.log",
         "/var/log/cloud-init.log",

--- a/aws/masterData.json
+++ b/aws/masterData.json
@@ -1456,6 +1456,10 @@
     }
   },
   "LogFiles": {
+    "/var/log/update.log": {
+      "FilePath": "/var/log/update.log",
+      "TimeFormat": "%b %d %H:%M:%S"
+    },
     "/var/log/cfn-init.log": {
       "FilePath": "/var/log/cfn-init.log",
       "TimeFormat": "%b %d %H:%M:%S"
@@ -1499,6 +1503,7 @@
     },
     "aws-system": {
       "LogFiles": [
+        "/var/log/update.log",
         "/var/log/cfn-init.log",
         "/var/log/cfn-init-cmd.log",
         "/var/log/cloud-init.log",


### PR DESCRIPTION
## Description
aws implementation of  https://github.com/hamlet-io/engine/pull/1470 
- Supports configuration of patching schedule and updates in solution 
- Moves the patching process to an init script which allows for failing the instance init process if the patching fails
- Includes update log in cloudwatch log forwarding

## Motivation and Context
Provides user control to the patching process and also provides better error handling when there are issues with patching. I.e. fail the instance startup when patching can't be applied 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Requires https://github.com/hamlet-io/engine/pull/1470 

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
