### PR TITLE
refactor(consolidatelogs): remove logwatcher support

### DIFF
--- a/aws/modules/consolidatelogs/module.ftl
+++ b/aws/modules/consolidatelogs/module.ftl
@@ -45,7 +45,6 @@
     lambdaSourceHash
     tier]
 
-    [@debug message="Entering Module: consolidate-logs" context=layerActiveData enabled=false /]
 
     [#local lambdaName = formatName(namePrefix + "cwlogslambda")]
     [#local datafeedName = formatName(namePrefix + "cwlogsdatafeed")]
@@ -69,11 +68,6 @@
                                         "DataBucket": "opsdata",
                                         "Instance": "",
                                         "Version": ""
-                                    }
-                                },
-                                "LogWatchers": {
-                                    "app-all": {
-                                        "LogFilter": "all-logs"
                                     }
                                 },
                                 "Profiles" : {


### PR DESCRIPTION
## Description
Removes the logwatcher support from the consolidatelogs module

## Motivation and Context
We currently have two supported methods for integrating logs with the data feed component 
- Pull Approach - On the data feed you can use the LogWatchers configuration to link to components you want to collect logs from. In this approach the datafeed component needs a link to all components that it wants logs for 
- Push Approach - Using a LogProfile each component creates the log subscription as part of logging components deployment. In this approach you just need to create a logprofile and use this profile for the components which need to log to this datafeed 

From a module perspective the push approach is far more maintainable than the pull approach. 

## How Has This Been Tested?
TEsted locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
