### PR TITLE
Refactor: Composite Object Data Types

### DIFF
--- a/aws/components/apigateway/id.ftl
+++ b/aws/components/apigateway/id.ftl
@@ -13,13 +13,13 @@
                 {
                     "Names" : "aws:KinesisFirehose",
                     "Description" : "Send Access logs to a KinesisFirehose. By default, the Firehose destination is the OpsData DataBucket, but can be overwritten by specifying a DestinationLink.",
-                    "Type" : BOOLEAN_TYPE,
+                    "Types" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
                     "Names" : "aws:KeepLogGroup",
                     "Description" : "Prevent the destruction of existing LogGroups when enabling KinesisFirehose.",
-                    "Type" : BOOLEAN_TYPE,
+                    "Types" : BOOLEAN_TYPE,
                     "Default" : true
                 }
             ]

--- a/aws/components/datafeed/id.ftl
+++ b/aws/components/datafeed/id.ftl
@@ -5,7 +5,7 @@
         {
             "Names" : "WAFLogFeed",
             "Description" : "Feed is intended for use with WAF. Enforces a strict naming convention required by the provider.",
-            "Type" : BOOLEAN_TYPE,
+            "Types" : BOOLEAN_TYPE,
             "Default" : false
         }
     ]

--- a/aws/components/ecs/id.ftl
+++ b/aws/components/ecs/id.ftl
@@ -23,7 +23,7 @@
         {
             "Names" : "FargatePlatform",
             "Description" : "The version of the fargate platform to use",
-            "Type" : STRING_TYPE,
+            "Types" : STRING_TYPE,
             "Default" : "LATEST"
         }
     ]
@@ -38,7 +38,7 @@
         {
             "Names" : "FargatePlatform",
             "Description" : "The version of the fargate platform to use",
-            "Type" : STRING_TYPE,
+            "Types" : STRING_TYPE,
             "Default" : "LATEST"
         }
     ]

--- a/aws/components/efs/id.ftl
+++ b/aws/components/efs/id.ftl
@@ -5,7 +5,7 @@
         {
             "Names" : "IAMRequired",
             "Description" : "Require IAM Access to EFS",
-            "Type" : BOOLEAN_TYPE,
+            "Types" : BOOLEAN_TYPE,
             "Default" : false
         }
     ]

--- a/aws/components/mta/id.ftl
+++ b/aws/components/mta/id.ftl
@@ -17,17 +17,17 @@
         {
             "Names" : "Prefix",
             "Description" : "Prefix when saving to an S3 bucket",
-            "Type" : STRING_TYPE,
+            "Types" : STRING_TYPE,
             "Default" : ""
         },
         {
             "Names" : "Encryption",
             "Description" : "Details of message encryption",
-            "Type" : STRING_TYPE,
+            "Types" : STRING_TYPE,
             "Children" : [
                 {
                     "Names" : "Enabled",
-                    "Type" : BOOLEAN_TYPE,
+                    "Types" : BOOLEAN_TYPE,
                     "Default" : false
                 }
             ]

--- a/aws/components/router/id.ftl
+++ b/aws/components/router/id.ftl
@@ -8,19 +8,19 @@
             "Children" : [
                 {
                     "Names" : "Enabled",
-                    "Type" : BOOLEAN_TYPE,
+                    "Types" : BOOLEAN_TYPE,
                     "Default" : false
                 },
                 {
                     "Names" : "AccountPrincipals",
                     "Description" : "List of AWS Account Ids or Organisation ARNS to share the resource with",
-                    "Type": ARRAY_OF_STRING_TYPE,
+                    "Types": ARRAY_OF_STRING_TYPE,
                     "Default" : []
                 },
                 {
                     "Names" : "AllowExternalPrincipals",
                     "Description" : "Allow resources to be shared outside of the Organisation",
-                    "Type" : BOOLEAN_TYPE,
+                    "Types" : BOOLEAN_TYPE,
                     "Default" : false
                 }
             ]

--- a/aws/components/secretstore/id.ftl
+++ b/aws/components/secretstore/id.ftl
@@ -5,6 +5,7 @@
     attributes=[
         {
             "Names": "Engine",
+            "Types" : STRING_TYPE,
             "Values" : [ "secretsmanager" ],
             "Default" : "aws:secretsmanager"
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates AWS-specific attributes that are a part of the composite object data model to use the attribute `Types` instead of the singular `Type`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
AWS Provider implementation of hamlet-io/engine#1514

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested successfully alongside corresponding engine PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
