### PR TITLE
fix(consolidatelogs): disable log fwd for datafeed

### DIFF
--- a/aws/components/s3/state.ftl
+++ b/aws/components/s3/state.ftl
@@ -81,7 +81,7 @@
                     "consume" : s3ConsumePermission(id) + s3ReadEncryptionPolicy,
                     "replicadestination" : s3ReplicaDestinationPermission(id) + s3AllEncryptionPolicy,
                     "replicasource" : {},
-                    "datafeed" : s3KinesesStreamPermission(id)
+                    "datafeed" : s3KinesesStreamPermission(id) + s3AllEncryptionPolicy
             }
             }
         }

--- a/aws/modules/consolidatelogs/module.ftl
+++ b/aws/modules/consolidatelogs/module.ftl
@@ -77,6 +77,9 @@
                                         "LogFilter": "all-logs"
                                     }
                                 },
+                                "Profiles" : {
+                                    "Logging" : "noforward"
+                                },
                                 "Bucket" : {
                                     "Prefix" : "CWLogs/Logs/",
                                     "ErrorPrefix" : "CWLogs/Errors/"

--- a/aws/modules/consolidatelogs/module.ftl
+++ b/aws/modules/consolidatelogs/module.ftl
@@ -62,7 +62,6 @@
                                         "DeploymentUnits": [ datafeedName ]
                                     }
                                 },
-                                "Encrypted": true,
                                 "Destination": {
                                     "Link": {
                                         "Tier": "mgmt",


### PR DESCRIPTION
## Description
- Disable log forwarding for the datafeed component
- Determine s3 at rest encryption for a datafeed destination based on the destinations encryption configuration
- Support KMS lookup from baseline data to kms key - This allows for passing the appropriate policy to the data feed 


## Motivation and Context
- Infinite loop prevention 

With our current role implementation the permissions are supplied by the linked resource, as a result of this enabling encryption on the datafeed doesn't necessarily provide the appropriate permissions required to perform encryption on the s3 destination. So instead we need to check the based component for its s3 config 

The KMS lookup is a bit of a weird lookup to allow for the "sibling" components to perform lookups between each other. It relies on the fact that the parent occurrence Id extensions are a sub set of the subcomponents. Based on this both components linking to each other share the same parent so we can share there id's 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
