### PR TITLE
refactor: bastion ipaddressgroups on component def

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -260,7 +260,7 @@
                         "Ports" : [ "ssh" ],
                         "IPAddressGroups" :
                             sshEnabled?then(
-                                (segmentObject.Bastion.IPAddressGroups)!(segmentObject.IPAddressGroups)![],
+                                (solution.IPAddressGroups)!(segmentObject.Bastion.IPAddressGroups)!(segmentObject.IPAddressGroups)![],
                                 []
                             ),
                         "Description" : "Bastion Access Groups"

--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -260,7 +260,11 @@
                         "Ports" : [ "ssh" ],
                         "IPAddressGroups" :
                             sshEnabled?then(
-                                (solution.IPAddressGroups)!(segmentObject.Bastion.IPAddressGroups)!(segmentObject.IPAddressGroups)![],
+                                combineEntities(
+                                    (segmentObject.Bastion.IPAddressGroups)!(segmentObject.IPAddressGroups)![],
+                                    (solution.IPAddressGroups)![],
+                                    UNIQUE_COMBINE_BEHAVIOUR
+                                ),
                                 []
                             ),
                         "Description" : "Bastion Access Groups"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Previously in order to configure ip access to a bastion
the configuration was applied via the segment object.

This change aligns the bastion component with other IP
address group implementations on the component in the
solution.

Existing functionality is maintained, but deemed deprecated

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes hamlet-io/engine#1559

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
