### PR TITLE
fix: add lambda attributes to context

### DIFF
--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -112,7 +112,8 @@
             "DefaultBaselineVariables" : true,
             "Policy" : standardPolicies(fn, baselineComponentIds),
             "ManagedPolicy" : [],
-            "CodeHash" : solution.FixedCodeVersion.CodeHash
+            "CodeHash" : solution.FixedCodeVersion.CodeHash,
+            "VersionDependencies" : []
         }
     ]
     [#local _context = invokeExtensions( fn, _context )]


### PR DESCRIPTION
## Description
Adds the VersionDependencies attribute to the context so that it can be updated as required using extensions

## Motivation and Context
Lambda functions which use the LambdaAttributes extension macro but don't set the VersionDependencies value are failing

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
