### PR TITLE
fix(s3): s3event to lambda fixes

### DIFF
--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -78,8 +78,8 @@
                                 [#break]
 
                             [#case LAMBDA_FUNCTION_COMPONENT_TYPE ]
-                                [#local resourceId = linkTargetResources["lambda"].Id ]
-                                [#local resourceType = linkTargetResources["lambda"].Type ]
+                                [#local resourceId = linkTargetResources["function"].Id ]
+                                [#local resourceType = linkTargetResources["function"].Type ]
 
                                 [#local policyId =
                                     formatS3NotificationPolicyId(
@@ -92,7 +92,7 @@
                                     [@createLambdaPermission
                                         id=policyId
                                         targetId=resourceId
-                                        sourceId=s3Id
+                                        sourceId=formatGlobalArn("s3", s3Name, "")
                                         sourcePrincipal="s3.amazonaws.com"
                                     /]
                                 [/#if]

--- a/aws/services/lambda/resource.ftl
+++ b/aws/services/lambda/resource.ftl
@@ -170,7 +170,7 @@
                 source,
                 {
                     "Principal" : sourcePrincipal,
-                    "SourceArn" : getReference(sourceId, ARN_ATTRIBUTE_TYPE)
+                    "SourceArn" : getArn(sourceId)
                 }
             )
         outputs=LAMBDA_PERMISSION_OUTPUT_MAPPINGS


### PR DESCRIPTION
## Description

Some minor fixes around S3 events triggering lambda 

- Update the S3 event lambda permission configuration to use a formatted Arn rather than a get reference to avoid circular dependencies on the bucket ARN
- Update the resource lookup to determine the lambda Id
- Allow for formatted ARNs in lambda Permissions

## Motivation and Context
template generation was failing 

## How Has This Been Tested?
tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
