### PR TITLE
feat: autoscale replacement updates

### DIFF
--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -882,7 +882,15 @@
                 "AutoScalingRollingUpdate" : {
                     "WaitOnResourceSignals" : autoScalingConfig.WaitForSignal,
                     "MinInstancesInService" : autoscalingMinUpdateInstances,
-                    "PauseTime" : "PT" + autoScalingConfig.UpdatePauseTime
+                    "MinSuccessfulInstancesPercent" : autoScalingConfig.MinSuccessInstances,
+                    "PauseTime" : "PT" + autoScalingConfig.UpdatePauseTime,
+                    "SuspendProcesses" : [
+                        "HealthCheck",
+                        "ReplaceUnhealthy",
+                        "AZRebalance",
+                        "AlarmNotification",
+                        "ScheduledActions"
+                    ]
                 }
             }
         )


### PR DESCRIPTION
## Description
Implements https://github.com/hamlet-io/engine/pull/1471  and also adds process suspension during cloud formation updates 

## Motivation and Context
When cloudformation applies updates to an autoscaling group it will scale the cluster to meet the configuration parameters in the template ( min, max desired ) If other scaling events are triggered during the update the cfn stack becomes stuck in the UPDATE_IN_PROGRESS stage until it times out ( around 1-2 hours ). This is really difficult to balance as the roll back takes the same amount of time 

Suspending services which can cause instance count changes during cloudformation updates is the recommended approach to fixing this 
https://aws.amazon.com/premiumsupport/knowledge-center/auto-scaling-group-rolling-updates/ 


## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
