### PR TITLE
Externalnetwork alerts

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -562,7 +562,7 @@
                             reportOK=alert.ReportOk
                             unit=alert.Unit
                             missingData=alert.MissingData
-                            dimensions=getMetricDimensions(alert, stageVariables, monitoredResource, resources)
+                            dimensions=getMetricDimensions(alert, monitoredResource, resources, stageVariables)
                         /]
                     [#break]
                 [/#switch]

--- a/aws/components/externalnetwork/state.ftl
+++ b/aws/components/externalnetwork/state.ftl
@@ -54,16 +54,52 @@
             [#local customerGatewayId = formatResourceId(
                                             AWS_VPNGATEWAY_CUSTOMER_GATEWAY_RESOURCE_TYPE,
                                             core.Id)]
+
+            [#list solution.Links as id,link]
+                [#if link?is_hash]
+
+                    [#local linkTarget = getLinkTarget(occurrence, link) ]
+
+                    [@debug message="Link Target" context=linkTarget enabled=false /]
+
+                    [#if !linkTarget?has_content]
+                        [#continue]
+                    [/#if]
+
+                    [#local linkTargetCore = linkTarget.Core ]
+                    [#local linkTargetConfiguration = linkTarget.Configuration ]
+                    [#local linkTargetResources = linkTarget.State.Resources ]
+                    [#local linkTargetAttributes = linkTarget.State.Attributes ]
+
+                    [#switch linkTargetCore.Type]
+                        [#case NETWORK_ROUTER_COMPONENT_TYPE ]
+
+                            [#switch solution.Engine ]
+                                [#case "SiteToSite" ]
+
+                                    [#local resources += {
+                                        "VpnConnections" : {
+                                            id : {
+                                                "Id" : formatResourceId(
+                                                    AWS_VPNGATEWAY_VPN_CONNECTION_RESOURCE_TYPE,
+                                                    core.Id,
+                                                    linkTarget.Core.Id
+                                                ),
+                                                "Name" : formatName(core.FullName, linkTargetCore.Name),
+                                                "Type" : AWS_VPNGATEWAY_VPN_CONNECTION_RESOURCE_TYPE
+                                            }
+                                        }
+                                    }]
+                                    [#break]
+                            [/#switch]
+                            [#break]
+                    [/#switch]
+                [/#if]
+            [/#list]
+
+
             [#local resources = mergeObjects( resources,
                 {
-                    "vpnConnection" : {
-                        "Id" : formatResourceId(
-                                    AWS_VPNGATEWAY_VPN_CONNECTION_RESOURCE_TYPE,
-                                    core.Id
-                        ),
-                        "Name" : core.FullName,
-                        "Type" : AWS_VPNGATEWAY_VPN_CONNECTION_RESOURCE_TYPE
-                    },
                     "customerGateway" : {
                         "Id" : customerGatewayId,
                         "Name" : core.FullName,

--- a/aws/services/cw/resource.ftl
+++ b/aws/services/cw/resource.ftl
@@ -506,8 +506,8 @@
             [#continue]
         [/#if]
 
-        [@debug message="Rule" context=rule enabled=true /]
-        [#list rule.Destinations.Links?values as link ]
+        [@debug message="Rule" context=rule enabled=false /]
+        [#list (rule.Destinations.Links?values)!{} as link ]
 
             [#if link?is_hash]
                 [#local linkTarget = getLinkTarget(occurrence, link ) ]

--- a/aws/services/vpngateway/resource.ftl
+++ b/aws/services/vpngateway/resource.ftl
@@ -1,5 +1,18 @@
 [#ftl]
 
+[#assign metricAttributes +=
+    {
+        AWS_VPNGATEWAY_VPN_CONNECTION_RESOURCE_TYPE : {
+            "Namespace" : "AWS/VPN",
+            "Dimensions" : {
+                "VpnId" : {
+                    "Output" : ""
+                }
+            }
+        }
+    }
+]
+
 [#macro createVPNCustomerGateway
             id
             name


### PR DESCRIPTION
## Description
Adds support for configuring Cloudwatch alerts on external network connections ( VPN Connections ) as part of the solution deployment 
Includes some minor fixes for alert related code 

## Motivation and Context
Required to monitor the state of a VPN connection which has been having some connection issues 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
