### PR TITLE
fix: prodiver id migration cleanup

### DIFF
--- a/aws/services/s3/resource.ftl
+++ b/aws/services/s3/resource.ftl
@@ -251,7 +251,7 @@
 
     [#local crossAccountReplication = false ]
     [#if replicationDestinationAccountId?has_content
-            && replicationDestinationAccountId != accountObject.AWSId ]
+            && replicationDestinationAccountId != accountObject.ProviderId ]
         [#local crossAccountReplication = true ]
     [/#if]
 


### PR DESCRIPTION
## Description
Minor fix to the S3 resource lookup Id when using cross account replication to align with the Provider Id value in #169  

## Motivation and Context
Template generation was broken. This change was implemented just after the provider changes were merged so was just a missed timing

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
