### PR TITLE
refactor: s3 encryption replication role creation

### DIFF
--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -272,7 +272,7 @@
             isPartOfCurrentDeploymentUnit(roleId)]
         [#local linkPolicies =
             getLinkTargetsOutboundRoles(links) +
-            replicateEncryptedData?then(
+            (replicationEnabled && replicateEncryptedData)?then(
                 s3EncryptionReadPermission(
                     kmsKeyId,
                     s3Name,


### PR DESCRIPTION
## Description
Only include the necessary policies to allow s3 replication read access to the source bucket if replication is enabled.

## Motivation and Context
Otherwise, the role always gets created even if replication is not configured. It also makes review of the templates more confusing as they contain unnecessary resources.
## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
