### PR TITLE
fix: permission on globaldb secondary indexes

### DIFF
--- a/aws/components/globaldb/state.ftl
+++ b/aws/components/globaldb/state.ftl
@@ -8,6 +8,11 @@
     [#local key = solution.PrimaryKey ]
     [#local sortKey = solution.SecondaryKey ]
 
+    [#local globalSecondaryIndexes = [] ]
+    [#list solution.SecondaryIndexes!{} as key,value]
+        [#local globalSecondaryIndexes += [value.Name] ]
+    [/#list]
+
     [#assign componentState =
         {
             "Resources" : {
@@ -37,12 +42,35 @@
                     "default" : "consume",
                     "consume" : dynamoDbViewerPermission(
                                     getReference(id, ARN_ATTRIBUTE_TYPE)
+                                ) +
+                                arrayIfContent(
+                                    dynamoDbViewerPermission(
+                                        getReference(id, ARN_ATTRIBUTE_TYPE),
+                                        globalSecondaryIndexes
+                                    ),
+                                    globalSecondaryIndexes
                                 ),
                     "produce" : dynamodbProducePermission(
                                     getReference(id, ARN_ATTRIBUTE_TYPE)
+                                ) +
+                                arrayIfContent(
+                                    dynamodbProducePermission(
+                                        getReference(id, ARN_ATTRIBUTE_TYPE),
+                                        "",
+                                        {},
+                                        globalSecondaryIndexes
+                                    ),
+                                    globalSecondaryIndexes
                                 ),
                     "all"     : dynamodbAllPermission(
                                     getReference(id,ARN_ATTRIBUTE_TYPE)
+                                ) +
+                                arrayIfContent(
+                                    dynamodbAllPermission(
+                                        getReference(id, ARN_ATTRIBUTE_TYPE),
+                                        globalSecondaryIndexes
+                                    ),
+                                    globalSecondaryIndexes
                                 )
                }
             }


### PR DESCRIPTION
## Description
Where a globaldb is defined to have secondary indexes, linking to a globaldb will also grant access to the secondary indexes.

## Motivation and Context
This fix required some refactoring of the dynamodb policy support to correctly support permissions on secondary indexes. The changes were made to be backwards compatible, but this did result in a degree of inconsistency in the ordering of parameters to some methods that previously didn't accept a list of secondary indexes.

## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
