### PR TITLE
bugfix: relocate configuration attribute in masterdata

### DIFF
--- a/aws/inputsources/shared/masterdata.ftl
+++ b/aws/inputsources/shared/masterdata.ftl
@@ -1202,8 +1202,7 @@
                 "Versions": {
                   "v1": {
                     "deployment:Unit" : "cfredirect-v1",
-                    "Enabled": false,
-                    "Extensions": [ "_cfredirect-v1" ]
+                    "Enabled": false
                   }
                 }
               }
@@ -1223,6 +1222,7 @@
                   "AppData": false,
                   "AppPublic": false
                 },
+                "Extensions": [ "_cfredirect-v1" ],
                 "PredefineLogGroup": false
               }
             }

--- a/aws/masterData.json
+++ b/aws/masterData.json
@@ -1205,8 +1205,7 @@
                     "DeploymentUnits": [
                       "cfredirect-v1"
                     ],
-                    "Enabled": false,
-                    "Extensions": [ "_cfredirect-v1" ]
+                    "Enabled": false
                   }
                 }
               }
@@ -1226,6 +1225,7 @@
                   "AppData": false,
                   "AppPublic": false
                 },
+                "Extensions": [ "_cfredirect-v1" ],
                 "PredefineLogGroup": false
               }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes incorrect placement of the lambda function extension attribute in masterdata.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Incorrect placement was discovered through the testing of the validation entrance [here](https://github.com/hamlet-io/engine/pull/1548)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Validates

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
