### PR TITLE
fix(template): change to virtual hosted s3 path

### DIFF
--- a/aws/components/template/setup.ftl
+++ b/aws/components/template/setup.ftl
@@ -16,6 +16,7 @@
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"], NAME_ATTRIBUTE_TYPE )]
+    [#local operationsBucketFQDN = getExistingReference(baselineComponentIds["OpsData"], DNS_ATTRIBUTE_TYPE)]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"], NAME_ATTRIBUTE_TYPE )]
     [#local kmsKeyArn = getExistingReference(baselineComponentIds["Encryption"], ARN_ATTRIBUTE_TYPE )]
 
@@ -24,12 +25,16 @@
         "templates"
     )]
 
-    [#local templateRootFileUrl = formatRelativePath(
-                                    "https://s3.amazonaws.com/",
-                                    operationsBucket,
-                                    templatePath,
-                                    solution.RootFile
-                                )]
+    [#local templateRootFileUrl = {
+                                    "Fn::Join" : [
+                                        "/",
+                                        [
+                                            "https://${operationsBucketFQDN}"
+                                            templatePath,
+                                            solution.RootFile
+                                        ]
+                                    ]
+                                }]
 
     [#local buildReference = getOccurrenceBuildReference(occurrence)]
     [#local buildUnit = getOccurrenceBuildUnit(occurrence)]


### PR DESCRIPTION
## Description

Move to using the virtual hosted s3 url path instead of the path style s3 sytnax which is on the way to deprecation

## Motivation and Context

AWS are planning on deprecating the path syntax for s3 links and move to virtual host paths instead. This also makes the error returned from cloudformation slightly different ( moves from a weird service error to a 403 ) when the file can't be found

## How Has This Been Tested?

Tested locally 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
