### PR TITLE
fix(baseline): use s3 encryption for opsdata

### DIFF
--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1009,6 +1009,9 @@
             "DataBuckets": {
               "opsdata": {
                 "Role": "operations",
+                "Encryption" : {
+                  "EncryptionSource" : "LocalService"
+                },
                 "Lifecycles": {
                   "awslogs": {
                     "Prefix": "AWSLogs",

--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1010,6 +1010,7 @@
               "opsdata": {
                 "Role": "operations",
                 "Encryption" : {
+                  "Enabled" : false,
                   "EncryptionSource" : "LocalService"
                 },
                 "Lifecycles": {

--- a/aws/masterData.json
+++ b/aws/masterData.json
@@ -1005,6 +1005,9 @@
             "DataBuckets": {
               "opsdata": {
                 "Role": "operations",
+                "Encryption" : {
+                  "EncryptionSource" : "LocalService"
+                },
                 "Lifecycles": {
                   "awslogs": {
                     "Prefix": "AWSLogs",

--- a/aws/masterData.json
+++ b/aws/masterData.json
@@ -1006,6 +1006,7 @@
               "opsdata": {
                 "Role": "operations",
                 "Encryption" : {
+                  "Enabled" : false,
                   "EncryptionSource" : "LocalService"
                 },
                 "Lifecycles": {


### PR DESCRIPTION
## Description
Set the default encryption service for the opsdata bucket to use the S3 SSE encryption service instead of the KMS - CMK method 

## Motivation and Context
The ops data bucket is our logging destination for Load balancer logs which do not support the KMS-CMK encryption method for bucket encryption. They only support the S3 SSE method. Each object can define its own encryption process and if no default method is set load balancers still encrypt data using S3 SSE. This is a known issue with AWS and no know fix 


## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
