### PR TITLE
fix: bastion eip subset

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -41,15 +41,13 @@
             [#break]
     [/#switch]
 
-    [#if deploymentSubsetRequired("bastion", true) ]
+    [#if deploymentSubsetRequired("eip", false) || deploymentSubsetRequired("bastion", true) ]
         [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
         [#local networkLink = occurrenceNetwork.Link!{} ]
         [#local networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
 
         [#if ! networkLinkTarget?has_content ]
-            [#if deploymentSubsetRequired(BASTION_COMPONENT_TYPE, false)]
-                [@fatal message="Network could not be found" context=networkLink /]
-            [/#if]
+            [@fatal message="Network could not be found" context=networkLink /]
             [#return]
         [/#if]
 


### PR DESCRIPTION
## Description
Ensure the eip is created as part of an eip subset.

## Motivation and Context
The logic to detect a public network (and hence the need for an eip), did not take into account an eip subset pass. It now explicitly checks for this.

Fixes #179.

## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
