### PR TITLE
feat(s3): inventory report support

### DIFF
--- a/aws/services/s3/resource.ftl
+++ b/aws/services/s3/resource.ftl
@@ -295,6 +295,39 @@
     ]
 [/#function]
 
+[#function getS3InventoryReportConfiguration
+    inventoryId
+    inventoryFormat
+    destinationBucketArn
+    scheduleFrequency
+    sourcePrefix=""
+    destinationPrefix=""
+    includeVersions=false
+    ]
+
+    [#return
+        {
+            "Destination" : {
+                "BucketAccountId" : accountObject.ProviderId,
+                "BucketArn" : getArn(destinationBucketArn),
+                "Format" : inventoryFormat
+            } +
+            attributeIfContent(
+                "Prefix",
+                destinationPrefix
+            ),
+            "Enabled" : true,
+            "Id" : inventoryId,
+            "IncludedObjectVersions" : includeVersions?then("All", "Current"),
+            "ScheduleFrequency" : scheduleFrequency
+        } +
+        attributeIfContent(
+            "Prefix",
+            sourcePrefix
+        )
+    ]
+[/#function]
+
 [#assign S3_OUTPUT_MAPPINGS =
     {
         REFERENCE_ATTRIBUTE_TYPE : {
@@ -335,6 +368,7 @@
                         replicationConfiguration={}
                         cannedACL=""
                         CORSBehaviours=[]
+                        inventoryReports=[]
                         dependencies=""
                         outputId=""]
 
@@ -474,6 +508,10 @@
                 "BucketEncryption",
                 encrypted,
                 bucketEncryptionConfig
+            ) +
+            attributeIfContent(
+                "InventoryConfigurations",
+                inventoryReports
             )
         tags=getCfTemplateCoreTags("", tier, component, "", false, false, 7)
         outputs=S3_OUTPUT_MAPPINGS


### PR DESCRIPTION
## Description
AWS implementation of s3 inventory reports. Supports using S3 and Baseline data ( baseline buckets ) as destinations

## Motivation and Context
Allows for the generation of S3 bucket listings. Can be used for s3 batch operations or for reporting and auditing 

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Dependent on https://github.com/hamlet-io/engine/pull/1525

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
