### PR TITLE
Account s3 replica

### DIFF
--- a/aws/services/kms/policy.ftl
+++ b/aws/services/kms/policy.ftl
@@ -72,7 +72,7 @@
         [
             getPolicyStatement(
                 asArray(actions),
-                getReference(keyId, ARN_ATTRIBUTE_TYPE),
+                getArn(keyId, false, bucketRegion),
                 "",
                 {
                     "StringEquals" : {

--- a/aws/services/s3/name.ftl
+++ b/aws/services/s3/name.ftl
@@ -25,3 +25,16 @@
                 extensions),
             segmentSeed)]
 [/#function]
+
+[#function formatAccountS3PrimaryBucketName bucketType ]
+    [#assign existingName = getExistingReference(formatAccountS3Id(bucketType), NAME_ATTRIBUTE_TYPE, commandLineOptions.Regions.Segment )]
+    [#return valueIfContent(
+                existingName,
+                existingName,
+                formatName("account", bucketType, accountObject.Seed ))]
+[/#function]
+
+
+[#function formatAccountS3ReplicaBucketName bucketType region ]
+    [#return formatAccountS3PrimaryBucketName(bucketType)?ensure_ends_with("-" + region)]
+[/#function]


### PR DESCRIPTION
## Description
AWs provider support for https://github.com/hamlet-io/engine/pull/1508 
- Add standard naming for account level s3 buckets 
- Allow for regional KMS key permissions for bucket replication on encrypted at rest buckets 

## Motivation and Context
Supports the use of multi region registry deployments 

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
