### PR TITLE
feat(s3): adds bucket policy for inventory

### DIFF
--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -13,6 +13,7 @@
 
     [#local s3Id = resources["bucket"].Id ]
     [#local s3Name = resources["bucket"].Name ]
+    [#local s3Arn = formatGlobalArn("s3", s3Name, "")]
 
     [#local bucketPolicyId = resources["bucketpolicy"].Id ]
 
@@ -263,6 +264,12 @@
 
 
                 [#case S3_COMPONENT_TYPE ]
+                    [#if (linkDirection == "inbound") && (linkRole == "inventorysrc") ]
+                        [#local policyStatements +=
+                            s3InventorySerivcePermssion(s3Name,  linkTargetRoles.Inbound[linkRole].SourceArn)
+                        ]
+                    [/#if]
+
                     [#switch linkRole ]
                         [#case "replicadestination" ]
                             [#local replicationEnabled = true]
@@ -385,12 +392,13 @@
                         getS3InventoryReportConfiguration(
                             inventoryId,
                             inventoryReport.InventoryFormat,
-                            formatGlobalArn("s3", s3Name, ""),
+                            s3Arn,
                             inventoryReport.Schedule
                             inventoryReport.InventoryPrefix,
                             inventoryReport.DestinationPrefix,
                             inventoryReport.IncludeVersions
                         )]]
+                    [#local policyStatements += s3InventorySerivcePermssion(s3Name, s3Arn)]
                 [#break]
 
             [#case "link"]

--- a/aws/components/s3/state.ftl
+++ b/aws/components/s3/state.ftl
@@ -73,6 +73,10 @@
                     "invoke" : {
                         "Principal" : "s3.amazonaws.com",
                         "SourceArn" : getReference(id, ARN_ATTRIBUTE_TYPE)
+                    },
+                    "inventorysrc" : {
+                        "Principal" : "s3.amazonaws.com",
+                        "SourceArn" : getReference(id, ARN_ATTRIBUTE_TYPE)
                     }
                 },
                 "Outbound" : {

--- a/aws/services/s3/policy.ftl
+++ b/aws/services/s3/policy.ftl
@@ -266,3 +266,37 @@
         )
     ]
 [/#function]
+
+
+[#function s3InventorySerivcePermssion sourceBucket destBucket="" sourceAccount={ "Ref" : "AWS::AccountId" } ]
+    [#return
+        getS3Statement(
+            [
+                "s3:PutObject"
+            ],
+            sourceBucket,
+            "*",
+            "",
+            {
+                "Service" : "s3.amazonaws.com"
+            },
+            { } +
+            destBucket?has_content?then(
+                {
+                    "ArnLike" : {
+                        "aws:SourceArn" : getArn(destBucket)
+                    },
+                    "StringEquals" : {
+                        "aws:SourceAccount" : sourceAccount,
+                        "s3:x-amz-acl" : "bucket-owner-full-control"
+                    }
+                },
+                {
+                    "StringEquals" : {
+                        "s3:x-amz-acl" : "bucket-owner-full-control"
+                    }
+                }
+            )
+        )
+    ]
+[/#function]


### PR DESCRIPTION
## Description
Adds the bucket policy required for s3 inventory reports to deliver the reports to the inventory destination bucket

## Motivation and Context
Policy was missing as part of the existing inventory report configuration which meant reports weren't being delivered 

## How Has This Been Tested?
Tested locally and on development deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
