### PR TITLE
feat(userpool): adds constraints for schema

### DIFF
--- a/aws/components/userpool/setup.ftl
+++ b/aws/components/userpool/setup.ftl
@@ -173,7 +173,8 @@
                             key,
                             schemaAttribute.DataType,
                             schemaAttribute.Mutable,
-                            schemaAttribute.Required
+                            schemaAttribute.Required,
+                            schemaAttribute.Constraints
         )]
     [/#list]
 

--- a/aws/services/cognito/resource.ftl
+++ b/aws/services/cognito/resource.ftl
@@ -107,15 +107,58 @@
     ]
 [/#function]
 
-[#function getUserPoolSchemaObject name, datatype, mutable, required]
+[#function getUserPoolSchemaObject name datatype mutable required constraints ]
+
+    [#local schema =
+        {
+            "Name" : name,
+            "AttributeDataType" : datatype,
+            "Mutable" : mutable,
+            "Required" : required
+        }]
+
+    [#switch datatype?lower_case ]
+        [#case "string"]
+
+            [#if constraints.String.MinLength > 0 ]
+                [#local schema += {
+                    "StringAttributeConstraints" : {
+                        "MinLength" : (constraints.String.MinLength)?c
+                    }
+                }]
+            [/#if]
+
+            [#if constraints.String.MaxLength > 0 ]
+                [#local schema += {
+                    "StringAttributeConstraints" : {
+                        "MaxLength" : (constraints.String.MaxLength)?c
+                    }
+                }]
+            [/#if]
+            [#break]
+
+        [#case "number"]
+            [#if ((constraints.Number.MinValue)!"")?has_content ]
+                [#local schema += {
+                    "StringAttributeConstraints" : {
+                        "MinValue" : (constraints.Number.MinValue)?c
+                    }
+                }]
+            [/#if]
+
+            [#if ((constraints.Number.MaxValue)!"")?has_content ]
+                [#local schema += {
+                    "StringAttributeConstraints" : {
+                        "MaxValue" : (constraints.Number.MaxValue)?c
+                    }
+                }]
+            [/#if]
+            [#break]
+    [/#switch]
+
     [#return
         [
-            {
-                "Name" : name,
-                "AttributeDataType" : datatype,
-                "Mutable" : mutable,
-                "Required" : required
-            }
+            schema
         ]
     ]
 [/#function]

--- a/aws/services/cognito/resource.ftl
+++ b/aws/services/cognito/resource.ftl
@@ -154,6 +154,13 @@
                 }]
             [/#if]
             [#break]
+
+        [#default]
+            [@fatal
+                message="Unexpected data type for cognito userpool schema attribute constraints"
+                context=datatype
+            /]
+            [#break]
     [/#switch]
 
     [#return


### PR DESCRIPTION
## Description

Adds support for configuring attribute constraints on userpool schema
components.

If not provided the default action is to use the AWS specified defaults

## Motivation and Context
closes https://github.com/hamlet-io/engine-plugin-aws/issues/228

## How Has This Been Tested?
Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] Requires: https://github.com/hamlet-io/engine/pull/1564

## Checklist:
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
