### PR TITLE
feat(alerts): get metric dimensions from blueprint

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -571,7 +571,7 @@
                             reportOK=alert.ReportOk
                             unit=alert.Unit
                             missingData=alert.MissingData
-                            dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                            dimensions=getMetricDimensions(alert, stageVariables, monitoredResource, resources)
                         /]
                     [#break]
                 [/#switch]

--- a/aws/components/cache/setup.ftl
+++ b/aws/components/cache/setup.ftl
@@ -161,7 +161,7 @@
                                 reportOK=alert.ReportOk
                                 unit=alert.Unit
                                 missingData=alert.MissingData
-                                dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                                dimensions=getMetricDimensions(alert, monitoredResource, resources)
                             /]
                         [#break]
                     [/#switch]

--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -410,7 +410,7 @@
                         }
                     ]]
                 [#else]
-                    [#local resourceDimensions = getResourceMetricDimensions(monitoredResource, resources) ]
+                    [#local resourceDimensions = dimensions=getMetricDimensions(alert, monitoredResource, resources) ]
                 [/#if]
 
                 [#switch alert.Comparison ]

--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -410,7 +410,7 @@
                         }
                     ]]
                 [#else]
-                    [#local resourceDimensions = dimensions=getMetricDimensions(alert, monitoredResource, resources) ]
+                    [#local resourceDimensions = getMetricDimensions(alert, monitoredResource, resources) ]
                 [/#if]
 
                 [#switch alert.Comparison ]

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -500,7 +500,7 @@
                             reportOK=alert.ReportOk
                             unit=alert.Unit
                             missingData=alert.MissingData
-                            dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                            dimensions=getMetricDimensions(alert, monitoredResource, resources, environmentVariables)
                         /]
                     [#break]
                 [/#switch]
@@ -1493,7 +1493,7 @@
                                 reportOK=alert.ReportOk
                                 unit=alert.Unit
                                 missingData=alert.MissingData
-                                dimensions=getResourceMetricDimensions(monitoredResource, ( resources + { "cluster" : parentResources["cluster"] } ) )
+                                dimensions=getMetricDimensions(alert, monitoredResource, ( resources + { "cluster" : parentResources["cluster"] } ) )
                             /]
                         [#break]
                     [/#switch]

--- a/aws/components/es/setup.ftl
+++ b/aws/components/es/setup.ftl
@@ -361,7 +361,7 @@
                             reportOK=alert.ReportOk
                             unit=alert.Unit
                             missingData=alert.MissingData
-                            dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                            dimensions=getMetricDimensions(alert, monitoredResource, resources)
                         /]
                     [#break]
                 [/#switch]

--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -501,7 +501,7 @@
                             reportOK=alert.ReportOk
                             unit=alert.Unit
                             missingData=alert.MissingData
-                            dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                            dimensions=getMetricDimensions(alert, monitoredResource, resources, finalAsFileEnvironment)
                         /]
                     [#break]
                 [/#switch]

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -117,7 +117,7 @@
                             reportOK=alert.ReportOk
                             unit=alert.Unit
                             missingData=alert.MissingData
-                            dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                            dimensions=getMetricDimensions(alert, monitoredResource, resources)
                         /]
                     [#break]
                 [/#switch]

--- a/aws/components/mobilenotifier/setup.ftl
+++ b/aws/components/mobilenotifier/setup.ftl
@@ -176,7 +176,7 @@
                                 reportOK=alert.ReportOk
                                 unit=alert.Unit
                                 missingData=alert.MissingData
-                                dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                                dimensions=getMetricDimensions(alert, monitoredResource, resources)
                             /]
                         [#break]
                     [/#switch]

--- a/aws/components/sqs/setup.ftl
+++ b/aws/components/sqs/setup.ftl
@@ -74,7 +74,7 @@
                             reportOK=alert.ReportOk
                             unit=alert.Unit
                             missingData=alert.MissingData
-                            dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                            dimensions=getMetricDimensions(alert, monitoredResource, resources)
                         /]
                     [#break]
                 [/#switch]

--- a/aws/components/topic/setup.ftl
+++ b/aws/components/topic/setup.ftl
@@ -56,7 +56,7 @@
                             reportOK=alert.ReportOk
                             unit=alert.Unit
                             missingData=alert.MissingData
-                            dimensions=getResourceMetricDimensions(monitoredResource, resources)
+                            dimensions=getMetricDimensions(alert, monitoredResource, resources)
                         /]
                     [#break]
                 [/#switch]


### PR DESCRIPTION
## Description
AWS implementation of https://github.com/hamlet-io/engine/pull/1490 which allows for metric dimensions to be assigned through component configuration or settings

Note: the current implementation uses the finalEnvironment of a component to determine the settings to use, this isn;t available on all components as some don't support settings

## Motivation and Context
To create custom alerts based on business level metrics

## How Has This Been Tested?
TEsted locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
