### PR TITLE
fix(apigateway): throttle handling for apigw

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -364,7 +364,7 @@
             [#list definitionsObject[core.Id].paths as path,pathConfig]
                 [#list pathConfig?keys as verb]
                     [#list openapiIntegrations.Patterns![] as pattern]
-                        [#if path?matches(pattern.Path) && verb?matches(pattern.Verb)]
+                        [#if path?matches( (pattern.Path)!"" ) && verb?matches( (pattern.Verb)!"" )]
                             [#if pattern.Throttling?has_content]
                                 [#local methodSettings +=
                                 [


### PR DESCRIPTION
## Description
Workaround for #237 
Minor fix to allow for a missing path or verb when setting up API GW throttling

## Motivation and Context
Template generation failing

## How Has This Been Tested?
Tested locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
