### PR TITLE
feat(cdn): add support for external service origins

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -355,7 +355,7 @@
 
                 [#local originHostName = originLinkTargetAttributes["FQDN"]!"HamletFatal: Could not find FQDN Attribute on external service" ]
 
-                [#local path = originLinkTargetAttributes["PATH"]!"HamletFatal: Could not fid PATH Attribute on external service" ]
+                [#local path = originLinkTargetAttributes["PATH"]!"HamletFatal: Could not find PATH Attribute on external service" ]
                 [#local originPath = formatAbsolutePath( path, subSolution.Origin.BasePath ) ]
 
                 [#local origin =

--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -350,6 +350,34 @@
                                 eventHandlers )]
                 [#local routeBehaviours += behaviour ]
                 [#break]
+
+            [#case EXTERNALSERVICE_COMPONENT_TYPE ]
+
+                [#local originHostName = originLinkTargetAttributes["FQDN"]!"HamletFatal: Could not find FQDN Attribute on external service" ]
+
+                [#local path = originLinkTargetAttributes["PATH"]!"HamletFatal: Could not fid PATH Attribute on external service" ]
+                [#local originPath = formatAbsolutePath( path, subSolution.Origin.BasePath ) ]
+
+                [#local origin =
+                            getCFHTTPOrigin(
+                                originId,
+                                originHostName,
+                                _context.CustomOriginHeaders,
+                                originPath
+                            )]
+                [#local origins += origin ]
+
+                [#local behaviour =
+                            getCFLBCacheBehaviour(
+                                origin,
+                                behaviourPattern,
+                                subSolution.CachingTTL,
+                                subSolution.Compress,
+                                _context.ForwardHeaders,
+                                eventHandlers )]
+                [#local routeBehaviours += behaviour ]
+                [#break]
+
         [/#switch]
 
         [#list routeBehaviours as behaviour ]


### PR DESCRIPTION
## Description
Adds support for using an external service as a CDN origin. The external service must have 2 attributes defined, FQDN which sets the host name of the origin endpoint and PATH which can be used to define an origin path override 

## Motivation and Context
This allows for external URLs to be routed through a CDN or to allow for the creation of dummy origins used in combination with Lambda@Edge functions

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
