### PR TITLE
feat(queuehost): support for rabbitmq as queuehost

### DIFF
--- a/aws/components/queuehost/id.ftl
+++ b/aws/components/queuehost/id.ftl
@@ -1,0 +1,13 @@
+[#ftl]
+[@addResourceGroupInformation
+    type=QUEUEHOST_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_VIRTUAL_PRIVATE_CLOUD_SERVICE,
+            AWS_AMAZONMQ_SERVICE,
+            AWS_SECRETS_MANAGER_SERVICE
+        ]
+/]

--- a/aws/components/queuehost/setup.ftl
+++ b/aws/components/queuehost/setup.ftl
@@ -1,0 +1,187 @@
+[#ftl]
+[#macro aws_queuehost_cf_deployment_generationcontract occurrence ]
+    [@addDefaultGenerationContract subsets="template" /]
+[/#macro]
+
+[#macro aws_queuehost_cf_deployment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#-- Component State helpers --]
+    [#local core = occurrence.Core ]
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local resources = occurrence.State.Resources ]
+
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+    [#local cmkKeyId = baselineComponentIds["Encryption"]!"" ]
+
+    [#-- Network Lookup --]
+    [#local networkLink = getOccurrenceNetwork(occurrence).Link!{} ]
+    [#local networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
+    [#if ! networkLinkTarget?has_content ]
+        [@fatal message="Network could not be found" context=networkLink /]
+        [#return]
+    [/#if]
+    [#local networkConfiguration = networkLinkTarget.Configuration.Solution]
+    [#local networkResources = networkLinkTarget.State.Resources ]
+    [#local vpcId = networkResources["vpc"].Id ]
+
+    [#-- Resources and base configuration --]
+    [#local brokerId = resources["broker"].Id ]
+    [#local brokerFullName = resources["broker"].Name ]
+    [#local brokerShortName = resources["broker"].ShortName ]
+    [#local brokerPorts = resources["broker"].Ports]
+    [#local securityGroupId = resources["sg"].Id ]
+    [#local securityGroupName = resources["sg"].Name ]
+
+    [#local engine = solution.Engine]
+    [#local engineVersion = solution.EngineVersion ]
+
+    [#local networkProfile = getNetworkProfile(solution.Profiles.Network)]
+
+    [#local hibernate = solution.Hibernate.Enabled && isOccurrenceDeployed(occurrence)]
+
+    [#-- Link Processing --]
+    [#list solution.Links?values as link]
+        [#if link?is_hash]
+            [#local linkTarget = getLinkTarget(occurrence, link) ]
+
+            [@debug message="Link Target" context=linkTarget enabled=false /]
+
+            [#if !linkTarget?has_content]
+                [#continue]
+            [/#if]
+
+            [#local linkTargetCore = linkTarget.Core ]
+            [#local linkTargetConfiguration = linkTarget.Configuration ]
+            [#local linkTargetResources = linkTarget.State.Resources ]
+            [#local linkTargetAttributes = linkTarget.State.Attributes ]
+
+            [#if deploymentSubsetRequired(QUEUEHOST_COMPONENT_TYPE, true)]
+                [@createSecurityGroupRulesFromLink
+                    occurrence=occurrence
+                    groupId=cacheSecurityGroupId
+                    linkTarget=linkTarget
+                    inboundPorts=[ port ]
+                /]
+            [/#if]
+
+        [/#if]
+    [/#list]
+
+    [#-- Secret Management --]
+    [#local secretStoreLink = getLinkTarget(occurrence, solution.RootCredentials.SecretStore) ]
+    [@setupComponentSecret
+        occurrence=occurrence
+        secretStoreLink=secretStoreLink
+        kmsKeyId=cmkKeyId
+        secretComponentResources=resources["rootCredentials"]
+        secretComponentConfiguration=
+            solution.RootCredentials.Secret + {
+                "Generated" : {
+                    "Content" : { "username" : solution.RootCredentials.Username },
+                    "SecretKey" : "password"
+                }
+            }
+        componentType=QUEUEHOST_COMPONENT_TYPE
+    /]
+
+    [#-- Output Generation --]
+    [#if deploymentSubsetRequired(QUEUEHOST_COMPONENT_TYPE, true)]
+
+        [#-- Network Security --]
+        [@createSecurityGroup
+            id=securityGroupId
+            name=securityGroupName
+            vpcId=vpcId
+            occurrence=occurrence
+        /]
+
+        [@createSecurityGroupRulesFromNetworkProfile
+            occurrence=occurrence
+            groupId=securityGroupId
+            networkProfile=networkProfile
+            inboundPorts=brokerPorts
+        /]
+
+        [#local ingressNetworkRule = {
+                "Ports" : brokerPorts,
+                "IPAddressGroups" : solution.IPAddressGroups
+        }]
+
+        [@createSecurityGroupIngressFromNetworkRule
+            occurrence=occurrence
+            groupId=securityGroupId
+            networkRule=ingressNetworkRule
+        /]
+
+
+        [#if !hibernate]
+
+            [#-- Monitoring and Alerts --]
+            [#list solution.Alerts?values as alert ]
+
+                [#local monitoredResources = getMonitoredResources(core.Id, resources, alert.Resource)]
+                [#list monitoredResources as name,monitoredResource ]
+
+                    [@debug message="Monitored resource" context=monitoredResource enabled=false /]
+
+                    [#switch alert.Comparison ]
+                        [#case "Threshold" ]
+                            [@createAlarm
+                                id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
+                                severity=alert.Severity
+                                resourceName=core.FullName
+                                alertName=alert.Name
+                                actions=getCWAlertActions(occurrence, solution.Profiles.Alert, alert.Severity )
+                                metric=getMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
+                                namespace=getResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
+                                description=alert.Description!alert.Name
+                                threshold=alert.Threshold
+                                statistic=alert.Statistic
+                                evaluationPeriods=alert.Periods
+                                period=alert.Time
+                                operator=alert.Operator
+                                reportOK=alert.ReportOk
+                                unit=alert.Unit
+                                missingData=alert.MissingData
+                                dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                            /]
+                        [#break]
+                    [/#switch]
+                [/#list]
+            [/#list]
+
+            [#-- Component Specific Resources --]
+            [@createAmazonMqBroker
+                id=brokerId
+                name=brokerShortName
+                engineType=engine
+                engineVersion=engineVersion
+                instanceType=solution.Processor.Type
+                multiAz=multiAZ
+                encrypted=solution.Encrypted
+                kmsKeyId=cmkKeyId
+                subnets=getSubnets(core.Tier, networkResources )
+                securityGroupId=securityGroupId
+                tags=getOccurrenceCoreTags(occurrence, brokerFullName)
+                users=[
+                    getAmazonMqUser(
+                        getSecretManagerSecretRef(resources["rootCredentials"]["secret"].Id, "username"),
+                        getSecretManagerSecretRef(resources["rootCredentials"]["secret"].Id, "password")
+                    )
+                ]
+                autoMinorVersionUpdate=solution.AutoMinorUpgrade
+                logging=true
+                maintenanceWindow=
+                    getAmazonMqMaintenanceWindow(
+                        solution.MaintenanceWindow.DayOfTheWeek,
+                        solution.MaintenanceWindow.TimeOfDay,
+                        solution.MaintenanceWindow.TimeZone
+                    )
+            /]
+
+        [/#if]
+    [/#if]
+[/#macro]

--- a/aws/components/queuehost/setup.ftl
+++ b/aws/components/queuehost/setup.ftl
@@ -74,20 +74,29 @@
     [#local secretStoreLink = getLinkTarget(occurrence, solution.RootCredentials.SecretStore) ]
     [#local passwordSecretKey = "password" ]
 
-    [@setupComponentSecret
-        occurrence=occurrence
-        secretStoreLink=secretStoreLink
-        kmsKeyId=cmkKeyId
-        secretComponentResources=resources["rootCredentials"]
-        secretComponentConfiguration=
-            solution.RootCredentials.Secret + {
-                "Generated" : {
-                    "Content" : { "username" : solution.RootCredentials.Username },
-                    "SecretKey" : passwordSecretKey
+    [#if secretStoreLink?has_content ]
+
+        [@setupComponentSecret
+            occurrence=occurrence
+            secretStoreLink=secretStoreLink
+            kmsKeyId=cmkKeyId
+            secretComponentResources=resources["rootCredentials"]
+            secretComponentConfiguration=
+                solution.RootCredentials.Secret + {
+                    "Generated" : {
+                        "Content" : { "username" : solution.RootCredentials.Username },
+                        "SecretKey" : passwordSecretKey
+                    }
                 }
-            }
-        componentType=QUEUEHOST_COMPONENT_TYPE
-    /]
+            componentType=QUEUEHOST_COMPONENT_TYPE
+        /]
+    [#else]
+        [@fatal
+            message="Could not find link to secret store or link was invalid"
+            detail="Added a link to a secret store component which will manage the root credentials"
+            context=solution.RootCredentials.SecretStore
+        /]
+    [/#if]
 
     [#-- Output Generation --]
     [#if deploymentSubsetRequired(QUEUEHOST_COMPONENT_TYPE, true)]

--- a/aws/components/queuehost/state.ftl
+++ b/aws/components/queuehost/state.ftl
@@ -11,6 +11,13 @@
     [#local segmentSeedId = formatSegmentSeedId() ]
     [#local segmentSeed = getExistingReference(segmentSeedId)]
 
+    [#local rootCredentialResources = getComponentSecretResources(
+                                        occurrence,
+                                        "root",
+                                        "root",
+                                        "Root credentials for broker"
+                                    )]
+
     [#assign componentState =
         {
             "Resources" : {
@@ -27,16 +34,15 @@
                     "Name" : core.FullName,
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 },
-                "rootCredentials" : getComponentSecretResoures(
-                    occurrence,
-                    "root",
-                    "root",
-                    "Root credentials for broker"
-                 )
+                "rootCredentials" : rootCredentialResources
             },
             "Attributes" : {
                 "ENGINE" : solution.Engine,
-                "URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE)
+                "URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE)?ensure_starts_with(solution.RootCredentials.EncryptionScheme),
+                "ENDPOINT" : getExistingReference(id, DNS_ATTRIBUTE_TYPE),
+                "USERNAME" : solution.RootCredentials.Username,
+                "PASSWORD" : getExistingReference(rootCredentialResources["secret"].Id, GENERATEDPASSWORD_ATTRIBUTE_TYPE)?ensure_starts_with(solution.RootCredentials.EncryptionScheme),
+                "SECRET" : getExistingReference(rootCredentialResources["secret"].Id )
             },
             "Roles" : {
                 "Inbound" : {

--- a/aws/components/queuehost/state.ftl
+++ b/aws/components/queuehost/state.ftl
@@ -1,0 +1,58 @@
+[#ftl]
+[#macro aws_queuehost_cf_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution ]
+
+    [#local id = formatResourceId(AWS_AMAZONMQ_BROKER_RESOURCE_TYPE, core.Id) ]
+    [#local securityGroupId = formatDependentSecurityGroupId(id)]
+
+    [#local ports = [ "rabbitmq", "https", "rabbitmq-ui" ]]
+
+    [#local segmentSeedId = formatSegmentSeedId() ]
+    [#local segmentSeed = getExistingReference(segmentSeedId)]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "broker" : {
+                    "Id" : id,
+                    "Name" : core.FullName,
+                    "ShortName" : formatName( core.ShortFullName, segmentSeed)?truncate_c(50, ''),
+                    "Type" : AWS_AMAZONMQ_BROKER_RESOURCE_TYPE,
+                    "Ports" : ports,
+                    "Monitored" : true
+                },
+                "sg" : {
+                    "Id" : securityGroupId,
+                    "Name" : core.FullName,
+                    "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
+                },
+                "rootCredentials" : getComponentSecretResoures(
+                    occurrence,
+                    "root",
+                    "root",
+                    "Root credentials for broker"
+                 )
+            },
+            "Attributes" : {
+                "ENGINE" : solution.Engine,
+                "URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE)
+            },
+            "Roles" : {
+                "Inbound" : {
+                    "networkacl" : {
+                        "SecurityGroups" : securityGroupId,
+                        "Description" : core.FullName
+                    }
+                },
+                "Outbound" : {
+                    "networkacl" : {
+                        "Ports" : ports,
+                        "SecurityGroups" : securityGroupId,
+                        "Description" : core.FullName
+                    }
+                }
+            }
+        }
+    ]
+[/#macro]

--- a/aws/deploymentframeworks/cf/output.ftl
+++ b/aws/deploymentframeworks/cf/output.ftl
@@ -201,21 +201,41 @@
                 value.Export!false
             /]
         [#else]
-            [@cfOutput
-                formatAttributeId(oId, type),
-                ((value.UseRef)!false)?then(
-                    {
-                        "Ref" : id
-                    },
-                    value.Value?has_content?then(
-                        value.Value,
+
+            [#if value.Replace?has_content ]
+                [#local content = getJSON(value.Replace)]
+                [#list [ "_id_" ] as replaceSting ]
+                    [#switch replaceSting ]
+                        [#case "_id_" ]
+                            [#local content = content?replace(replaceSting, id )]
+                            [#break]
+                    [/#switch]
+                [/#list]
+
+                [@cfOutput
+                    formatAttributeId(oId, type),
+                    content?eval,
+                    value.Export!false
+                /]
+            [#else]
+                [@cfOutput
+                    formatAttributeId(oId, type),
+                    ((value.UseRef)!false)?then(
                         {
-                            "Fn::GetAtt" : [id, value.Attribute]
-                        }
-                    )
-                ),
-                value.Export!false
-            /]
+                            "Ref" : id
+                        },
+                        value.Value?has_content?then(
+                            value.Value,
+                            {
+                                "Fn::GetAtt" : [id, value.Attribute]
+                            }
+                        )
+                    ),
+                    value.Export!false
+                /]
+            [/#if]
+
+
         [/#if]
     [/#list]
 [/#macro]

--- a/aws/deploymentframeworks/cf/output.ftl
+++ b/aws/deploymentframeworks/cf/output.ftl
@@ -204,10 +204,10 @@
 
             [#if value.Replace?has_content ]
                 [#local content = getJSON(value.Replace)]
-                [#list [ "_id_" ] as replaceSting ]
-                    [#switch replaceSting ]
+                [#list [ "_id_" ] as replaceString ]
+                    [#switch replaceString ]
                         [#case "_id_" ]
-                            [#local content = content?replace(replaceSting, id )]
+                            [#local content = content?replace(replaceString, id )]
                             [#break]
                     [/#switch]
                 [/#list]

--- a/aws/services/amazonmq/resource.ftl
+++ b/aws/services/amazonmq/resource.ftl
@@ -5,7 +5,7 @@
         REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true
         },
-        URL_ATTRIBUTE_TYPE : {
+        DNS_ATTRIBUTE_TYPE : {
             "Value" : {
                 "Fn::Join" : [
                     ";",

--- a/aws/services/amazonmq/resource.ftl
+++ b/aws/services/amazonmq/resource.ftl
@@ -6,12 +6,12 @@
             "UseRef" : true
         },
         DNS_ATTRIBUTE_TYPE : {
-            "Value" : {
+            "Replace" : {
                 "Fn::Join" : [
                     ";",
                     {
                         "Fn::GetAtt" : [
-                            "mqBrokerXmgmtXrabbithutch",
+                            "_id_",
                             "AmqpEndpoints"
                         ]
                     }

--- a/awstest/inputsources/shared/blueprint.ftl
+++ b/awstest/inputsources/shared/blueprint.ftl
@@ -25,6 +25,10 @@
                     "s3" : {
                         "Provider" : "awstest",
                         "Name" : "s3"
+                    },
+                    "queuehost" : {
+                        "Provider" : "awstest",
+                        "Name" : "queuehost"
                     }
                 }
             },

--- a/awstest/modules/queuehost/module.ftl
+++ b/awstest/modules/queuehost/module.ftl
@@ -1,0 +1,93 @@
+[#ftl]
+
+[@addModule
+    name="queuehost"
+    description="Testing module for the aws queuehost component"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_queuehost  ]
+
+    [#-- Base queuehost --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "queuehostbase" : {
+                            "queuehost" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-queuehost-base"
+                                    }
+                                },
+                                "Engine" : "rabbitmq",
+                                "EngineVersion" : "1.0.0",
+                                "Processor" : {
+                                    "Type" : "queue.m3.micro"
+                                },
+                                "Profiles" : {
+                                    "Testing" : [ "queuehostbase" ]
+                                },
+                                "RootCredentials" : {
+                                    "SecretStore" : {
+                                        "Tier" : "app",
+                                        "Component" : "queuehostsecretstore",
+                                        "Instance" : "",
+                                        "Version" :""
+                                    }
+                                }
+                            }
+                        },
+                        "queuehostsecretstore" : {
+                            "secretstore" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-queuehost-secretstore"
+                                    }
+                                },
+                                "Engine" : "aws:secretsmanager"
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "queuehostbase" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "queueHost" : {
+                                    "Name" : "mqBrokerXappXqueuehostbase",
+                                    "Type" : "AWS::AmazonMQ::Broker"
+                                },
+                                "securityGroup" : {
+                                    "Name" : "securityGroupXmqBrokerXappXqueuehostbase",
+                                    "Type" : "AWS::EC2::SecurityGroup"
+                                },
+                                "rootSecret" : {
+                                    "Name" : "secretXappXqueuehostbaseXroot",
+                                    "Type" : "AWS::SecretsManager::Secret"
+                                }
+                            },
+                            "Output" : [
+                                "mqBrokerXappXqueuehostbaseXurl",
+                                "securityGroupXmqBrokerXappXqueuehostbase",
+                                "secretXappXqueuehostbaseXroot"
+                            ]
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "queuehostbase" : {
+                    "queuehost" : {
+                        "TestCases" : [ "queuehostbase" ]
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Description
Initial support for the queue host component using AmazonMQ in aws.

## Motivation and Context
he queue host component is intended to support managed queue broker services which offer a platform to host queues as opposed to instances of queues like we have with Sqs already 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
