### PR TITLE
refactor: migrate to context paths

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -713,7 +713,7 @@
 
             [#local publisherLinks = getLinkTargets(occurrence, publisher.Links )]
 
-            [#local publisherPath = getContentPath( occurrence, publisher.Path )]
+            [#local publisherPath = getContextPath( occurrence, publisher.Path )]
             [#if publisher.UsePathInName ]
                 [#local fileName = formatName( publisherPath, buildRegistry + ".json") ]
                 [#local publisherPath = "" ]

--- a/aws/components/contentnode/setup.ftl
+++ b/aws/components/contentnode/setup.ftl
@@ -11,7 +11,7 @@
     [#local resources = occurrence.State.Resources]
 
     [#local contentNodeId = resources["contentnode"].Id ]
-    [#local pathObject = getContentPath(occurrence) ]
+    [#local pathObject = getContextPath(occurrence) ]
 
     [#if ! (solution.Links?has_content)]
         [@precondition

--- a/aws/components/contentnode/state.ftl
+++ b/aws/components/contentnode/state.ftl
@@ -17,7 +17,7 @@
                 }
             },
             "Attributes" : {
-                "PATH" : getContentPath(occurrence)
+                "PATH" : getContextPath(occurrence)
             },
             "Roles" : {
                 "Inbound" : {},


### PR DESCRIPTION
## Description
AWS provider updates to align with https://github.com/hamlet-io/engine/pull/1537 


## Motivation and Context
Allows for more flexible control over the path attributes and moves to using attribute set for shared config references

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Requires: https://github.com/hamlet-io/engine/pull/1537 

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
