### PR TITLE
refactor: inbound mta support

### DIFF
--- a/aws/components/mta/state.ftl
+++ b/aws/components/mta/state.ftl
@@ -16,6 +16,7 @@
         }
     ]
 
+    [#-- The certificate is needed to know the email domain --]
     [#if ! isPresent(solution.Certificate) ]
         [@fatal
             message="MTA Certificate must be configured to determine the email domain"
@@ -52,16 +53,11 @@
             [#break]
 
         [#case "receive" ]
+            [#-- The account level SES receive configuration needs to be in the same region as the inbound mta --]
             [#assign componentState +=
                 {
-                    "Resources" : {
-                        "ruleset" : {
-                            "Id" : formatResourceId(AWS_SES_RECEIPT_RULESET_RESOURCE_TYPE, core.Id),
-                            "Name" : formatComponentFullName(core.Tier, core.Component, occurrence),
-                            "Type" : AWS_SES_RECEIPT_RULESET_RESOURCE_TYPE
-                        }
-                    },
                     "Attributes" : {
+                        "RULESET" : getExistingReference(formatSESReceiptRuleSetId(), NAME_ATTRIBUTE_TYPE, regionId),
                         "REGION" : regionId
                     }
                 }

--- a/aws/services/ses/id.ftl
+++ b/aws/services/ses/id.ftl
@@ -21,3 +21,19 @@
     service=AWS_SIMPLE_EMAIL_SERVICE
     resource=AWS_SES_RECEIPT_FILTER_RESOURCE_TYPE
 /]
+
+[#function formatSESReceiptRuleSetId ]
+    [#return formatAccountResourceId(AWS_SES_RECEIPT_RULESET_RESOURCE_TYPE) ]
+[/#function]
+
+[#function formatSESReceiptRuleId extensions...]
+    [#return formatResourceId(
+                AWS_SES_RECEIPT_RULE_RESOURCE_TYPE,
+                extensions)]
+[/#function]
+
+[#function formatSESReceiptFilterId extensions...]
+    [#return formatAccountResourceId(
+                AWS_SES_RECEIPT_FILTER_RESOURCE_TYPE,
+                extensions)]
+[/#function]


### PR DESCRIPTION
## Description
Refactor the inbound MTA support to recognise that only one ruleset can be active for an account/region, meaning that it needs to be shared across environments and created at the account level.

Implements hamlet-io/engine#1499

## Motivation and Context
Refactor due to constraints of SES support for receive rule sets.

## How Has This Been Tested?
Local template generation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
