### PR TITLE
feat: Cloudformation parameter support

### DIFF
--- a/aws/deploymentframeworks/cf/output.ftl
+++ b/aws/deploymentframeworks/cf/output.ftl
@@ -240,6 +240,67 @@
     [/#list]
 [/#macro]
 
+[#macro cfParameter
+            id
+            type
+            default=""
+            description=""
+            allowedPattern=""
+            allowedValues=""
+            constraintDescription=""
+            maxLength=""
+            maxValue=""
+            minLength=""
+            minValue=""
+    ]
+
+    [@mergeWithJsonOutput
+        name="parameters"
+        content=
+            {
+                id : {
+                    "Type" : type
+                } +
+                attributeIfContent(
+                    "AllowedPattern",
+                    allowedPattern
+                ) +
+                attributeIfContent(
+                    "AllowedValues",
+                    allowedValues
+                ) +
+                attributeIfContent(
+                    "ConstraintDescription",
+                    constraintDescription
+                ) +
+                attributeIfContent(
+                    "Default",
+                    default
+                ) +
+                attributeIfContent(
+                    "Description",
+                    description
+                ) +
+                attributeIfContent(
+                    "MaxLength",
+                    maxLength
+                ) +
+                attributeIfContent(
+                    "MaxValue",
+                    maxValue
+                ) +
+                attributeIfContent(
+                    "MinLength",
+                    minLength
+                ) +
+                attributeIfContent(
+                    "MinValue",
+                    minValue
+                )
+            }
+    /]
+[/#macro]
+
 [#function cf_output_resource level="" include=""]
 
     [@setOutputFileProperties format="json" /]
@@ -271,7 +332,11 @@
                 "Outputs" :
                     getOutputContent("outputs") +
                     getCFTemplateCoreOutputs()
-            }
+            } +
+            attributeIfContent(
+                "Parameters",
+                getOutputContent("parameters")
+            )
         ]
     [/#if]
     [#return {}]
@@ -279,6 +344,7 @@
 
 
 [#-- Initialise the possible outputs to make sure they are available to all steps --]
+[@initialiseJsonOutput name="parameters" /]
 [@initialiseJsonOutput name="resources" /]
 [@initialiseJsonOutput name="outputs" /]
 

--- a/aws/services/ssm/resource.ftl
+++ b/aws/services/ssm/resource.ftl
@@ -205,3 +205,42 @@
             clientContext
         )]
 [/#function]
+
+[#-- SSM Parameter Resolution in CFN Templates --]
+[#-- Allows for Cloudformation to return parameter data from SSM Paramter Store --]
+
+[#macro addCFNSSMStringParam id default="" description="" ]
+    [@cfParameter
+        id=id
+        type="AWS::SSM::Parameter::Value<String>"
+        default=default
+        description=description
+    /]
+[/#macro]
+
+[#macro addCFNSSMStringListParam id default="" description="" ]
+    [@cfParameter
+        id=id
+        type="AWS::SSM::Parameter::Value<List<String>>"
+        default=default
+        description=description
+    /]
+[/#macro]
+
+[#macro addCFNSSMCommaListParam id default="" description="" ]
+    [@cfParameter
+        id=id
+        type="AWS::SSM::Parameter::Value<CommaDelimitedList>"
+        default=default
+        description=description
+    /]
+[/#macro]
+
+[#macro addCFNSSMEC2ImageParam id default="" description="" ]
+    [@cfParameter
+        id=id
+        type="AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
+        default=default
+        description=description
+    /]
+[/#macro]


### PR DESCRIPTION
## Description

Adds support for adding parameters to cloudformation templates

## Motivation and Context

The main reason for adding this is to support Public SSM Parameter Store
entries which can only be provided to templates via parameters

## How Has This Been Tested?

Tested locally 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
