### PR TITLE
feat(modules): add no_master modules

### DIFF
--- a/aws/modules/no_master_resourcesets/module.ftl
+++ b/aws/modules/no_master_resourcesets/module.ftl
@@ -1,0 +1,59 @@
+[#ftl]
+
+[@addModule
+    name="no_master_resourcesets"
+    description="Disables the resource set configuration provided by the masterdata"
+    provider=AWS_PROVIDER
+    properties=[]
+/]
+
+[#macro aws_module_no_master_resourcesets ]
+    [@loadModule
+        blueprint={
+            "DeploymentGroups": {
+                "segment": {
+                    "ResourceSets": {
+                        "iam": {
+                            "Enabled": false
+                        },
+                        "lg": {
+                            "Enabled": false
+                        },
+                        "eip": {
+                            "Enabled": false
+                        },
+                        "s3": {
+                            "Enabled": false
+                        },
+                        "cmk": {
+                            "Enabled": false
+                        }
+                    }
+                },
+                "solution": {
+                    "ResourceSets": {
+                        "eip": {
+                            "Enabled": false
+                        },
+                        "iam": {
+                            "Enabled": false
+                        },
+                        "lg": {
+                            "Enabled": false
+                        }
+                    }
+                },
+                "application": {
+                    "ResourceSets": {
+                        "iam": {
+                            "Enabled": false
+                        },
+                        "lg": {
+                            "Enabled": false
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/aws/modules/no_master_vpc/module.ftl
+++ b/aws/modules/no_master_vpc/module.ftl
@@ -1,0 +1,46 @@
+[#ftl]
+
+[@addModule
+    name="no_master_vpc"
+    description="Disables the vpc added to the solution from masterdata"
+    provider=AWS_PROVIDER
+    properties=[]
+/]
+
+[#macro aws_module_no_master_vpc ]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "mgmt" : {
+                    "Components" : {
+                        "vpc" : {
+                            "network" : {
+                                "Enabled" : false
+                            }
+                        },
+                        "igw" : {
+                            "gateway" : {
+                                "Enabled" : false
+                            }
+                        },
+                        "vpcendpoint" : {
+                            "gateway" : {
+                                "Enabled" : false
+                            }
+                        },
+                        "nat" : {
+                            "gateway" : {
+                                "Enabled" : false
+                            }
+                        },
+                        "ssh" : {
+                            "bastion" : {
+                                "Enabled" : false
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Description
Adds two new modules to the AWS provider 
- no_master_vpc - Which disables all VPC related components added by the masterdata
- no_master_resourcesets - Which disables the resource sets added by the masterdata

## Motivation and Context
The AWS master data currently creates a collection of deployments for VPC and resource sets. In simpler deployments these are often not required. These modules simply disable what is added as deployments from the master data. This maintains compatibility with existing deployments

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
