### PR TITLE
feat: baselinekey extensions and policy migration

### DIFF
--- a/aws/extensions/cmk_cloudfront_access/extension.ftl
+++ b/aws/extensions/cmk_cloudfront_access/extension.ftl
@@ -1,0 +1,35 @@
+[#ftl]
+
+[@addExtension
+    id="cmk_cloudfront_access"
+    aliases=[
+        "_cmk_cloudfront_access"
+    ]
+    description=[
+        "Grants access to a CMK from the CloudFront Service"
+    ]
+    supportedTypes=[
+        BASELINE_KEY_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_cmk_cloudfront_access_deployment_setup occurrence ]
+
+    [@Policy
+        [
+            getPolicyStatement(
+                [
+                    "kms:GenerateDataKey"
+                ],
+                "*"
+                {
+                     "Service" : "delivery.logs.amazonaws.com"
+                },
+                "",
+                true,
+                "CloudFront Log Delivery access"
+            )
+        ]
+    /]
+
+[/#macro]

--- a/aws/extensions/cmk_s3_access/extension.ftl
+++ b/aws/extensions/cmk_s3_access/extension.ftl
@@ -1,0 +1,35 @@
+[#ftl]
+
+[@addExtension
+    id="cmk_s3_access"
+    aliases=[
+        "_cmk_s3_access"
+    ]
+    description=[
+        "Grants access to a CMK from the S3 Service"
+    ]
+    supportedTypes=[
+        BASELINE_KEY_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_cmk_s3_access_deployment_setup occurrence ]
+
+    [@Policy
+        [
+            getPolicyStatement(
+                [
+                    "kms:GenerateDataKey"
+                ],
+                "*"
+                {
+                    "Service" : "s3.amazonaws.com"
+                },
+                "",
+                true,
+                "S3 Access for Inventory Report storage"
+            )
+        ]
+    /]
+
+[/#macro]

--- a/aws/extensions/cmk_ses_access/extension.ftl
+++ b/aws/extensions/cmk_ses_access/extension.ftl
@@ -1,0 +1,42 @@
+[#ftl]
+
+[@addExtension
+    id="cmk_ses_access"
+    aliases=[
+        "_cmk_ses_access"
+    ]
+    description=[
+        "Allows SES to access KMS for S3 storage"
+    ]
+    supportedTypes=[
+        BASELINE_KEY_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_cmk_ses_access_deployment_setup occurrence ]
+
+    [@Policy
+        [
+            getPolicyStatement(
+                [
+                    "kms:Encrypt",
+                    "kms:GenerateDataKey"
+                ],
+                "*"
+                {
+                    "Service" : "ses.amazonaws.com"
+                },
+                {
+                    "Null": {
+                        "kms:EncryptionContext:aws:ses:rule-name": false,
+                        "kms:EncryptionContext:aws:ses:message-id": false
+                    },
+                    "StringEquals": { "kms:EncryptionContext:aws:ses:source-account" : { "Ref" : "AWS::AccountId" }}
+                },
+                true,
+                "SES Access to CMK"
+            )
+        ]
+    /]
+
+[/#macro]

--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1046,7 +1046,12 @@
                 "Engine": "ssh"
               },
               "cmk": {
-                "Engine": "cmk"
+                "Engine": "cmk",
+                "Extensions" : [
+                    "_cmk_s3_access",
+                    "_cmk_ses_access",
+                    "_cmk_cloudfront_access"
+                ]
               },
               "oai": {
                 "Engine": "oai"


### PR DESCRIPTION
## Description
- AWS implementation of https://github.com/hamlet-io/engine/pull/1533 which adds extension support to the baselinekey component. Initial support is to control the CMK policy which can be defined in extensions like we do for IAM policies. 
- migrates the existing policies with the exception of the root principal over to extensions
- Adds a new extension policy for S3 access when creating Inventory Reports 

## Motivation and Context
Allows for customisable KMS key policies to align with deployment requirements and service integration

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Requires: https://github.com/hamlet-io/engine/pull/153

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
