### PR TITLE
fix: firehose encryption policy

### DIFF
--- a/aws/services/kinesis/resource.ftl
+++ b/aws/services/kinesis/resource.ftl
@@ -191,7 +191,7 @@
                             s3EncryptionKinesisPermission(
                                 cmkKeyId,
                                 bucket.Name,
-                                logPrefix,
+                                bucketPrefix,
                                 region
                             ),
                             []


### PR DESCRIPTION
## Description
Broaden encryption policy to cover both logs and errors.

## Motivation and Context
This also avoids issues with passing an object to the s3Encryption functions which expect the prefix to be a string.

## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
