### PR TITLE
fix(datafeed): use error prefix for errors

### DIFF
--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -274,12 +274,10 @@
                     [/#if]
                 [/#list]
 
-                [#local bucketPrefix = (solution.Bucket.Prefix)?remove_ending("/")]
-
                 [#local streamS3DestinationPrefix = {
                     "Fn::Join" : [
                         "/",
-                        [ bucketPrefix ] +
+                        [  (solution.Bucket.Prefix)?remove_ending("/") ] +
                         prefixIncludes
                     ]
                 }]
@@ -287,7 +285,7 @@
                 [#local streamS3DestinationErrorPrefix = {
                     "Fn::Join" : [
                         "/",
-                        [ bucketPrefix ] +
+                        [ (solution.Bucket.ErrorPrefix)?remove_ending("/") ] +
                         prefixIncludes
                     ]
                 }]


### PR DESCRIPTION
## Description
Silly fix after fixing the prefix formatting

## Motivation and Context
Error logs were being sent to actual logs 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
