### PR TITLE
feat(secretstore): secrets manager support

### DIFF
--- a/aws/components/secretstore/id.ftl
+++ b/aws/components/secretstore/id.ftl
@@ -88,7 +88,7 @@
                         [
                             r'case ${STACK_OPERATION} in',
                             r'  create|update)',
-                            r'    info "Saving secret to CMDB",
+                            r'    info "Saving secret to CMDB"',
                             r'    secret_arn="$(get_cloudformation_stack_output "' + regionId + r'" ' + r' "${STACK_NAME}" ' + secretId + r' "ref" || return $?)"',
                             r'    secret_content="$(aws --region "' + regionId + r'" --output text secretsmanager get-secret-value --secret-id "${secret_arn}" --query "SecretString" || return $?)"',
                             r'    secret_value="$( echo "${secret_content}" | jq -r "' + secretKeyPath + r'")"',

--- a/aws/components/secretstore/id.ftl
+++ b/aws/components/secretstore/id.ftl
@@ -58,7 +58,10 @@
 
         [#local generateSecret = (solution.Source == "generated") ]
         [#local secretKeyPath = "." ]
+        [#local secretAttribute = SECRET_ATTRIBUTE_TYPE]
+
         [#if generateSecret ]
+            [#local secretAttribute = GENERATEDPASSWORD_ATTRIBUTE_TYPE ]
             [#local secretKeyPath = (solution.Generated.SecretKey)?ensure_starts_with(".") ]
         [/#if]
 
@@ -97,7 +100,7 @@
                         pseudoStackOutputScript(
                             "KMS Encrypted Secret",
                             {
-                                formatId(secretId, SECRET_ATTRIBUTE_TYPE) : r'${kms_encrypted_secret}'
+                                formatId(secretId, secretAttribute) : r'${kms_encrypted_secret}'
                             },
                             secretId
                         ) +

--- a/aws/components/secretstore/id.ftl
+++ b/aws/components/secretstore/id.ftl
@@ -1,0 +1,86 @@
+[#ftl]
+
+[@addResourceGroupInformation
+    type=SECRETSTORE_COMPONENT_TYPE
+    attributes=[
+        {
+            "Names": "Engine",
+            "Values" : [ "secretsmanager" ],
+            "Default" : "secretsmanager"
+        },
+        {
+            "Names" : "SaveToCMDB",
+            "Description" : "Save secrets to CMDB as KMS encyrpted strings",
+            "type" : BOOLEAN_TYPE,
+            "Default" : true
+        }
+    ]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_SECRETS_MANAGER_SERVICE
+        ]
+/]
+
+[#macro setupComponentSecret
+            occurrence
+            secretStoreLink
+            kmsKeyId
+            secretComponentResources={}
+            secretComponentConfiguration={}
+            componentType=""
+            secretString="" ]
+
+    [#local secretStoreCore = secretStoreLink.Core ]
+    [#local secretStoreSolution = secretStoreLink.Configuration.Solution ]
+    [#local secretStoreResources = secretStoreLink.State.Resources ]
+
+    [#if secretStoreCore.Type != SECRETSTORE_COMPONENT_TYPE ]
+        [@fatal
+            message="Secret Store link is to the wrong component"
+            detail="Secret store must be a ${SECRETSTORE_COMPONENT_TYPE} component"
+            context={
+                "Id" : secretStoreCore.Id,
+                "Type" : secretStoreCore.Type
+            }
+        /]
+
+    [#else]
+        [#local resources = secretComponentResources?has_content?then(
+                            secretComponentResources,
+                            occurrence.State.Resources
+        )]
+
+        [#local solution = secretComponentConfiguration?has_content?then(
+                                secretComponentConfiguration,
+                                occurrence.Configuration.Solution.Secret
+        )]
+
+        [#local componentType = componentType?has_content?then(
+                                componentType,
+                                occurrence.Core.Type
+        )]
+
+        [#local generateSecret = (solution.Source == "generated") ]
+
+        [#switch secretStoreSolution.Engine ]
+            [#case "aws:secretsmanager" ]
+                [#if deploymentSubsetRequired(componentType, true) ]
+
+                    [#local secretPolicy = getSecretsManagerPolicyFromComponentConfig(solution)]
+                    [@createSecretsManagerSecret
+                        id=resources["secret"].Id
+                        name=resources["secret"].Name
+                        tags=getOccurrenceCoreTags(occurrence, resources["secret"].Name)
+                        kmsKeyId=kmsKeyId
+                        description=resources["secret"].Description
+                        generateSecret=generateSecret
+                        generateSecretPolicy=secretPolicy
+                        secretString=secretString
+                    /]
+                [/#if]
+                [#break]
+        [/#switch]
+    [/#if]
+[/#macro]

--- a/aws/components/secretstore/id.ftl
+++ b/aws/components/secretstore/id.ftl
@@ -60,7 +60,7 @@
         [#local secretKeyPath = "." ]
         [#if generateSecret ]
             [#local secretKeyPath = (solution.Generated.SecretKey)?ensure_starts_with(".") ]
-        [/#if
+        [/#if]
 
         [#switch secretStoreSolution.Engine ]
             [#case "aws:secretsmanager" ]

--- a/aws/components/secretstore/id.ftl
+++ b/aws/components/secretstore/id.ftl
@@ -88,6 +88,7 @@
                         [
                             r'case ${STACK_OPERATION} in',
                             r'  create|update)',
+                            r'    info "Saving secret to CMDB",
                             r'    secret_arn="$(get_cloudformation_stack_output "' + regionId + r'" ' + r' "${STACK_NAME}" ' + secretId + r' "ref" || return $?)"',
                             r'    secret_content="$(aws --region "' + regionId + r'" --output text secretsmanager get-secret-value --secret-id "${secret_arn}" --query "SecretString" || return $?)"',
                             r'    secret_value="$( echo "${secret_content}" | jq -r "' + secretKeyPath + r'")"',
@@ -96,7 +97,7 @@
                         pseudoStackOutputScript(
                             "KMS Encrypted Secret",
                             {
-                                formatId(secretId, "key") : r'${kms_encrypted_secret}'
+                                formatId(secretId, SECRET_ATTRIBUTE_TYPE) : r'${kms_encrypted_secret}'
                             },
                             secretId
                         ) +

--- a/aws/components/secretstore/state.ftl
+++ b/aws/components/secretstore/state.ftl
@@ -1,0 +1,26 @@
+[#ftl]
+[#macro aws_queuehost_cf_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution ]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "secretStore" : {
+                    "Id" : core.Id,
+                    "Name" : core.FullName,
+                    "Deployed" : true
+                }
+            },
+            "Attributes" : {
+                "ENGINE" : solution.Engine
+            },
+            "Roles" : {
+                "Inbound" : {
+                },
+                "Outbound" : {
+                }
+            }
+        }
+    ]
+[/#macro]

--- a/aws/services/secretsmanager/id.ftl
+++ b/aws/services/secretsmanager/id.ftl
@@ -1,0 +1,9 @@
+[#ftl]
+
+[#-- Resources --]
+[#assign AWS_SECRETS_MANAGER_SECRET_RESOURCE_TYPE = "secret" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_SECRETS_MANAGER_SERVICE
+    resource=AWS_SECRETS_MANAGER_SECRET_RESOURCE_TYPE
+/]

--- a/aws/services/secretsmanager/resource.ftl
+++ b/aws/services/secretsmanager/resource.ftl
@@ -14,7 +14,7 @@
     ]
 [/#function]
 
-[#function getComponentSecretResoures occurrence secretId secretName secretDescription="" ]
+[#function getComponentSecretResources occurrence secretId secretName secretDescription="" ]
     [#return {
         "secret" : {
             "Id" : formatResourceId(AWS_SECRETS_MANAGER_SECRET_RESOURCE_TYPE, occurrence.Core.Id, secretId),

--- a/aws/services/secretsmanager/resource.ftl
+++ b/aws/services/secretsmanager/resource.ftl
@@ -1,0 +1,111 @@
+[#ftl]
+
+[#function getSecretManagerSecretRef secretId secretKey ]
+    [#return
+        {
+            "Fn::Sub": [
+                r'{{resolve:secretsmanager:${secretId}:SecretString:${secretKey}}}',
+                {
+                    "secretId": getReference(secretId),
+                    "secretKey" : secretKey
+                }
+            ]
+        }
+    ]
+[/#function]
+
+[#function getComponentSecretResoures occurrence secretId secretName secretDescription="" ]
+    [#return {
+        "secret" : {
+            "Id" : formatResourceId(AWS_SECRETS_MANAGER_SECRET_RESOURCE_TYPE, occurrence.Core.Id, secretId),
+            "Name" : formatName(occurrence.Core.FullName, secretName),
+            "Description" : secretDescription,
+            "Type" : AWS_SECRETS_MANAGER_SECRET_RESOURCE_TYPE
+        }
+    }]
+[/#function]
+
+[#function getSecretsManagerPolicyFromComponentConfig secretSolutionConfig ]
+    [#local requirements = secretSolutionConfig.Requirements ]
+    [#return
+        getSecretsManagerSecretGenerationPolicy(
+            requirements.MinLength,
+            secretSolutionConfig.Generated.SecretKey,
+            secretSolutionConfig.Generated.Content,
+            requirements.ExcludedCharacters?join(""),
+            !(requirements.IncludeUpper),
+            !(requirements.IncludeLower),
+            !(requirements.IncludeNumber),
+            !(requirements.IncludeSpecial),
+            false,
+            requirements.RequireAllIncludedTypes
+        )
+    ]
+[/#function]
+
+[#function getSecretsManagerSecretGenerationPolicy
+        passwordLength
+        generateStringKey
+        secretTemplate
+
+        excludeChars=""
+        excludeLowercase=false
+        excludeUppercase=false
+        excludeNumbers=false
+        excludePunctuation=false
+        includeSpace=false
+        requireEachType=true
+    ]
+    [#return
+        {
+            "SecretStringTemplate" : getJSON(secretTemplate),
+            "GenerateStringKey" : generateStringKey,
+            "PasswordLength" : passwordLength,
+            "ExcludeLowercase" : excludeLowercase,
+            "ExcludeNumbers" : excludeNumbers,
+            "ExcludePunctuation" : excludePunctuation,
+            "ExcludeUppercase" : excludeUppercase,
+            "IncludeSpace" : includeSpace,
+            "RequireEachIncludedType" : requireEachType
+        } +
+        attributeIfContent(
+            "ExcludeCharacters",
+            excludeChars
+        )
+    ]
+[/#function]
+
+[#macro createSecretsManagerSecret
+        id
+        name
+        tags
+        kmsKeyId
+        description=""
+        generateSecret=true
+        generateSecretPolicy={}
+        secretString=""
+    ]
+
+    [@cfResource
+        id=id
+        type="AWS::SecretsManager::Secret"
+        properties=
+            {
+                "Name" : name,
+                "KmsKeyId" : getReference(kmsKeyId, ARN_ATTRIBUTE_TYPE)
+            } +
+            attributeIfContent(
+                "Description",
+                description
+            ) +
+            generateSecret?then(
+                {
+                    "GenerateSecretString" : generateSecretPolicy
+                },
+                {
+                    "SecretString" : secretString
+                }
+            )
+        tags=tags
+    /]
+[/#macro]

--- a/aws/services/secretsmanager/resource.ftl
+++ b/aws/services/secretsmanager/resource.ftl
@@ -47,7 +47,6 @@
         passwordLength
         generateStringKey
         secretTemplate
-
         excludeChars=""
         excludeLowercase=false
         excludeUppercase=false

--- a/aws/services/service.ftl
+++ b/aws/services/service.ftl
@@ -76,6 +76,9 @@
 [#assign AWS_ROUTE53_SERVICE = "dns"]
 [@addService provider=AWS_PROVIDER service=AWS_ROUTE53_SERVICE /]
 
+[#assign AWS_SECRETS_MANAGER_SERVICE = "secretsmanager" ]
+[@addService provider=AWS_PROVIDER service=AWS_SECRETS_MANAGER_SERVICE /]
+
 [#assign AWS_SIMPLE_STORAGE_SERVICE = "s3"]
 [@addService provider=AWS_PROVIDER service=AWS_SIMPLE_STORAGE_SERVICE /]
 


### PR DESCRIPTION
## Description
Initial support in aws for the secrets store component 
- Allows components to use the secret store to define generated secrets for system credentials ( root passwords for managed services ) 
- Adds a dummy implementation of a component for the secrets manager secret store which doesn't require any infrastructure to actually create secrets 
- Ref support for resolving secrets in cloudformation templates 

## Motivation and Context
The primary motivation for this PR is to support the generation of admin passwords which are required for services like RDS or amazonMQ which require an initial root user to be defined in the cloudformation template. We currently set a generated password as an epilogue script. which does lead to an interruption to the service while the password is reset 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
