### PR TITLE
feat(sqs): ordering configuration for queues

### DIFF
--- a/aws/components/sqs/setup.ftl
+++ b/aws/components/sqs/setup.ftl
@@ -24,20 +24,6 @@
         [#local sqsPolicyId = resources["queuePolicy"].Id ]
         [#local queuePolicyStatements = [] ]
 
-        [#if dlqRequired ]
-            [#local dlqId = resources["dlq"].Id ]
-            [#local dlqName = resources["dlq"].Name ]
-
-            [#local queueIds += [ dlqId ]]
-            [@createSQSQueue
-                id=dlqId
-                name=dlqName
-                retention=1209600
-                receiveWait=20
-            /]
-        [/#if]
-
-
         [#local fifoQueue = false]
 
         [#switch solution.Ordering ]
@@ -57,6 +43,20 @@
                     }
                 /]
         [/#switch]
+
+        [#if dlqRequired ]
+            [#local dlqId = resources["dlq"].Id ]
+            [#local dlqName = resources["dlq"].Name ]
+
+            [#local queueIds += [ dlqId ]]
+            [@createSQSQueue
+                id=dlqId
+                name=dlqName
+                retention=1209600
+                receiveWait=20
+                fifoQueue=fifoQueue
+            /]
+        [/#if]
 
         [@createSQSQueue
             id=sqsId

--- a/aws/components/sqs/setup.ftl
+++ b/aws/components/sqs/setup.ftl
@@ -96,7 +96,6 @@
                 [#local resourceDimensions = []]
                 [#if getCLODeploymentUnitAlternative() == "replace1" ]
 
-                    [@debug message="SQSMonResource" context=monitoredResource enabled=true /]
                     [#switch monitoredResource.Id ]
                         [#case resources["queue"].Id ]
                             [#local resourceDimensions = [

--- a/aws/components/sqs/setup.ftl
+++ b/aws/components/sqs/setup.ftl
@@ -19,7 +19,7 @@
         [#local sqsName = resources["queue"].Name ]
 
         [#-- override the Id ane Name for replacement --]
-        [#if ((commandLineOptions.Deployment.Unit.Alternative)!"") == "replace1" ]
+        [#if getCLODeploymentUnitAlternative() == "replace1" ]
             [#local sqsId = resources["queue"].ReplaceId ]
             [#local sqsName = resources["queue"].ReplaceName ]
         [/#if]
@@ -55,7 +55,7 @@
             [#local dlqName = resources["dlq"].Name ]
 
             [#-- override the Id ane Name for replacement --]
-            [#if ((commandLineOptions.Deployment.Unit.Alternative)!"") == "replace1" ]
+            [#if getCLODeploymentUnitAlternative() == "replace1" ]
                 [#local dlqId = resources["dlq"].ReplaceId ]
                 [#local dlqName = resources["dlq"].ReplaceName ]
             [/#if]
@@ -94,7 +94,7 @@
             [#list monitoredResources as name,monitoredResource ]
 
                 [#local resourceDimensions = []]
-                [#if ((commandLineOptions.Deployment.Unit.Alternative)!"") == "replace1" ]
+                [#if getCLODeploymentUnitAlternative() == "replace1" ]
 
                     [@debug message="SQSMonResource" context=monitoredResource enabled=true /]
                     [#switch monitoredResource.Id ]

--- a/aws/components/sqs/state.ftl
+++ b/aws/components/sqs/state.ftl
@@ -31,31 +31,32 @@
         [#local solution = occurrence.Configuration.Solution]
 
         [#local id = formatResourceId(AWS_SQS_RESOURCE_TYPE, core.Id) ]
+        [#local replaceId = formatId(id, "replace")]
         [#local name = core.FullName ]
+        [#local replaceName = formatName(name, "replace")]
 
         [#local dlqId = formatDependentResourceId(AWS_SQS_RESOURCE_TYPE, id, "dlq") ]
+        [#local dlqReplaceId = formatId(dlqId, "replace")]
         [#local dlqName = formatName(name, "dlq")]
-
-        [#-- override the Id ane Name for replacement --]
-        [#if ((commandLineOptions.Deployment.Unit.Alternative)!"") == "replace1" ]
-            [#local id = formatId(id, "replace" ) ]
-            [#local name = formatName(name, "replace")]
-
-            [#local dlqId = formatId(dlqId, "replace")]
-            [#local dlqName = formatName(dlqName, "replace")]
-        [/#if]
+        [#local dlqReplaceName = formatName(dlqName, "replace")]
 
         [#-- fifo Queues require specific naming --]
         [#switch solution.Ordering ]
             [#case "FirstInFirstOut" ]
                 [#local fifoSuffix = ".fifo" ]
                 [#local name = name?truncate_c(80 - fifoSuffix?length, '')?ensure_ends_with(fifoSuffix) ]
+                [#local replaceName = replaceName?truncate_c(80 - fifoSuffix?length, '')?ensure_ends_with(fifoSuffix) ]
+
                 [#local dlqName = dlqName?truncate_c( (80 - (fifoSuffix)?length), '')?ensure_ends_with(fifoSuffix )]
+                [#local dlqReplaceName = dlqReplaceName?truncate_c( (80 - (fifoSuffix)?length), '')?ensure_ends_with(fifoSuffix )]
                 [#break]
 
             [#default]
                 [#local name = name?truncate_c(80) ]
+                [#local replaceName = replaceName?truncate_c(80)]
+
                 [#local dlqName = dlqName?truncate_c(80) ]
+                [#local dlqReplaceName = dlqReplaceName?truncate_c(80)]
         [/#switch]
 
         [#local dlqRequired =
@@ -67,7 +68,9 @@
                 "Resources" : {
                     "queue" : {
                         "Id" : id,
+                        "ReplaceId" : replaceId,
                         "Name" : name,
+                        "ReplaceName" : replaceName,
                         "Type" : AWS_SQS_RESOURCE_TYPE,
                         "Monitored" : true
                     },
@@ -80,7 +83,9 @@
                     {
                         "dlq" : {
                             "Id" : dlqId,
+                            "ReplaceId" : dlqReplaceId,
                             "Name" : dlqName,
+                            "ReplaceName" : dlqReplaceName,
                             "Type" : AWS_SQS_RESOURCE_TYPE,
                             "Monitored" : true
                         }

--- a/aws/components/sqs/state.ftl
+++ b/aws/components/sqs/state.ftl
@@ -36,6 +36,28 @@
         [#local dlqId = formatDependentResourceId(AWS_SQS_RESOURCE_TYPE, id, "dlq") ]
         [#local dlqName = formatName(name, "dlq")]
 
+        [#-- override the Id ane Name for replacement --]
+        [#if ((commandLineOptions.Deployment.Unit.Alternative)!"") == "replace1" ]
+            [#local id = formatId(id, "replace" ) ]
+            [#local name = formatName(name, "replace")]
+
+            [#local dlqId = formatId(dlqId, "replace")]
+            [#local dlqName = formatName(dlqName, "replace")]
+        [/#if]
+
+        [#-- fifo Queues require specific naming --]
+        [#switch solution.Ordering ]
+            [#case "FirstInFirstOut" ]
+                [#local fifoSuffix = ".fifo" ]
+                [#local name = name?truncate_c(80 - fifoSuffix?length, '')?ensure_ends_with(fifoSuffix) ]
+                [#local dlqName = dlqName?truncate_c( (80 - (fifoSuffix)?length), '')?ensure_ends_with(fifoSuffix )]
+                [#break]
+
+            [#default]
+                [#local name = name?truncate_c(80) ]
+                [#local dlqName = dlqName?truncate_c(80) ]
+        [/#switch]
+
         [#local dlqRequired =
             isPresent(solution.DeadLetterQueue) ||
             ((environmentObject.Operations.DeadLetterQueue.Enabled)!false)]

--- a/aws/services/sqs/resource.ftl
+++ b/aws/services/sqs/resource.ftl
@@ -37,7 +37,7 @@
     }
 /]
 
-[#macro createSQSQueue id name delay="" maximumSize="" retention="" receiveWait="" visibilityTimout="" dlq="" dlqReceives=1 dependencies=""]
+[#macro createSQSQueue id name delay="" maximumSize="" retention="" receiveWait="" visibilityTimout="" dlq="" dlqReceives=1 fifoQueue=false dependencies=""]
     [@cfResource
         id=id
         type="AWS::SQS::Queue"
@@ -56,7 +56,12 @@
                   "deadLetterTargetArn" : getReference(dlq, ARN_ATTRIBUTE_TYPE),
                   "maxReceiveCount" : dlqReceives
                 }) +
-            attributeIfContent("VisibilityTimeout", visibilityTimout)
+            attributeIfContent("VisibilityTimeout", visibilityTimout) +
+            attributeIfTrue(
+                "FifoQueue",
+                fifoQueue,
+                fifoQueue
+            )
         outputs=SQS_OUTPUT_MAPPINGS
         dependencies=dependencies
     /]


### PR DESCRIPTION
## Description

Adds support for enabling FIFO queues on SQS queues

- Adds the basic configuration parameter to the CFN resources
- Changing from standard queue to FIFO requires replacement and named
queues must include renaming. So added replace alternatives and naming to handle replacing when there is only the queue resource in the template ( can't remove it since that can make the template empty ) 
- Truncates the queue name to ensure that the special fifo suffix .fifo is always included in the name

## Motivation and Context

Add support for handling different queue ordering processes

closes https://github.com/hamlet-io/engine-plugin-aws/issues/257

## How Has This Been Tested?

Tested locally and on test deployment

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
