### PR TITLE
fix(userpool): set userpool region for multi region deployments

### DIFF
--- a/aws/components/userpool/state.ftl
+++ b/aws/components/userpool/state.ftl
@@ -45,7 +45,7 @@
         [#local userPoolDomainId = formatResourceId(AWS_COGNITO_USERPOOL_DOMAIN_RESOURCE_TYPE, core.Id)]
         [#local certificatePresent = isPresent(solution.HostedUI.Certificate) ]
         [#local userPoolDomainName = formatName("auth", core.ShortFullName, segmentSeed)]
-        [#local userPoolFQDN = formatDomainName(userPoolDomainName, "auth", region, "amazoncognito.com")]
+        [#local userPoolFQDN = formatDomainName(userPoolDomainName, "auth", occurrence.State.ResourceGroups["default"].Placement.Region, "amazoncognito.com")]
         [#local userPoolBaseUrl = "https://" + userPoolFQDN + "/" ]
 
         [#local region = getExistingReference(userPoolId, REGION_ATTRIBUTE_TYPE)!regionId ]


### PR DESCRIPTION
## Description
A fix to the creation of the userpool UI url which was using the region for a deployment instead of the components region

## Motivation and Context
This fixes an issue where you have a multi region deployment where a component links to a userpool in another region. Since the hosted UI url was using the `region` global variable, this didn't reflect where the userpool was deployed to. Instead we now use the placement region for the userpool component

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
