### PR TITLE
fix(dynamodb): query scan permissions for read access

### DIFF
--- a/aws/services/dynamodb/policy.ftl
+++ b/aws/services/dynamodb/policy.ftl
@@ -191,7 +191,17 @@
         dynamodbWritePermission(
             tables,
             principals,
-            conditions)]
+            conditions) +
+        dynamodbQueryPermission(
+            tables,
+            [],
+            principals,
+            conditions) +
+        dynamodbScanPermission(
+            tables,
+            [],
+            principals,
+            conditions) ]
 [/#function]
 
 [#function dynamodbConsumePermission tables="*" principals="" conditions={} ]
@@ -203,7 +213,17 @@
         dynamodbDeletePermission(
             tables,
             principals,
-            conditions)]
+            conditions) +
+        dynamodbQueryPermission(
+            tables,
+            [],
+            principals,
+            conditions) +
+        dynamodbScanPermission(
+            tables,
+            [],
+            principals,
+            conditions) ]
 [/#function]
 
 [#function dynamodbManageTablesPermission tables="*" principals="" conditions={} ]


### PR DESCRIPTION
## Description
Minor fix to support query and scan permissions for the globaldb component

## Motivation and Context
Query and scan are important parts of the dynamdb permissions when using dynamodb in most application contexts. This provides them to both the consume and produce roles 

## How Has This Been Tested?
Tested on deployment

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
