### PR TITLE
feat(ecs): external image sourcing

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -653,7 +653,7 @@
 [/#macro]
 
 [#macro aws_ecs_cf_deployment_generationcontract_application occurrence ]
-    [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue", "cli"] /]å
+    [@addDefaultGenerationContract subsets=[ "pregeneration", "prologue", "template", "epilogue", "cli"] /]å
 [/#macro]
 
 [#macro aws_ecs_cf_deployment_application occurrence ]
@@ -1436,6 +1436,28 @@
                         logGroupName=container.LogGroup.Name
                         loggingProfile=loggingProfile
                     /]
+            [/#if]
+        [/#list]
+
+        [#list solution.Containers as id, container ]
+            [#local imageSource = container.Image.Source]
+
+            [#if deploymentSubsetRequired("pregeneration", false)
+                    && imageSource == "containerregistry" ]
+                [@addToDefaultBashScriptOutput
+                    content=
+                        getImageFromContainerRegistryScript(
+                                productName,
+                                environmentName,
+                                segmentName,
+                                subOccurrence,
+                                container.Image["Source:containerregistry"].Image,
+                                "docker",
+                                getRegistryEndPoint("docker", subOccurrence),
+                                "ecr",
+                                regionId
+                        )
+                /]
             [/#if]
         [/#list]
 


### PR DESCRIPTION
## Description
AWS implementation of https://github.com/hamlet-io/engine/pull/1495

Allows for external images to be provided for ecs tasks or services. The image is pulled from the public repository and copied to the hamlet registry 

## Motivation and Context
Allows for the use of utility docker containers or for images built outside of the product CI/CD pipeline 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Requires https://github.com/hamlet-io/executor-bash/pull/141

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
