### PR TITLE
Datafeed based logging deployment prefixes

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -279,11 +279,11 @@
             [/#if]
 
             [@setupLoggingFirehoseStream
+                occurrence=occurrence
                 componentSubset="apigateway"
                 resourceDetails=accessLogStreamingResources
                 destinationLink=destinationLink
-                bucketPrefix=formatRelativePath("APIGatewayAccess", "Logs", occurrence.Core.FullRelativePath)
-                errorPrefix=formatRelativePath("APIGatewayAccess", "Error", occurrence.Core.FullRelativePath )
+                bucketPrefix="APIGatewayAccess"
                 cloudwatchEnabled=true
                 cmkKeyId=kmsKeyId
             /]
@@ -603,11 +603,11 @@
         [#if wafLogStreamingResources?has_content ]
 
             [@setupLoggingFirehoseStream
+                occurrence=occurrence
                 componentSubset="apigateway"
                 resourceDetails=wafLogStreamingResources
                 destinationLink=baselineLinks["OpsData"]
-                bucketPrefix=formatRelativePath("WAF", "Logs", occurrence.Core.FullRelativePath)
-                errorPrefix=formatRelativePath("WAF", "Error", occurrence.Core.FullRelativePath )
+                bucketPrefix="WAF"
                 cloudwatchEnabled=true
                 cmkKeyId=kmsKeyId
             /]

--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -486,11 +486,11 @@
                     formatResourceId(AWS_KINESIS_FIREHOSE_STREAM_RESOURCE_TYPE, wafAclId)]
 
                 [@setupLoggingFirehoseStream
+                    occurrence=occurrence
                     componentSubset=CDN_COMPONENT_TYPE
                     resourceDetails=wafLogStreamingResources
                     destinationLink=baselineLinks["OpsData"]
-                    bucketPrefix=formatRelativePath("WAF", "Logs", occurrence.Core.FullRelativePath)
-                    errorPrefix=formatRelativePath("WAF", "Error", occurrence.Core.FullRelativePath )
+                    bucketPrefix="WAF"
                     cloudwatchEnabled=true
                     cmkKeyId=kmsKeyId
                 /]

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -726,11 +726,11 @@
             [#if wafLogStreamingResources?has_content ]
 
                 [@setupLoggingFirehoseStream
+                    occurrence=occurrence
                     componentSubset=LB_COMPONENT_TYPE
                     resourceDetails=wafLogStreamingResources
                     destinationLink=baselineLinks["OpsData"]
-                    bucketPrefix=formatRelativePath("WAF", "Logs", occurrence.Core.FullRelativePath)
-                    errorPrefix=formatRelativePath("WAF", "Error", occurrence.Core.FullRelativePath )
+                    bucketPrefix="WAF"
                     cloudwatchEnabled=true
                     cmkKeyId=kmsKeyId
                 /]

--- a/aws/modules/consolidatelogs/module.ftl
+++ b/aws/modules/consolidatelogs/module.ftl
@@ -75,7 +75,12 @@
                                 },
                                 "Bucket" : {
                                     "Prefix" : "CWLogs/Logs/",
-                                    "ErrorPrefix" : "CWLogs/Errors/"
+                                    "ErrorPrefix" : "CWLogs/Errors/",
+                                    "Include" : {
+                                        "Order" : [ "AccountId", "ComponentPath" ],
+                                        "AccountId" : true,
+                                        "ComponentPath" : true
+                                    }
                                 },
                                 "Backup" : {
                                     "Enabled" : false


### PR DESCRIPTION
## Description
- Implements https://github.com/hamlet-io/engine/pull/1483 for datafeeds 
- Adds a fixed set of deployment prefixes to the datafeeds created for component specific logging - This ensures account id and full path are always included in the s3 prefix 
- Adds support for the prefix paths in consolidatelogs module

Breaking change: this will change the path for existing log consolidation modules to include the Account Id after the initial prefix 

## Motivation and Context
Removes the risk of collisions when store logs from multiple accounts in a central store 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] None of the above.
