### PR TITLE
refactor: composite template inclusion

### DIFF
--- a/aws/deploymentframeworks/cf/output.ftl
+++ b/aws/deploymentframeworks/cf/output.ftl
@@ -307,7 +307,14 @@
 
     [#-- Resources --]
     [#if include?has_content]
-        [#include include?ensure_starts_with("/")]
+        [#if include?contains("[#ftl]") ]
+            [#-- treat as interpretable content --]
+            [#local inlineInclude = include?interpret]
+            [@inlineInclude /]
+        [#else]
+            [#-- assume a filename --]
+            [#include include?ensure_starts_with("/") ]
+        [/#if]
     [#else]
         [@processFlows
             level=level

--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -971,7 +971,7 @@
                     ]
                 }
             },
-            "CompositeTemplate": "accountList"
+            "CompositeTemplate": "accountTemplate"
         },
         "segment": {
             "ResourceSets": {


### PR DESCRIPTION
## Description
Support composite templates to be provided via a filename or via the content being directly included. Switch to the content based input variable for composite accounts rather than the filename based variable.

## Motivation and Context
As part of moving to dynamic input loading, reliance on pre-assembled content needs to be removed. This change starts the process by using the `?interpret` builtin internally to avoid use of the `[#include]` directive if the content appears to be freemarker markup.


## How Has This Been Tested?
Local template generation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
