### PR TITLE
feat:  ComputeTask and ImageSource Support

### DIFF
--- a/aws/attributesets/attributeset.ftl
+++ b/aws/attributesets/attributeset.ftl
@@ -2,4 +2,4 @@
 
 [#assign AWS_OPERATINGSYSTEM_ATTRIBUTESET_TYPE = "aws_operatingsystem" ]
 [#assign AWS_COMPUTEIMAGE_ATTRIBUTESET_TYPE = "aws_computeimage" ]
-[#assign AWS_ECS_COMPUTEIMAGE_ATTRIBUTESET_TYPE = "aws_ecs_comptueimage"]
+[#assign AWS_ECS_COMPUTEIMAGE_ATTRIBUTESET_TYPE = "aws_ecs_computeimage"]

--- a/aws/attributesets/attributeset.ftl
+++ b/aws/attributesets/attributeset.ftl
@@ -1,0 +1,5 @@
+[#ftl]
+
+[#assign AWS_OPERATINGSYSTEM_ATTRIBUTESET_TYPE = "aws_operatingsystem" ]
+[#assign AWS_COMPUTEIMAGE_ATTRIBUTESET_TYPE = "aws_computeimage" ]
+[#assign AWS_ECS_COMPUTEIMAGE_ATTRIBUTESET_TYPE = "aws_ecs_comptueimage"]

--- a/aws/attributesets/aws_computeimage/id.ftl
+++ b/aws/attributesets/aws_computeimage/id.ftl
@@ -1,0 +1,41 @@
+[#ftl]
+
+[@addExtendedAttributeSet
+    type=AWS_COMPUTEIMAGE_ATTRIBUTESET_TYPE
+    baseType=COMPUTEIMAGE_ATTRIBUTESET_TYPE
+    pluralType="AWSComputeImages"
+    provider=AWS_PROVIDER
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "AWS Specific overrides to source compute images"
+        }]
+    attributes=[
+        {
+            "Names" : "Source",
+            "Values" : [ "AMI", "SSMParam" ]
+        },
+        {
+            "Names" : "Source:AMI",
+            "Description" : "Use an explicit AMI for the image ",
+            "Children" : [
+                {
+                    "Names" : "ImageId",
+                    "Types" : STRING_TYPE
+                }
+            ]
+        },
+        {
+            "Names" : "Source:SSMParam",
+            "Description" : "Lookup the image Id using the SSM ParameterStore",
+            "Children" : [
+                {
+                    "Names" : "Name",
+                    "Description" : "The name of the parameter to lookup",
+                    "Types" : STRING_TYPE,
+                    "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
+                }
+            ]
+        }
+    ]
+/]

--- a/aws/attributesets/aws_ecs_computeimage/id.ftl
+++ b/aws/attributesets/aws_ecs_computeimage/id.ftl
@@ -1,0 +1,37 @@
+[#ftl]
+
+[@addExtendedAttributeSet
+    type=AWS_ECS_COMPUTEIMAGE_ATTRIBUTESET_TYPE
+    baseType=AWS_COMPUTEIMAGE_ATTRIBUTESET_TYPE
+    pluralType="AWSECSComputeImages"
+    provider=AWS_PROVIDER
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "AWS ECS Specific overrides to source compute images"
+        }]
+    attributes=[
+        {
+            "Names" : "Source:Reference",
+            "Children" : [
+                {
+                    "Names" : "OS",
+                    "Default" : "Centos"
+                },
+                {
+                    "Names" : "Type",
+                    "Default" : "ECS"
+                }
+            ]
+        },
+        {
+            "Names" : "Source:SSMParam",
+            "Children" : [
+                {
+                    "Names" : "Name",
+                    "Default" : "/aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id"
+                }
+            ]
+        }
+    ]
+/]

--- a/aws/attributesets/aws_operatingsystem/id.ftl
+++ b/aws/attributesets/aws_operatingsystem/id.ftl
@@ -1,0 +1,27 @@
+[#ftl]
+
+[@addExtendedAttributeSet
+    type=AWS_OPERATINGSYSTEM_ATTRIBUTESET_TYPE
+    baseType=OPERATINGSYSTEM_ATTRIBUTESET_TYPE
+    pluralType="AWSOperatingSystems"
+    provider=AWS_PROVIDER
+    properties=[
+        {
+                "Type"  : "Description",
+                "Value" : "Standard Configuration options to define an operating system"
+        }]
+    attributes=[
+        {
+            "Names" : "Family",
+            "Default" : "linux"
+        },
+        {
+            "Names" : "Distribution",
+            "Default": "awslinux"
+        },
+        {
+            "Names" : "MajorVersion",
+            "Default" : "1"
+        }
+    ]
+/]

--- a/aws/components/bastion/id.ftl
+++ b/aws/components/bastion/id.ftl
@@ -24,33 +24,30 @@
             "Names" : "ComputeInstance",
             "Children" : [
                 {
+                    "Names" : "OperatingSystem",
+                    "AttributeSet" : AWS_OPERATINGSYSTEM_ATTRIBUTESET_TYPE
+                },
+                {
                     "Names" : "Image",
+                    "AttributeSet" : AWS_COMPUTEIMAGE_ATTRIBUTESET_TYPE
+                },
+                {
+                    "Names" : "ComputeTasks",
                     "Children" : [
                         {
-                            "Names" : "Source",
-                            "Description" : "The source of the image",
-                            "Values" : [ "AMI", "SSMParam" ]
-                        },
-                        {
-                            "Names" : "Source:AMI",
-                            "Description" : "Use an explicit AMI for the image ",
-                            "Children" : [
-                                {
-                                    "Names" : "ImageId",
-                                    "Types" : STRING_TYPE
-                                }
-                            ]
-                        },
-                        {
-                            "Names" : "Source:SSMParam",
-                            "Description" : "Lookup the image Id using the SSM ParameterStore",
-                            "Children" : [
-                                {
-                                    "Names" : "Name",
-                                    "Description" : "The name of the parameter to lookup",
-                                    "Types" : STRING_TYPE,
-                                    "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
-                                }
+                            "Names" : "Extensions",
+                            "Default" : [
+                                "_computetask_awslinux_cfninit",
+                                "_computetask_linux_hamletenv",
+                                "_computetask_linux_volumemount",
+                                "_computetask_awslinux_ospatching",
+                                "_computetask_linux_filedir",
+                                "_computetask_linux_sshkeys",
+                                "_computetask_awscli",
+                                "_computetask_awslinux_cwlog",
+                                "_computetask_awslinux_efsmount",
+                                "_computetask_awslinux_eip",
+                                "_computetask_linux_userbootstrap"
                             ]
                         }
                     ]

--- a/aws/components/bastion/id.ftl
+++ b/aws/components/bastion/id.ftl
@@ -21,32 +21,37 @@
     provider=AWS_PROVIDER
     extensions=[
         {
-            "Names" : "Image",
+            "Names" : "ComputeInstance",
             "Children" : [
                 {
-                    "Names" : "Source",
-                    "Description" : "The source of the image",
-                    "Values" : [ "AMI", "SSMParam" ]
-                },
-                {
-                    "Names" : "Source:AMI",
-                    "Description" : "Use an explicit AMI for the image ",
+                    "Names" : "Image",
                     "Children" : [
                         {
-                            "Names" : "ImageId",
-                            "Types" : STRING_TYPE
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Source:SSMParam",
-                    "Description" : "Lookup the image Id using the SSM ParameterStore",
-                    "Children" : [
+                            "Names" : "Source",
+                            "Description" : "The source of the image",
+                            "Values" : [ "AMI", "SSMParam" ]
+                        },
                         {
-                            "Names" : "Name",
-                            "Description" : "The name of the parameter to lookup",
-                            "Types" : STRING_TYPE,
-                            "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
+                            "Names" : "Source:AMI",
+                            "Description" : "Use an explicit AMI for the image ",
+                            "Children" : [
+                                {
+                                    "Names" : "ImageId",
+                                    "Types" : STRING_TYPE
+                                }
+                            ]
+                        },
+                        {
+                            "Names" : "Source:SSMParam",
+                            "Description" : "Lookup the image Id using the SSM ParameterStore",
+                            "Children" : [
+                                {
+                                    "Names" : "Name",
+                                    "Description" : "The name of the parameter to lookup",
+                                    "Types" : STRING_TYPE,
+                                    "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
+                                }
+                            ]
                         }
                     ]
                 }

--- a/aws/components/bastion/id.ftl
+++ b/aws/components/bastion/id.ftl
@@ -15,3 +15,42 @@
             AWS_SYSTEMS_MANAGER_SERVICE
         ]
 /]
+
+[@addResourceGroupAttributeValues
+    type=BASTION_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names" : "Image",
+            "Children" : [
+                {
+                    "Names" : "Source",
+                    "Description" : "The source of the image",
+                    "Values" : [ "AMI", "SSMParam" ]
+                },
+                {
+                    "Names" : "Source:AMI",
+                    "Description" : "Use an explicit AMI for the image ",
+                    "Children" : [
+                        {
+                            "Names" : "ImageId",
+                            "Types" : STRING_TYPE
+                        }
+                    ]
+                },
+                {
+                    "Names" : "Source:SSMParam",
+                    "Description" : "Lookup the image Id using the SSM ParameterStore",
+                    "Children" : [
+                        {
+                            "Names" : "Name",
+                            "Description" : "The name of the parameter to lookup",
+                            "Types" : STRING_TYPE,
+                            "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+/]

--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -100,7 +100,7 @@
     [#local _context = invokeExtensions( occurrence, _context )]
     [#local linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
 
-    [#local osPatching = mergeObjects((solution.OSPatching)!{}, environmentObject.OSPatching )]
+    [#local osPatching = mergeObjects(solution.ComputeInstance.OSPatching, environmentObject.OSPatching )]
     [#local environmentVariables = getFinalEnvironment(occurrence, _context).Environment ]
 
     [#local configSets =
@@ -312,7 +312,7 @@
                 securityGroupId=bastionSecurityGroupToId
                 instanceProfileId=bastionInstanceProfileId
                 resourceId=bastionAutoScaleGroupId
-                imageId=getEC2AMIImageId(solution.Image, bastionLaunchConfigId)
+                imageId=getEC2AMIImageId(solution.ComputeInstance.Image, bastionLaunchConfigId)
                 publicIP=publicRouteTable
                 configSet=configSetName
                 enableCfnSignal=true

--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -312,7 +312,7 @@
                 securityGroupId=bastionSecurityGroupToId
                 instanceProfileId=bastionInstanceProfileId
                 resourceId=bastionAutoScaleGroupId
-                imageId=imageId
+                imageId=getEC2AMIImageId(solution.Image, bastionLaunchConfigId)
                 publicIP=publicRouteTable
                 configSet=configSetName
                 enableCfnSignal=true

--- a/aws/components/bastion/state.ftl
+++ b/aws/components/bastion/state.ftl
@@ -30,7 +30,21 @@
                 "autoScaleGroup" : {
                     "Id" : formatResourceId( AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE, core.Id ),
                     "Name" : core.FullName,
-                    "Type" : AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE,
+                    "ComputeTasks" : [
+                        COMPUTE_TASK_RUN_STARTUP_CONFIG,
+                        COMPUTE_TASK_AWS_CFN_SIGNAL,
+                        COMPUTE_TASK_DATA_VOLUME_MOUNTING,
+                        COMPUTE_TASK_FILE_DIR_CREATION,
+                        COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES,
+                        COMPUTE_TASK_OS_SECURITY_PATCHING,
+                        COMPUTE_TASK_AWS_CLI,
+                        COMPUTE_TASK_SYSTEM_LOG_FORWARDING,
+                        COMPUTE_TASK_AWS_EIP,
+                        COMPUTE_TASK_USER_ACCESS,
+                        COMPUTE_TASK_EFS_MOUNT,
+                        COMPUTE_TASK_USER_BOOTSTRAP
+                    ]
                 },
                 "lg" : {
                     "Id" : formatLogGroupId(core.Id),

--- a/aws/components/computecluster/id.ftl
+++ b/aws/components/computecluster/id.ftl
@@ -21,32 +21,37 @@
     provider=AWS_PROVIDER
     extensions=[
         {
-            "Names" : "Image",
+            "Names" : "ComputeInstance",
             "Children" : [
                 {
-                    "Names" : "Source",
-                    "Description" : "The source of the image",
-                    "Values" : [ "AMI", "SSMParam" ]
-                },
-                {
-                    "Names" : "Source:AMI",
-                    "Description" : "Use an explicit AMI for the image ",
+                    "Names" : "Image",
                     "Children" : [
                         {
-                            "Names" : "ImageId",
-                            "Types" : STRING_TYPE
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Source:SSMParam",
-                    "Description" : "Lookup the image Id using the SSM ParameterStore",
-                    "Children" : [
+                            "Names" : "Source",
+                            "Description" : "The source of the image",
+                            "Values" : [ "AMI", "SSMParam" ]
+                        },
                         {
-                            "Names" : "Name",
-                            "Description" : "The name of the parameter to lookup",
-                            "Types" : STRING_TYPE,
-                            "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
+                            "Names" : "Source:AMI",
+                            "Description" : "Use an explicit AMI for the image ",
+                            "Children" : [
+                                {
+                                    "Names" : "ImageId",
+                                    "Types" : STRING_TYPE
+                                }
+                            ]
+                        },
+                        {
+                            "Names" : "Source:SSMParam",
+                            "Description" : "Lookup the image Id using the SSM ParameterStore",
+                            "Children" : [
+                                {
+                                    "Names" : "Name",
+                                    "Description" : "The name of the parameter to lookup",
+                                    "Types" : STRING_TYPE,
+                                    "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
+                                }
+                            ]
                         }
                     ]
                 }

--- a/aws/components/computecluster/id.ftl
+++ b/aws/components/computecluster/id.ftl
@@ -15,3 +15,42 @@
             AWS_SYSTEMS_MANAGER_SERVICE
         ]
 /]
+
+[@addResourceGroupAttributeValues
+    type=COMPUTECLUSTER_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names" : "Image",
+            "Children" : [
+                {
+                    "Names" : "Source",
+                    "Description" : "The source of the image",
+                    "Values" : [ "AMI", "SSMParam" ]
+                },
+                {
+                    "Names" : "Source:AMI",
+                    "Description" : "Use an explicit AMI for the image ",
+                    "Children" : [
+                        {
+                            "Names" : "ImageId",
+                            "Types" : STRING_TYPE
+                        }
+                    ]
+                },
+                {
+                    "Names" : "Source:SSMParam",
+                    "Description" : "Lookup the image Id using the SSM ParameterStore",
+                    "Children" : [
+                        {
+                            "Names" : "Name",
+                            "Description" : "The name of the parameter to lookup",
+                            "Types" : STRING_TYPE,
+                            "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+/]

--- a/aws/components/computecluster/id.ftl
+++ b/aws/components/computecluster/id.ftl
@@ -24,33 +24,33 @@
             "Names" : "ComputeInstance",
             "Children" : [
                 {
+                    "Names" : "OperatingSystem",
+                    "AttributeSet" : AWS_OPERATINGSYSTEM_ATTRIBUTESET_TYPE
+                },
+                {
                     "Names" : "Image",
+                    "AttributeSet" : AWS_COMPUTEIMAGE_ATTRIBUTESET_TYPE
+                },
+                {
+                    "Names" : "ComputeTasks",
+                    "Description" : "Customisation to setup the compute instance from its image",
                     "Children" : [
                         {
-                            "Names" : "Source",
-                            "Description" : "The source of the image",
-                            "Values" : [ "AMI", "SSMParam" ]
-                        },
-                        {
-                            "Names" : "Source:AMI",
-                            "Description" : "Use an explicit AMI for the image ",
-                            "Children" : [
-                                {
-                                    "Names" : "ImageId",
-                                    "Types" : STRING_TYPE
-                                }
-                            ]
-                        },
-                        {
-                            "Names" : "Source:SSMParam",
-                            "Description" : "Lookup the image Id using the SSM ParameterStore",
-                            "Children" : [
-                                {
-                                    "Names" : "Name",
-                                    "Description" : "The name of the parameter to lookup",
-                                    "Types" : STRING_TYPE,
-                                    "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
-                                }
+                            "Names" : "Extensions",
+                            "Default" : [
+                                "_computetask_awslinux_cfninit",
+                                "_computetask_linux_hamletenv",
+                                "_computetask_linux_volumemount",
+                                "_computetask_awslinux_ospatching",
+                                "_computetask_linux_filedir",
+                                "_computetask_linux_sshkeys",
+                                "_computetask_awscli",
+                                "_computetask_awslinux_cwlog",
+                                "_computetask_awslinux_efsmount",
+                                "_computetask_awslinux_eip",
+                                "_computetask_linux_userbootstrap",
+                                "_computetask_linux_scriptsdeployment"
+                                "_computetask_linux_vpc_lb"
                             ]
                         }
                     ]

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -563,7 +563,7 @@
             securityGroupId=computeClusterSecurityGroupId
             instanceProfileId=computeClusterInstanceProfileId
             resourceId=computeClusterAutoScaleGroupId
-            imageId=imageId
+            imageId=getEC2AMIImageId(solution.Image, computeClusterLaunchConfigId)
             publicIP=publicRouteTable
             configSet=configSetName
             enableCfnSignal=(solution.UseInitAsService != true)

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -147,7 +147,7 @@
 
     [#local environmentVariables += getFinalEnvironment(occurrence, _context ).Environment ]
 
-    [#local osPatching = mergeObjects(solution.OSPatching, environmentObject.OSPatching )]
+    [#local osPatching = mergeObjects(solution.ComputeInstance.OSPatching, environmentObject.OSPatching )]
     [#local configSets =
             getInitConfigBootstrap(occurrence, operationsBucket, dataBucket, environmentVariables) +
             osPatching.Enabled?then(
@@ -563,7 +563,7 @@
             securityGroupId=computeClusterSecurityGroupId
             instanceProfileId=computeClusterInstanceProfileId
             resourceId=computeClusterAutoScaleGroupId
-            imageId=getEC2AMIImageId(solution.Image, computeClusterLaunchConfigId)
+            imageId=getEC2AMIImageId(solution.ComputeInstance.Image, computeClusterLaunchConfigId)
             publicIP=publicRouteTable
             configSet=configSetName
             enableCfnSignal=(solution.UseInitAsService != true)

--- a/aws/components/computecluster/state.ftl
+++ b/aws/components/computecluster/state.ftl
@@ -56,7 +56,23 @@
                 "autoScaleGroup" : {
                     "Id" : autoScaleGroupId,
                     "Name" : core.FullName,
-                    "Type" : AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE
+                    "Type" : AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE,
+                    "ComputeTasks" : [
+                        COMPUTE_TASK_RUN_STARTUP_CONFIG,
+                        COMPUTE_TASK_AWS_CFN_SIGNAL,
+                        COMPUTE_TASK_DATA_VOLUME_MOUNTING,
+                        COMPUTE_TASK_FILE_DIR_CREATION,
+                        COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES,
+                        COMPUTE_TASK_OS_SECURITY_PATCHING,
+                        COMPUTE_TASK_AWS_CLI,
+                        COMPUTE_TASK_SYSTEM_LOG_FORWARDING,
+                        COMPUTE_TASK_AWS_EIP,
+                        COMPUTE_TASK_USER_ACCESS,
+                        COMPUTE_TASK_EFS_MOUNT,
+                        COMPUTE_TASK_USER_BOOTSTRAP,
+                        COMPUTE_TASK_RUN_SCRIPTS_DEPLOYMENT,
+                        COMPUTE_TASK_AWS_LB_REGISTRATION
+                    ]
                 },
                 "lg" : {
                     "Id" : formatLogGroupId(core.Id),

--- a/aws/components/ec2/id.ftl
+++ b/aws/components/ec2/id.ftl
@@ -1,9 +1,9 @@
 [#ftl]
 [@addResourceGroupInformation
     type=EC2_COMPONENT_TYPE
-    attributes=[]
     provider=AWS_PROVIDER
     resourceGroup=DEFAULT_RESOURCE_GROUP
+    attributes=[]
     services=
         [
             AWS_CLOUDWATCH_SERVICE,
@@ -13,4 +13,43 @@
             AWS_KEY_MANAGEMENT_SERVICE,
             AWS_SYSTEMS_MANAGER_SERVICE
         ]
+/]
+
+[@addResourceGroupAttributeValues
+    type=EC2_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names" : "Image",
+            "Children" : [
+                {
+                    "Names" : "Source",
+                    "Description" : "The source of the image",
+                    "Values" : [ "AMI", "SSMParam" ]
+                },
+                {
+                    "Names" : "Source:AMI",
+                    "Description" : "Use an explicit AMI for the image ",
+                    "Children" : [
+                        {
+                            "Names" : "ImageId",
+                            "Types" : STRING_TYPE
+                        }
+                    ]
+                },
+                {
+                    "Names" : "Source:SSMParam",
+                    "Description" : "Lookup the image Id using the SSM ParameterStore",
+                    "Children" : [
+                        {
+                            "Names" : "Name",
+                            "Description" : "The name of the parameter to lookup",
+                            "Types" : STRING_TYPE,
+                            "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 /]

--- a/aws/components/ec2/id.ftl
+++ b/aws/components/ec2/id.ftl
@@ -20,32 +20,37 @@
     provider=AWS_PROVIDER
     extensions=[
         {
-            "Names" : "Image",
+            "Names" : "ComputeInstance",
             "Children" : [
                 {
-                    "Names" : "Source",
-                    "Description" : "The source of the image",
-                    "Values" : [ "AMI", "SSMParam" ]
-                },
-                {
-                    "Names" : "Source:AMI",
-                    "Description" : "Use an explicit AMI for the image ",
+                    "Names" : "Image",
                     "Children" : [
                         {
-                            "Names" : "ImageId",
-                            "Types" : STRING_TYPE
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Source:SSMParam",
-                    "Description" : "Lookup the image Id using the SSM ParameterStore",
-                    "Children" : [
+                            "Names" : "Source",
+                            "Description" : "The source of the image",
+                            "Values" : [ "AMI", "SSMParam" ]
+                        },
                         {
-                            "Names" : "Name",
-                            "Description" : "The name of the parameter to lookup",
-                            "Types" : STRING_TYPE,
-                            "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
+                            "Names" : "Source:AMI",
+                            "Description" : "Use an explicit AMI for the image ",
+                            "Children" : [
+                                {
+                                    "Names" : "ImageId",
+                                    "Types" : STRING_TYPE
+                                }
+                            ]
+                        },
+                        {
+                            "Names" : "Source:SSMParam",
+                            "Description" : "Lookup the image Id using the SSM ParameterStore",
+                            "Children" : [
+                                {
+                                    "Names" : "Name",
+                                    "Description" : "The name of the parameter to lookup",
+                                    "Types" : STRING_TYPE,
+                                    "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
+                                }
+                            ]
                         }
                     ]
                 }

--- a/aws/components/ec2/id.ftl
+++ b/aws/components/ec2/id.ftl
@@ -23,33 +23,32 @@
             "Names" : "ComputeInstance",
             "Children" : [
                 {
+                    "Names" : "OperatingSystem",
+                    "AttributeSet" : AWS_OPERATINGSYSTEM_ATTRIBUTESET_TYPE
+                },
+                {
                     "Names" : "Image",
+                    "AttributeSet" : AWS_COMPUTEIMAGE_ATTRIBUTESET_TYPE
+                },
+                {
+                    "Names" : "ComputeTasks",
+                    "Description" : "Customisation to setup the compute instance from its image",
                     "Children" : [
                         {
-                            "Names" : "Source",
-                            "Description" : "The source of the image",
-                            "Values" : [ "AMI", "SSMParam" ]
-                        },
-                        {
-                            "Names" : "Source:AMI",
-                            "Description" : "Use an explicit AMI for the image ",
-                            "Children" : [
-                                {
-                                    "Names" : "ImageId",
-                                    "Types" : STRING_TYPE
-                                }
-                            ]
-                        },
-                        {
-                            "Names" : "Source:SSMParam",
-                            "Description" : "Lookup the image Id using the SSM ParameterStore",
-                            "Children" : [
-                                {
-                                    "Names" : "Name",
-                                    "Description" : "The name of the parameter to lookup",
-                                    "Types" : STRING_TYPE,
-                                    "Default" : "/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs"
-                                }
+                            "Names" : "Extensions",
+                            "Default" : [
+                                "_computetask_awslinux_cfninit",
+                                "_computetask_linux_hamletenv",
+                                "_computetask_linux_volumemount",
+                                "_computetask_awslinux_ospatching",
+                                "_computetask_linux_filedir",
+                                "_computetask_linux_sshkeys",
+                                "_computetask_awscli",
+                                "_computetask_awslinux_cwlog",
+                                "_computetask_awslinux_efsmount",
+                                "_computetask_linux_userbootstrap",
+                                "_computetask_linux_scriptsdeployment"
+                                "_computetask_linux_vpc_lb"
                             ]
                         }
                     ]

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -113,7 +113,7 @@
 
     [#local configSetName = occurrence.Core.Type]
 
-    [#local osPatching = mergeObjects(solution.OSPatching, environmentObject.OSPatching )]
+    [#local osPatching = mergeObjects(solution.ComputeInstance.OSPatching, environmentObject.OSPatching )]
     [#local configSets =
             getInitConfigBootstrap(occurrence, operationsBucket, dataBucket, environmentVariables) +
             osPatching.Enabled?then(
@@ -367,7 +367,7 @@
                 [#local zoneEc2EIPName             = zoneResources[zone.Id]["ec2EIP"].Id]
                 [#local zoneEc2EIPAssociationId    = zoneResources[zone.Id]["ec2EIPAssociation"].Id]
 
-                [#local imageId = getEC2AMIImageId(solution.Image, zoneEc2InstanceId)]
+                [#local imageId = getEC2AMIImageId(solution.ComputeInstance.Image, zoneEc2InstanceId)]
 
                 [#local updateCommand = "yum clean all && yum -y update"]
                 [#local dailyUpdateCron = 'echo \"59 13 * * * ${updateCommand} >> /var/log/update.log 2>&1\" >crontab.txt && crontab crontab.txt']

--- a/aws/components/ec2/state.ftl
+++ b/aws/components/ec2/state.ftl
@@ -19,7 +19,21 @@
                 "ec2Instance" : {
                     "Id"   : formatResourceId(AWS_EC2_INSTANCE_RESOURCE_TYPE, core.Id, zone.Id),
                     "Name" : formatName(tenantId, formatComponentFullName(core.Tier, core.Component), zone.Id),
-                    "Type" : AWS_EC2_INSTANCE_RESOURCE_TYPE
+                    "Type" : AWS_EC2_INSTANCE_RESOURCE_TYPE,
+                    "ComputeTasks" : [
+                        COMPUTE_TASK_RUN_STARTUP_CONFIG,
+                        COMPUTE_TASK_AWS_CFN_SIGNAL,
+                        COMPUTE_TASK_DATA_VOLUME_MOUNTING,
+                        COMPUTE_TASK_FILE_DIR_CREATION,
+                        COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES,
+                        COMPUTE_TASK_OS_SECURITY_PATCHING,
+                        COMPUTE_TASK_AWS_CLI,
+                        COMPUTE_TASK_SYSTEM_LOG_FORWARDING,
+                        COMPUTE_TASK_USER_ACCESS,
+                        COMPUTE_TASK_EFS_MOUNT,
+                        COMPUTE_TASK_USER_BOOTSTRAP,
+                        COMPUTE_TASK_AWS_LB_REGISTRATION
+                    ]
                 },
                 "ec2ENI" : {
                     "Id" : formatResourceId(AWS_EC2_NETWORK_INTERFACE_RESOURCE_TYPE, core.Id, zone.Id, "eth0"),

--- a/aws/components/ecs/id.ftl
+++ b/aws/components/ecs/id.ftl
@@ -25,33 +25,33 @@
             "Names" : "ComputeInstance",
             "Children" : [
                 {
+                    "Names" : "OperatingSystem",
+                    "AttributeSet" : AWS_OPERATINGSYSTEM_ATTRIBUTESET_TYPE
+                },
+                {
                     "Names" : "Image",
+                    "AttributeSet" : AWS_ECS_COMPUTEIMAGE_ATTRIBUTESET_TYPE
+                },
+                {
+                    "Names" : "ComputeTasks",
+                    "Description" : "Customisation to setup the compute instance from its image",
                     "Children" : [
                         {
-                            "Names" : "Source",
-                            "Description" : "The source of the image",
-                            "Values" : [ "AMI", "SSMParam" ]
-                        },
-                        {
-                            "Names" : "Source:AMI",
-                            "Description" : "Use an explicit AMI for the image ",
-                            "Children" : [
-                                {
-                                    "Names" : "ImageId",
-                                    "Types" : STRING_TYPE
-                                }
-                            ]
-                        },
-                        {
-                            "Names" : "Source:SSMParam",
-                            "Description" : "Lookup the image Id using the SSM ParameterStore",
-                            "Children" : [
-                                {
-                                    "Names" : "Name",
-                                    "Description" : "The name of the parameter to lookup",
-                                    "Types" : STRING_TYPE,
-                                    "Default" : "/aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id"
-                                }
+                            "Names" : "Extensions",
+                            "Default" : [
+                                "_computetask_awslinux_cfninit",
+                                "_computetask_linux_hamletenv",
+                                "_computetask_linux_volumemount",
+                                "_computetask_awslinux_ospatching",
+                                "_computetask_linux_filedir",
+                                "_computetask_linux_sshkeys",
+                                "_computetask_awscli",
+                                "_computetask_awslinux_cwlog",
+                                "_computetask_awslinux_efsmount",
+                                "_computetask_awslinux_eip",
+                                "_computetask_linux_userbootstrap",
+                                "_computetask_awslinux_ssm",
+                                "_computetask_awslinux_ecs"
                             ]
                         }
                     ]

--- a/aws/components/ecs/id.ftl
+++ b/aws/components/ecs/id.ftl
@@ -22,32 +22,37 @@
     provider=AWS_PROVIDER
     extensions=[
         {
-            "Names" : "HostImage",
+            "Names" : "ComputeInstance",
             "Children" : [
                 {
-                    "Names" : "Source",
-                    "Description" : "The source of the image",
-                    "Values" : [ "AMI", "SSMParam" ]
-                },
-                {
-                    "Names" : "Source:AMI",
-                    "Description" : "Use an explicit AMI for the image ",
+                    "Names" : "Image",
                     "Children" : [
                         {
-                            "Names" : "ImageId",
-                            "Types" : STRING_TYPE
-                        }
-                    ]
-                },
-                {
-                    "Names" : "Source:SSMParam",
-                    "Description" : "Lookup the image Id using the SSM ParameterStore",
-                    "Children" : [
+                            "Names" : "Source",
+                            "Description" : "The source of the image",
+                            "Values" : [ "AMI", "SSMParam" ]
+                        },
                         {
-                            "Names" : "Name",
-                            "Description" : "The name of the parameter to lookup",
-                            "Types" : STRING_TYPE,
-                            "Default" : "/aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id"
+                            "Names" : "Source:AMI",
+                            "Description" : "Use an explicit AMI for the image ",
+                            "Children" : [
+                                {
+                                    "Names" : "ImageId",
+                                    "Types" : STRING_TYPE
+                                }
+                            ]
+                        },
+                        {
+                            "Names" : "Source:SSMParam",
+                            "Description" : "Lookup the image Id using the SSM ParameterStore",
+                            "Children" : [
+                                {
+                                    "Names" : "Name",
+                                    "Description" : "The name of the parameter to lookup",
+                                    "Types" : STRING_TYPE,
+                                    "Default" : "/aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id"
+                                }
+                            ]
                         }
                     ]
                 }

--- a/aws/components/ecs/id.ftl
+++ b/aws/components/ecs/id.ftl
@@ -17,6 +17,45 @@
         ]
 /]
 
+[@addResourceGroupAttributeValues
+    type=ECS_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names" : "HostImage",
+            "Children" : [
+                {
+                    "Names" : "Source",
+                    "Description" : "The source of the image",
+                    "Values" : [ "AMI", "SSMParam" ]
+                },
+                {
+                    "Names" : "Source:AMI",
+                    "Description" : "Use an explicit AMI for the image ",
+                    "Children" : [
+                        {
+                            "Names" : "ImageId",
+                            "Types" : STRING_TYPE
+                        }
+                    ]
+                },
+                {
+                    "Names" : "Source:SSMParam",
+                    "Description" : "Lookup the image Id using the SSM ParameterStore",
+                    "Children" : [
+                        {
+                            "Names" : "Name",
+                            "Description" : "The name of the parameter to lookup",
+                            "Types" : STRING_TYPE,
+                            "Default" : "/aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+/]
+
 [@addResourceGroupInformation
     type=ECS_SERVICE_COMPONENT_TYPE
     attributes=[

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -638,7 +638,7 @@
             instanceProfileId=ecsInstanceProfileId
             securityGroupId=ecsSecurityGroupId
             resourceId=ecsAutoScaleGroupId
-            imageId=regionObject.AMIs.Centos.ECS
+            imageId=getEC2AMIImageId(solution.HostImage, ecsLaunchConfigId)
             publicIP=publicRouteTable
             configSet=configSetName
             environmentId=environmentId

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -122,7 +122,7 @@
 
     [#local environmentVariables += getFinalEnvironment(occurrence, _context).Environment ]
 
-    [#local osPatching = mergeObjects(solution.OSPatching, environmentObject.OSPatching )]
+    [#local osPatching = mergeObjects(solution.ComputeInstance.OSPatching, environmentObject.OSPatching )]
 
     [#local configSetName = occurrence.Core.Type]
     [#local configSets =
@@ -638,7 +638,7 @@
             instanceProfileId=ecsInstanceProfileId
             securityGroupId=ecsSecurityGroupId
             resourceId=ecsAutoScaleGroupId
-            imageId=getEC2AMIImageId(solution.HostImage, ecsLaunchConfigId)
+            imageId=getEC2AMIImageId(solution.ComputeInstance.Image, ecsLaunchConfigId)
             publicIP=publicRouteTable
             configSet=configSetName
             environmentId=environmentId

--- a/aws/services/ec2/id.ftl
+++ b/aws/services/ec2/id.ftl
@@ -1,5 +1,9 @@
 [#ftl]
 
+[#-- ComputeTask config Engines --]
+[#assign AWS_EC2_USERDATA_COMPUTE_TASK_CONFIG_TYPE = "userdata"]
+[#assign AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE = "cfninit" ]
+
 [#-- Parameter Type --]
 [#assign AWS_EC2_AMI_PARAMETER_TYPE = "amiParam"]
 

--- a/aws/services/ec2/id.ftl
+++ b/aws/services/ec2/id.ftl
@@ -1,7 +1,7 @@
 [#ftl]
 
 [#-- Parameter Type --]
-[#assign AWS_EC2_AMI_PARATMETER_TYPE = "amiParam"]
+[#assign AWS_EC2_AMI_PARAMETER_TYPE = "amiParam"]
 
 [#-- Resources --]
 [#assign AWS_EC2_INSTANCE_RESOURCE_TYPE = "ec2Instance" ]

--- a/aws/services/ec2/id.ftl
+++ b/aws/services/ec2/id.ftl
@@ -1,5 +1,8 @@
 [#ftl]
 
+[#-- Parameter Type --]
+[#assign AWS_EC2_AMI_PARATMETER_TYPE = "amiParam"]
+
 [#-- Resources --]
 [#assign AWS_EC2_INSTANCE_RESOURCE_TYPE = "ec2Instance" ]
 [@addServiceResource

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -1319,7 +1319,7 @@
         [#case "aws:Source:SSMParam"]
 
             [#local param = imageConfiguration["aws:Source:SSMParam"]["Name"]]
-            [#local paramId = formatResourceId(AWS_EC2_AMI_PARATMETER_TYPE, ec2ResourceId) ]
+            [#local paramId = formatResourceId(AWS_EC2_AMI_PARAMETER_TYPE, ec2ResourceId) ]
 
             [@addCFNSSMEC2ImageParam
                 id=paramId

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -1300,3 +1300,42 @@
         dependencies=dependencies
     /]
 [/#macro]
+
+
+[#function getEC2AMIImageId imageConfiguration ec2ResourceId ]
+    [#local imageId = ""]
+    [#switch imageConfiguration.Source ]
+        [#case "Source:Reference"]
+            [#local OSFamily = imageConfiguration["Source:Reference"]["OS"]]
+            [#local OSType = imageConfiguration["Source:Reference"]["Type"]]
+
+            [#local imageId = regionObject.AMIs[OSFamily][OSType]]
+            [#break]
+
+        [#case "aws:Source:AMI"]
+            [#local imageId = imageConfiguration["aws:Source:AMI"]["ImageId"]]
+            [#break]
+
+        [#case "aws:Source:SSMParam"]
+
+            [#local param = imageConfiguration["aws:Source:SSMParam"]["Name"]]
+            [#local paramId = formatResourceId(AWS_EC2_AMI_PARATMETER_TYPE, ec2ResourceId) ]
+
+            [@addCFNSSMEC2ImageParam
+                id=paramId
+                default=param
+                description="AMI Image for EC2 Instance"
+            /]
+
+            [#local imageId = getReference(paramId)]
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Invalid AMI Image Source"
+                context={ "ec2Resoruce" : ec2ResourceId, "ImageConfiguration" : imageConfiguration }
+            /]
+    [/#switch]
+
+    [#return imageId ]
+[/#function]

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -378,18 +378,18 @@
 [#function getEC2AMIImageId imageConfiguration ec2ResourceId ]
     [#local imageId = ""]
     [#switch (imageConfiguration.Source)!"" ]
-        [#case "Source:Reference"]
+        [#case "Reference"]
             [#local OSFamily = imageConfiguration["Source:Reference"]["OS"]]
             [#local OSType = imageConfiguration["Source:Reference"]["Type"]]
 
             [#local imageId = regionObject.AMIs[OSFamily][OSType]]
             [#break]
 
-        [#case "aws:Source:AMI"]
+        [#case "aws:AMI"]
             [#local imageId = imageConfiguration["aws:Source:AMI"]["ImageId"]]
             [#break]
 
-        [#case "aws:Source:SSMParam"]
+        [#case "aws:SSMParam"]
 
             [#local param = imageConfiguration["aws:Source:SSMParam"]["Name"]]
             [#local paramId = formatResourceId(AWS_EC2_AMI_PARAMETER_TYPE, ec2ResourceId) ]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)
- Refactor

## Description

Adds support for configuring the AMI image of ec2 based components using
the image source configuration options.

Adds two AWS specific image source attributes to handle more explicit configuration options
- Source:AMI - Allows a user to explicitly define an AMI Id to use at the component level
- Source:SSMParam - Allows the user to define an SSM Parameter that holds the Image Id. The default value for these options is the AWS public parameters which list the latest recommended version of AWS provided AMI Images.

The default behaviour is to use the current AMI Ids defined in the
Region objects

Adds support and migrates all instance bootstrap configuration over to compute tasks to provide modular reusable configuration of instance based components. 

## Motivation and Context

This allows for users to have greater control over the AMI that is used for the virtual machine based components. Using the Public SSM parameters allows for deployments to automatically use the latest version of the image available from AWS at the time of deployment without having to depend on updates to hamlet to use the reference configuration 

The ability to use compute tasks allows for support of essentially any operating system that is used on the components as long as a compute task extension has been implemented for the required component compute tasks

## How Has This Been Tested?

Tested locally 

## Followup Actions

- [x] Requires: https://github.com/hamlet-io/engine/pull/1627 
- [x] Requires: https://github.com/hamlet-io/engine/pull/1625 
- [x] Requires: https://github.com/hamlet-io/engine/pull/1629
- [x] Requires: https://github.com/hamlet-io/engine/pull/1630
- [x] Requires: https://github.com/hamlet-io/engine/pull/1631 
- [x] Requires: #271 