### PR TITLE
fix(baselinekey): update permissions for SES

### DIFF
--- a/aws/extensions/cmk_ses_access/extension.ftl
+++ b/aws/extensions/cmk_ses_access/extension.ftl
@@ -20,7 +20,10 @@
             getPolicyStatement(
                 [
                     "kms:Encrypt",
-                    "kms:GenerateDataKey"
+                    "kms:Decrypt",
+                    "kms:ReEncrypt*",
+                    "kms:GenerateDataKey*",
+                    "kms:DescribeKey"
                 ],
                 "*"
                 {


### PR DESCRIPTION
## Description
Updates the permissions SES receives for KMS key access to align with the various recommendations form aws


## Motivation and Context
AWS has a little too much documentation on the KMS policy required for SES 

- The KMS Docs outline the following policy  - https://docs.aws.amazon.com/kms/latest/developerguide/services-ses.html 
- The SES Docs outline a slightly different policy for large email handling - https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html 

The updated policy puts them together which should in theory be right

## How Has This Been Tested?
Tested locally 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
