### PR TITLE
feat(baseline): add invoke inbound policy for data

### DIFF
--- a/aws/components/baseline/state.ftl
+++ b/aws/components/baseline/state.ftl
@@ -137,7 +137,12 @@
                 "FQDN" : getExistingReference(bucketId, DNS_ATTRIBUTE_TYPE)
             },
             "Roles" : {
-                "Inbound" : {},
+                "Inbound" : {
+                    "invoke" : {
+                        "Principal" : "s3.amazonaws.com",
+                        "SourceArn" : getReference(bucketId, ARN_ATTRIBUTE_TYPE)
+                    }
+                },
                 "Outbound" : {
                     "datafeed" : s3KinesesStreamPermission(bucketId) + s3AllEncryptionPolicy
                 }


### PR DESCRIPTION
## Description

Adds the policy details to allow for inbound links to s3 based data buckets

## Motivation and Context

Allows for inbound links from resources which S3 based components can invoke such as sqs queues which have a single policy document

## How Has This Been Tested?

Tested locally and on active deployment

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
