### PR TITLE
fix(datafeed): clean prefixes for s3 destinations

### DIFF
--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -274,10 +274,12 @@
                     [/#if]
                 [/#list]
 
+                [#local bucketPrefix = (solution.Bucket.Prefix)?remove_ending("/")]
+
                 [#local streamS3DestinationPrefix = {
                     "Fn::Join" : [
                         "/",
-                        [ solution.Bucket.Prefix ] +
+                        [ bucketPrefix ] +
                         prefixIncludes
                     ]
                 }]
@@ -285,7 +287,7 @@
                 [#local streamS3DestinationErrorPrefix = {
                     "Fn::Join" : [
                         "/",
-                        [ solution.Bucket.ErrorPrefix ] +
+                        [ bucketPrefix ] +
                         prefixIncludes
                     ]
                 }]


### PR DESCRIPTION
## Description
Remove trailing slashes from the user defined bucket prefix for datafeeds

## Motivation and Context
We use a join to create the datafeed s3 prefix which can include deployment specifc paths, if a user defines a trailing / this will be duplicated as part of our prefix generation

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
