### PR TITLE
fix: better control of opsdata encryption

### DIFF
--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1008,7 +1008,6 @@
               "opsdata": {
                 "Role": "operations",
                 "Encryption" : {
-                  "Enabled" : false,
                   "EncryptionSource" : "LocalService"
                 },
                 "Lifecycles": {

--- a/aws/masterData.json
+++ b/aws/masterData.json
@@ -1006,7 +1006,6 @@
               "opsdata": {
                 "Role": "operations",
                 "Encryption" : {
-                  "Enabled" : false,
                   "EncryptionSource" : "LocalService"
                 },
                 "Lifecycles": {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the `Enabled` attribute for baseline opsdata and rely instead on the explicit `Enabled` attribute in the configuration data.

## Motivation and Context
As there is now an explicit `Enabled` attribute for `baselinedata` encryption with a default of `false`, there is no need for this attribute to be included in the masterdata.

Removing the explicit value from the masterdata will also mean it is controllable via deployment profiles. At present, the masterdata is incorporated into the blueprint so can only be overridden in the solution and not via a deployment profile.

## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
