### PR TITLE
module: consolidatelogs lambda fixes

### DIFF
--- a/aws/modules/consolidatelogs/module.ftl
+++ b/aws/modules/consolidatelogs/module.ftl
@@ -2,7 +2,7 @@
 
 [@addModule
     name="consolidatelogs"
-    description="Solution-wide consolidation of logs, intended for consumption by ElasticSearch."
+    description="Solution-wide consolidation of logs into ops data bucket"
     provider=AWS_PROVIDER
     properties=[
         {

--- a/aws/modules/consolidatelogs/module.ftl
+++ b/aws/modules/consolidatelogs/module.ftl
@@ -110,17 +110,20 @@
                                 "Functions": {
                                     "processor": {
                                         "RunTime": "python3.6",
-                                        "MemorySize": 128,
-                                        "Timeout": 30,
+                                        "MemorySize": 256,
+                                        "Timeout": 300,
                                         "Handler": "src/run.lambda_handler",
+                                        "PredefineLogGroup" : true,
+                                        "Profiles" : {
+                                            "Logging" : "nofoward"
+                                        },
                                         "Links": {
                                             "feed" : {
                                                 "Tier" : tier,
                                                 "Component" : datafeedName,
                                                 "Instance" : "",
                                                 "Version" : "",
-                                                "Role" : "logwatch",
-                                                "Direction": "inbound"
+                                                "Role" : "produce"
                                             }
                                         }
                                     }
@@ -149,6 +152,10 @@
                                 }
                             }
                         }
+                    }
+                },
+                "nofoward" : {
+                    "ForwardingRules" : {
                     }
                 }
             },
@@ -183,8 +190,8 @@
                             },
                             "lb" : {
                                 "Logs" : true,
-                                "WAF" : { 
-                                    "Logging" : { 
+                                "WAF" : {
+                                    "Logging" : {
                                          "Enabled" : true
                                      }
                                  }
@@ -203,5 +210,5 @@
     [#-- TODO(rossmurr4y): feature: add test case to the provider: mocked apigw exists and logs to a firehose --]
     [#-- TODO(rossmurr4y): feature: add test case to the provider: mocked LB exists and has loadbalancerattributes enabling logs --]
     [#-- TODO(rossmurr4y): feature: add test profile to module --]
-    
+
 [/#macro]

--- a/aws/modules/consolidatelogs/module.ftl
+++ b/aws/modules/consolidatelogs/module.ftl
@@ -115,7 +115,7 @@
                                         "Handler": "src/run.lambda_handler",
                                         "PredefineLogGroup" : true,
                                         "Profiles" : {
-                                            "Logging" : "nofoward"
+                                            "Logging" : "noforward"
                                         },
                                         "Links": {
                                             "feed" : {
@@ -154,7 +154,7 @@
                         }
                     }
                 },
-                "nofoward" : {
+                "noforward" : {
                     "ForwardingRules" : {
                     }
                 }


### PR DESCRIPTION
## Description
Some minor fixes to the consolidate logs module 
- Update permissions required by lambda to refeed the kinesis firehose 
- Extend timeout and memory allocation on lambda to allow for extended processing 
- Predefine lambda log processor cloudwatch log group and set a no foward profile on the lambda to avoid infinite loops  
- Update description 

## Motivation and Context
Fixes from testing deployment 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
