### PR TITLE
fix: set nat gateway priority for mgmt contract

### DIFF
--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1002,10 +1002,8 @@
           "Enabled": false
         },
         "baseline": {
-          "DeploymentUnits": [
-            "baseline"
-          ],
           "baseline": {
+            "deployment:Unit" : "baseline",
             "DataBuckets": {
               "opsdata": {
                 "Role": "operations",
@@ -1065,11 +1063,9 @@
           }
         },
         "ssh": {
-          "DeploymentUnits": [
-            "ssh"
-          ],
           "MultiAZ": true,
           "bastion": {
+            "deployment:Unit" : "ssh",
             "AutoScaling": {
               "DetailedMetrics": false,
               "ActivityCooldown": 180,
@@ -1079,11 +1075,9 @@
           }
         },
         "vpc": {
-          "DeploymentUnits": [
-            "vpc"
-          ],
           "MultiAZ": true,
           "network": {
+            "deployment:Unit" : "vpc",
             "RouteTables": {
               "internal": {},
               "external": {
@@ -1131,10 +1125,8 @@
           }
         },
         "igw": {
-          "DeploymentUnits": [
-            "igw"
-          ],
           "gateway": {
+            "deployment:Unit" : "igw",
             "Engine": "igw",
             "Destinations": {
               "default": {
@@ -1153,10 +1145,9 @@
           }
         },
         "nat": {
-          "DeploymentUnits": [
-            "nat"
-          ],
           "gateway": {
+            "deployment:Unit" : "nat",
+            "deployment:Priority" : 75,
             "Engine": "natgw",
             "Destinations": {
               "default": {
@@ -1175,10 +1166,8 @@
           }
         },
         "vpcendpoint": {
-          "DeploymentUnits": [
-            "vpcendpoint"
-          ],
           "gateway": {
+            "deployment:Unit" : "vpcendpoint",
             "Engine": "privateservice",
             "DestinationPorts" : [ "http", "https" ],
             "Destinations": {
@@ -1217,9 +1206,7 @@
               "default": {
                 "Versions": {
                   "v1": {
-                    "DeploymentUnits": [
-                      "cfredirect-v1"
-                    ],
+                    "deployment:Unit" : "cfredirect-v1",
                     "Enabled": false,
                     "Fragment": "_cfredirect-v1"
                   }


### PR DESCRIPTION
## Description
Minor fix and refactor for the components in the aws master data 
- Updates the NAT Gateway deployment priority to ensure its deployed after the igw 
- Uses the new deployment:Unit formatting to start the migration to the new naming format

## Motivation and Context
When using management contract deployments the unit ordering is defined as part of the solution. Most components use their component priority default, but igw and nat are both gateways, since the nat depends on the igw we need to set a specific priority for the nat. A the moment the deployment run fails when running through the segment components

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
