### PR TITLE
feat: whatif input provider

### DIFF
--- a/aws/inputsources/mock/stackoutput.ftl
+++ b/aws/inputsources/mock/stackoutput.ftl
@@ -2,32 +2,5 @@
 
 [#-- Get stack output --]
 [#macro shared_input_mock_stackoutput id="" deploymentUnit="" level="" region="" account=""]
-    [#switch id?split("X")?last ]
-        [#case ARN_ATTRIBUTE_TYPE ]
-            [#local value = "arn:aws:iam::123456789012:mock/" + id ]
-            [#break]
-        [#case URL_ATTRIBUTE_TYPE ]
-            [#local value = "https://mock.local/" + id ]
-            [#break]
-        [#case IP_ADDRESS_ATTRIBUTE_TYPE ]
-            [#local value = "123.123.123.123" ]
-            [#break]
-        [#case REGION_ATTRIBUTE_TYPE ]
-            [#local value = "ap-mock-1" ]
-            [#break]
-        [#default]
-            [#local value = formatId( "##MockOutput", id, "##") ]
-    [/#switch]
-
-    [@addStackOutputs 
-        [
-            {
-                "Account" : account,
-                "Region" : region,
-                "Level" : level,
-                "DeploymentUnit" : deploymentUnit,
-                id : value
-            }
-        ]
-    /]
+    [@addStackOutputs getAWSCFMockStackOutputs(id, deploymentUnit, level, region, account) /]
 [/#macro]

--- a/aws/inputsources/shared/stackoutput.ftl
+++ b/aws/inputsources/shared/stackoutput.ftl
@@ -1,0 +1,33 @@
+[#ftl]
+
+[#-- AWS Mock Output --]
+[#function getAWSCFMockStackOutputs id="" deploymentUnit="" level="" region="" account=""]
+    [#switch id?split("X")?last ]
+        [#case ARN_ATTRIBUTE_TYPE ]
+            [#local value = "arn:aws:iam::123456789012:mock/" + id ]
+            [#break]
+        [#case URL_ATTRIBUTE_TYPE ]
+            [#local value = "https://mock.local/" + id ]
+            [#break]
+        [#case IP_ADDRESS_ATTRIBUTE_TYPE ]
+            [#local value = "123.123.123.123" ]
+            [#break]
+        [#case REGION_ATTRIBUTE_TYPE ]
+            [#local value = "ap-mock-1" ]
+            [#break]
+        [#default]
+            [#local value = formatId( "##MockOutput", id, "##") ]
+    [/#switch]
+
+    [#return
+        [
+            {
+                "Account" : account,
+                "Region" : region,
+                "Level" : level,
+                "DeploymentUnit" : deploymentUnit,
+                id : value
+            }
+        ]
+    ]
+[/#function]

--- a/aws/inputsources/whatif/stackoutput.ftl
+++ b/aws/inputsources/whatif/stackoutput.ftl
@@ -1,0 +1,26 @@
+[#ftl]
+
+[#-- Get stack output --]
+[#function aws_input_whatif_stackoutput_filter outputFilter ]
+    [#return {
+        "Account" : (outputFilter.Account)!accountObject.ProviderId,
+        "Region" : outputFilter.Region,
+        "DeploymentUnit" : outputFilter.DeploymentUnit
+    }]
+[/#function]
+
+[#macro aws_input_whatif_stackoutput id="" deploymentUnit="" level="" region="" account=""]
+
+    [#local compositeOutput = getCFCompositeStackOutputs(id, deploymentUnit, level, region, account) ]
+
+    [@debug message="compositeOutput" context=compositeOutput enabled=true /]
+
+    [#if compositeOutput?has_content ]
+        [@addStackOutputs compositeOutput /]
+    [#else]
+        [#local mockOutput = getAWSCFMockStackOutputs(id, deploymentUnit, level, region, account)]
+        [@addStackOutputs mockOutput /]
+        [@debug message="MockedOutput" context=mockOutput enabled=true /]
+    [/#if]
+
+[/#macro]


### PR DESCRIPTION
## Description
AWS implementation of https://github.com/hamlet-io/engine/pull/1538 

## Motivation and Context
Adds AWS support for the whatif provider which combines the mock and composite provider behaviour to work on existing CMDBs

## How Has This Been Tested?
Tested locally 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Requires https://github.com/hamlet-io/engine/pull/1538 

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
