### PR TITLE
feat(s3): bucket replication to ext services

### DIFF
--- a/aws/services/s3/policy.ftl
+++ b/aws/services/s3/policy.ftl
@@ -5,10 +5,9 @@
         [
             getPolicyStatement(
                 actions,
-                "arn:aws:s3:::" +
-                    (getExistingReference(bucket)?has_content)?then(getExistingReference(bucket),bucket) +
+                    ((getExistingReference(bucket)?has_content)?then(getExistingReference(bucket),bucket) +
                     key?has_content?then("/" + key, "") +
-                    object?has_content?then("/" + object, ""),
+                    object?has_content?then("/" + object, ""))?ensure_starts_with("arn:aws:s3:::"),
                 principals,
                 conditions)
         ]
@@ -30,8 +29,7 @@
         [
             getPolicyStatement(
                 actions,
-                "arn:aws:s3:::" +
-                    (getExistingReference(bucket)?has_content)?then(getExistingReference(bucket),bucket),
+                    ((getExistingReference(bucket)?has_content)?then(getExistingReference(bucket),bucket))?ensure_starts_with("arn:aws:s3:::"),
                 principals,
                 conditions +
                     s3PrefixCondition
@@ -205,12 +203,9 @@
 
 [#function s3ReplicaSourcePermission bucket prefix="" object="*"]
     [#return
-
         getS3Statement(
             [
-                "s3:GetObjectVersion",
                 "s3:GetObjectVersionAcl",
-                "s3:GetObjectVersionTagging",
                 "s3:GetObjectVersionForReplication"
             ],
             bucket,
@@ -238,7 +233,9 @@
             [
                 "s3:ReplicateObject",
                 "s3:ReplicateDelete",
-                "s3:ReplicateTags"
+                "s3:ObjectOwnerOverrideToBucketOwner",
+                "s3:ReplicateTags",
+                "s3:GetObjectVersionTagging"
             ],
             bucket,
             prefix,
@@ -258,7 +255,7 @@
             bucket,
             prefix,
             object
-        ) + 
+        ) +
         getS3BucketStatement(
             [
                 "s3:ListBucket",
@@ -267,5 +264,5 @@
             ],
             bucket
         )
-    ]   
+    ]
 [/#function]

--- a/awstest/modules/s3/module.ftl
+++ b/awstest/modules/s3/module.ftl
@@ -70,6 +70,81 @@
                                     }
                                 }
                             }
+                        },
+                        "s3replicasrc" : {
+                            "s3" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-s3-replication"
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Testing" : [ "s3replica" ]
+                                },
+                                "Replication" : {
+                                    "Enabled" : true
+                                },
+                                "Links" : {
+                                    "s3replicadst" : {
+                                        "Tier" : "app",
+                                        "Component" : "s3replicadst",
+                                        "Role" : "replicadestination"
+                                    }
+                                }
+                            }
+                        },
+                        "s3replicadst" : {
+                            "s3" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-s3-replication"
+                                    }
+                                }
+                            }
+                        },
+                        "s3replicasextrc" : {
+                            "s3" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-s3-replication-external"
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Testing" : [ "s3replicaext" ]
+                                },
+                                "Replication" : {
+                                    "Enabled" : true
+                                },
+                                "Links" : {
+                                    "s3replicaext" : {
+                                        "Tier" : "app",
+                                        "Component" : "s3replicaext",
+                                        "Role" : "replicadestination"
+                                    }
+                                }
+                            }
+                        },
+                        "s3replicaext" : {
+                            "externalservice" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-s3-replication-external"
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Placement" : "external"
+                                },
+                                "Properties" : {
+                                    "bucketArn" : {
+                                        "Key" : "ARN",
+                                        "Value" : "arn:aws:s3:::external-replication-destination"
+                                    },
+                                    "bucketAccount" : {
+                                        "Key" : "ACCOUNT_ID",
+                                        "Value" : "0987654321"
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -83,6 +158,16 @@
                 "s3notify" : {
                     "s3" : {
                         "TestCases" : [ "s3notify" ]
+                    }
+                },
+                "s3replica" : {
+                    "s3" : {
+                        "TestCases" : [ "s3replica" ]
+                    }
+                },
+                "s3replicaext" : {
+                    "s3" : {
+                        "TestCases" : [ "s3replicaext" ]
                     }
                 }
             },
@@ -140,6 +225,76 @@
                                 "S3NotificationsCreateEvent" : {
                                     "Path"  : "Resources.s3XappXs3notify.Properties.NotificationConfiguration.QueueConfigurations[0].Queue",
                                     "Value" : "arn:aws:iam::123456789012:mock/sqsXappXs3notifyqueueXarn"
+                                }
+                            }
+                        }
+                    }
+                },
+                "s3replica" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "s3BucketSource" : {
+                                    "Name" : "s3XappXs3replicasrc",
+                                    "Type" : "AWS::S3::Bucket"
+                                },
+                                "s3BucketDestination" : {
+                                    "Name" : "s3XappXs3replicadst",
+                                    "Type" : "AWS::S3::Bucket"
+                                }
+                            },
+                            "Output" : [
+                                "s3XappXs3replicasrc",
+                                "s3XappXs3replicasrcXname",
+                                "s3XappXs3replicasrcXarn",
+                                "s3XappXs3replicasrcXregion",
+                                "s3XappXs3replicadst",
+                                "s3XappXs3replicadstXname",
+                                "s3XappXs3replicadstXarn",
+                                "s3XappXs3replicadstXregion"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "S3NotificationsCreateEvent" : {
+                                    "Path"  : "Resources.s3XappXs3replicasrc.Properties.ReplicationConfiguration.Rules[0].Destination.Bucket",
+                                    "Value" : "arn:aws:iam::123456789012:mock/s3XappXs3replicadstXarn"
+                                }
+                            }
+                        }
+                    }
+                },
+                "s3replicaext" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "s3BucketSource" : {
+                                    "Name" : "s3XappXs3replicasextrc",
+                                    "Type" : "AWS::S3::Bucket"
+                                }
+                            },
+                            "Output" : [
+                                "s3XappXs3replicasextrc",
+                                "s3XappXs3replicasextrcXname",
+                                "s3XappXs3replicasextrcXarn",
+                                "s3XappXs3replicasextrcXregion"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "ReplicationRuleDestination" : {
+                                    "Path"  : "Resources.s3XappXs3replicasextrc.Properties.ReplicationConfiguration.Rules[0].Destination.Bucket",
+                                    "Value" : "arn:aws:s3:::external-replication-destination"
+                                },
+                                "ReplicationRuleDestinationTranslation" : {
+                                    "Path"  : "Resources.s3XappXs3replicasextrc.Properties.ReplicationConfiguration.Rules[0].Destination.AccessControlTranslation.Owner",
+                                    "Value" : "Destination"
+                                },
+                                "ReplicationRuleDestinationOwner" : {
+                                    "Path"  : "Resources.s3XappXs3replicasextrc.Properties.ReplicationConfiguration.Rules[0].Destination.Account",
+                                    "Value" : "0987654321"
                                 }
                             }
                         }


### PR DESCRIPTION
## Description
- Adds support for bucket replication to external services, including buckets outside of the account 
- Test cases for bucket replication
- Refactor on S3 policy generation to handle bucket details provided as ARN's 


## Motivation and Context
External bucket replication is a common pattern for log consolidation and backups. This allows for a bucket to be defined as a bucket replication destination which isn't part of the hamlet deployment and isn't part of the deployment AWS account 


## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
