### PR TITLE
feat: aws compute task implementations

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -100,7 +100,7 @@
     [#local _context = invokeExtensions( occurrence, _context )]
     [#local linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
 
-    [#local osPatching = mergeObjects(solution.OSPatching, environmentObject.OSPatching )]
+    [#local osPatching = mergeObjects((solution.OSPatching)!{}, environmentObject.OSPatching )]
     [#local environmentVariables = getFinalEnvironment(occurrence, _context).Environment ]
 
     [#local configSets =

--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -23,7 +23,7 @@
     [#local bastionLgId = resources["lg"].Id]
     [#local bastionLgName = resources["lg"].Name]
 
-    [#local bastionOS = solution.OS ]
+    [#local bastionOS = (solution.OS)!"linux" ]
     [#local bastionType = occurrence.Core.Type]
     [#local configSetName = bastionType]
 

--- a/aws/computetasks/computetask.ftl
+++ b/aws/computetasks/computetask.ftl
@@ -1,0 +1,56 @@
+[#ftl]
+
+[#assign COMPUTE_TASK_AWS_CFN_SIGNAL = "aws_cfn_signal" ]
+[@addComputeTask
+    type=COMPUTE_TASK_AWS_CFN_SIGNAL
+    properties=[
+        {
+            "Type" : "Description",
+            "Value" : "Use cfn-signal to notify cloudformation of setup result"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_AWS_CLI = "aws_cli" ]
+[@addComputeTask
+    type=COMPUTE_TASK_AWS_CLI
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Install the awscli"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_AWS_EIP = "aws_eip" ]
+[@addComputeTask
+    type=COMPUTE_TASK_AWS_EIP
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Allocate an assigned elastic IP to the primary interface of the instance"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_AWS_ECS_AGENT_SETUP = "aws_ecs_setup" ]
+[@addComputeTask
+    type=COMPUTE_TASK_AWS_ECS_AGENT_SETUP
+    properties=[
+        {
+            "Type" : "Description",
+            "Value" : "Install and Configure the AWS ECS Agent for an Ec2 based ECS Instance"
+        }
+    ]
+/]
+
+[#assign COMPUTE_TASK_AWS_LB_REGISTRATION = "aws_lb_registration" ]
+[@addComputeTask
+    type=COMPUTE_TASK_AWS_LB_REGISTRATION
+    properties=[
+        {
+            "Type" : "Description",
+            "Value" : "Register the primary interface of an instance with vpc load balancers"
+        }
+    ]
+/]

--- a/aws/extensions/computetask_awscli/extension.ftl
+++ b/aws/extensions/computetask_awscli/extension.ftl
@@ -1,0 +1,74 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_awscli"
+    aliases=[
+        "_computetask_awscli"
+    ]
+    description=[
+        "Installs the awscli"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_awscli_deployment_computetask occurrence ]
+
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local operatingSystem = solution.ComputeInstance.OperatingSystem]
+
+    [#local content = {}]
+    [#switch operatingSystem.Family ]
+        [#case "linux" ]
+            [#switch operatingSystem.Distribution ]
+                [#case "awslinux" ]
+                    [#switch operatingSystem.MajorVersion ]
+                        [#case "2"]
+                            [#local content = {
+                                "packages" : {
+                                    "yum" : {
+                                        "awscli" : []
+                                    }
+                                }
+                            }]
+                            [#break]
+                        [#case "1" ]
+                            [#local content = {
+                                "packages" : {
+                                    "yum" : {
+                                        "aws-cli" : []
+                                    }
+                                }
+                            }]
+                            [#break]
+                    [/#switch]
+                    [#break]
+            [/#switch]
+            [#break]
+        [#break]
+    [/#switch]
+
+    [#if ! (content?has_content) ]
+        [@fatal
+            message="computetask_awscli could not find a way to install the aws cli for this os"
+            detail="Check your operating system config or replace this extension with your own"
+            context={ "OccurrenceId" : core.Id, "OperatingSystem" : operatingSystem }
+        /]
+    [/#if]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_AWS_CLI ]
+        id="AWSClI"
+        priority=1
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content=content
+    /]
+
+[/#macro]

--- a/aws/extensions/computetask_awslinux_cfninit/extension.ftl
+++ b/aws/extensions/computetask_awslinux_cfninit/extension.ftl
@@ -1,0 +1,66 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_awslinux_cfninit"
+    aliases=[
+        "_computetask_awslinux_cfninit"
+    ]
+    description=[
+        "Updates and runs the cfn init process based on the provided cfninit metadata"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_awslinux_cfninit_deployment_computetask occurrence ]
+
+    [#local computeResourceId = (_context.ComputeResourceId)!"" ]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_RUN_STARTUP_CONFIG, COMPUTE_TASK_AWS_CFN_SIGNAL ]
+        id="CFNInit"
+        priority=0
+        engine=AWS_EC2_USERDATA_COMPUTE_TASK_CONFIG_TYPE
+        content=[
+            r'#!/bin/bash',
+            r'set -uo pipefail',
+            "exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1",
+            "# Updat cfn bootstrap commands",
+            "yum install -y aws-cfn-bootstrap",
+            "# Create staging dirs for cfninit scripts",
+            "mkdir -p /var/log/hamlet_cfninit/",
+            "mkdir -p /opt/hamlet_cfninit/",
+            "# Remainder of configuration via metadata",
+            {
+                "Fn::Sub" : [
+                    r'/opt/aws/bin/cfn-init -v --stack ${StackName} --resource ${Resource} --region ${Region} --configset ${ConfigSet}',
+                    {
+                        "StackName" : { "Ref" : "AWS::StackName" },
+                        "Region" : { "Ref" : "AWS::Region" },
+                        "Resource" : computeResourceId,
+                        "ConfigSet" : computeResourceId
+                    }
+                ]
+            },
+            "# Signal the status from cfn-init",
+            {
+                "Fn::Sub" : [
+                    r'/opt/aws/bin/cfn-signal -e $? --stack ${StackName} --resource ${Resource} --region ${Region}',
+                    {
+                        "StackName" : { "Ref" : "AWS::StackName" },
+                        "Region" : { "Ref" : "AWS::Region" },
+                        "Resource" : computeResourceId
+                    }
+                ]
+            }
+        ]
+    /]
+
+[/#macro]

--- a/aws/extensions/computetask_awslinux_cwlog/extension.ftl
+++ b/aws/extensions/computetask_awslinux_cwlog/extension.ftl
@@ -1,0 +1,163 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_awslinux_cwlog"
+    aliases=[
+        "_computetask_awslinux_cwlog"
+    ]
+    description=[
+        "Use the cloudwatch log agent for forwarding"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_awslinux_cwlog_deployment_computetask occurrence ]
+
+    [#local solution = occurrence.Configuration.Solution ]
+
+    [#local logFileProfile = _context.LogFileProfile ]
+    [#local logGroupName = _context.InstanceLogGroup ]
+
+    [#local logContent = [
+        "[general]",
+        "state_file = /var/lib/awslogs/agent-state",
+        ""
+    ]]
+
+    [#list logFileProfile.LogFileGroups as logFileGroup ]
+        [#local logGroup = logFileGroups[logFileGroup] ]
+        [#list logGroup.LogFiles as logFile ]
+            [#local logFileDetails = logFiles[logFile] ]
+            [#local logContent +=
+                [
+                    "[" + logFileDetails.FilePath + "]",
+                    "file = " + logFileDetails.FilePath,
+                    "log_group_name = " + logGroupName,
+                    "log_stream_name = {instance_id}" + logFileDetails.FilePath
+                ] +
+                (logFileDetails.TimeFormat!"")?has_content?then(
+                    [ "datetime_format = " + logFileDetails.TimeFormat ],
+                    []
+                ) +
+                (logFileDetails.MultiLinePattern!"")?has_content?then(
+                    [ "awslogs-multiline-pattern = " + logFileDetails.MultiLinePattern ],
+                    []
+                ) +
+                [ "" ]
+            ]
+        [/#list]
+    [/#list]
+
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local operatingSystem = solution.ComputeInstance.OperatingSystem]
+
+    [#local awsLogsServiceName = "" ]
+    [#switch operatingSystem.Family ]
+        [#case "linux" ]
+            [#switch operatingSystem.Distribution ]
+                [#case "awslinux" ]
+                    [#switch operatingSystem.MajorVersion ]
+                        [#case "2"]
+                            [#local awsLogsServiceName = "awslogsd"]
+                            [#break]
+                        [#case "1" ]
+                            [#local awsLogsServiceName = "awslogs"]
+                            [#break]
+                    [/#switch]
+                    [#break]
+            [/#switch]
+            [#break]
+        [#break]
+    [/#switch]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_SYSTEM_LOG_FORWARDING ]
+        id="CloudWatchLogs"
+        priority=2
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content={
+            "packages" : {
+                "yum" : {
+                    "awslogs" : [],
+                    "jq" : []
+                }
+            },
+            "files" : {
+                "/etc/awslogs/awscli.conf" : {
+                    "content" : {
+                        "Fn::Join" : [
+                            "\n",
+                            [
+                                "[plugins]",
+                                "cwlogs = cwlogs",
+                                "[default]",
+                                { "Fn::Sub" : r'region = ${AWS::Region}' }
+                            ]
+                        ]
+                    },
+                    "mode" : "000644"
+                },
+                "/etc/awslogs/awslogs.conf" : {
+                    "content" : {
+                        "Fn::Join" : [
+                            "\n",
+                            logContent
+                        ]
+                    },
+                    "mode" : "000644"
+                },
+                "/opt/hamlet_cfninit/awslogs.sh" : {
+                    "content" : {
+                        "Fn::Join" : [
+                            "\n",
+                            [
+                                r'#!/bin/bash',
+                                r'# Metadata log details',
+                                r"ecs_cluster=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .Cluster')",
+                                r"ecs_container_instance_id=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .ContainerInstanceArn' | awk -F/ '{print $2}' )",
+                                r'macs=$(curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/ | head -1 )',
+                                r'vpc_id=$(curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$macs/vpc-id )',
+                                r'instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)',
+                                r'',
+                                r'sed -i -e "s/{instance_id}/$instance_id/g" /etc/awslogs/awslogs.conf',
+                                r'sed -i -e "s/{ecs_container_instance_id}/$ecs_container_instance_id/g" /etc/awslogs/awslogs.conf',
+                                r'sed -i -e "s/{ecs_cluster}/$ecs_cluster/g" /etc/awslogs/awslogs.conf',
+                                r'sed -i -e "s/{vpc_id}/$vpc_id/g" /etc/awslogs/awslogs.conf'
+                            ]
+                        ]
+                    },
+                    "mode" : "000755"
+                }
+            },
+            "services" : {
+                "sysvinit" : {
+                    awsLogsServiceName : {
+                        "ensureRunning" : true,
+                        "enabled" : true,
+                        "files" : [
+                            "/etc/awslogs/awslogs.conf",
+                            "/etc/awslogs/awscli.conf"
+                        ],
+                        "packages" : [ "awslogs" ],
+                        "commands" : [ "ConfigureLogsAgent" ]
+                    }
+                }
+            },
+            "commands": {
+                "ConfigureLogsAgent" : {
+                    "command" : "/opt/hamlet_cfninit/awslogs.sh",
+                    "ignoreErrors" : false
+                }
+            }
+        }
+    /]
+
+[/#macro]

--- a/aws/extensions/computetask_awslinux_ecs/extension.ftl
+++ b/aws/extensions/computetask_awslinux_ecs/extension.ftl
@@ -1,0 +1,214 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_awslinux_ecs"
+    aliases=[
+        "_computetask_awslinux_ecs"
+    ]
+    description=[
+        "Setup the ecs agent and docker config for aws linux instances"
+    ]
+    supportedTypes=[
+        ECS_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_awslinux_ecs_deployment_computetask occurrence ]
+
+    [#local solution = occurrence.Configuration.Solution]
+    [#local resources = occurrence.State.Resources]
+
+    [#local ecsId               = resources["cluster"].Id ]
+    [#local dockerUsers         = solution.DockerUsers ]
+    [#local dockerVolumeDrivers = solution.VolumeDrivers ]
+    [#local defaultLogDriver    = solution.LogDriver ]
+
+    [#local dockerUsersEnv = "" ]
+
+    [#local userInit = {}]
+    [#if dockerUsers?has_content ]
+        [#list dockerUsers as userName,details ]
+
+            [#local userInit = mergeObjects(
+                                userInit,
+                                {
+                                    userName : {
+                                        "groups" : [ "docker" ],
+                                        "uid" : details.UID
+                                    }
+                                })]
+        [/#list]
+    [/#if]
+
+    [#local commands = {}]
+
+    [#local commands +=
+        {
+            "9_RestartECSAgent" : {
+                "command" : "stop ecs; start ecs",
+                "ignoreErrors" : false
+            }
+        }
+    ]
+
+    [#local dockerVolumeDriverScriptName = "ecs_volume_driver_install" ]
+    [#local dockerVolumeDriverScript = [] ]
+    [#if dockerVolumeDrivers?has_content ]
+        [#list dockerVolumeDrivers as dockerVolumeDriver ]
+
+            [#switch dockerVolumeDriver ]
+                [#case "ebs" ]
+
+                    [#local dockerVolumeDriverScript += [
+                        { "Fn::Sub" : r'docker plugin install rexray/ebs REXRAY_PREEMPT=true EBS_REGION="${AWS::Region}" --grant-all-permissions' }
+                    ]]
+                    [#break]
+            [/#switch]
+        [/#list]
+    [/#if]
+
+    [#local commands +=
+        attributeIfContent(
+            "1_InstallVolumeDrivers",
+            dockerVolumeDriverScript,
+            {
+                "command" : "/opt/hamlet_cfninit/${dockerVolumeDriverScriptName}.sh",
+                "ignoreErrors" : false
+            }
+        )]
+
+    [#if dockerVolumeDriverScript?has_content ]
+        [#local dockerVolumeDriverScript = [
+            r'#!/bin/bash',
+            r'set -euo pipefail',
+            'exec > >(tee /var/log/hamlet_cfninit/${dockerVolumeDriverScriptName}.log | logger -t ${dockerVolumeDriverScriptName} -s 2>/dev/console) 2>&1'
+        ] + dockerVolumeDriverScript ]
+    [/#if]
+
+    [#local dockerLoggingDriverScriptName = "ecs_log_driver_config" ]
+    [#local dockerLoggingDriverScript = []]
+    [#switch defaultLogDriver ]
+        [#case "awslogs"]
+            [#break]
+
+        [#case "json-file"]
+        [#case "fluentd" ]
+            [#local dockerLoggingDriverScript += [
+                r'function update_log_driver {',
+                r'  local ecs_log_driver="$1"; shift',
+                r'  . /etc/sysconfig/docker',
+                r'  if [[ -n "${OPTIONS}" ]]; then',
+                r'     sed -i "s,^\(OPTIONS=\).*,\1\"${OPTIONS} --log-driver=${ecs_log_driver}\",g" /etc/sysconfig/docker',
+                r'  else',
+                r'     echo "OPTIONS=\"--log-driver=${ecs_log_driver}\"" >> /etc/sysconfig/docker',
+                r'    fi'
+                r'}',
+                'update_log_driver "${defaultLogDriver}"'
+            ]]
+            [#break]
+    [/#switch]
+
+    [#if dockerLoggingDriverScript?has_content ]
+        [#local dockerVolumeDriverScript = [
+            r'#!/bin/bash',
+            r'set -euo pipefail',
+            'exec > >(tee /var/log/hamlet_cfninit/${dockerLoggingDriverScriptName}.log | logger -t ${dockerLoggingDriverScriptName} -s 2>/dev/console) 2>&1'
+        ] + dockerLoggingDriverScript ]
+    [/#if]
+
+    [#local commands +=
+        attributeIfContent(
+            "2_ConfigureDefaultLogDriver",
+            dockerLoggingDriverScript,
+            {
+                "command" : "/opt/hamlet_cfninit/${dockerLoggingDriverScriptName}.sh",
+                "ignoreErrors" : false
+            }
+        )]
+
+    [#local ecsCluster = valueIfContent(
+                            getExistingReference(ecsId),
+                            getExistingReference(ecsId),
+                            getReference(ecsId)
+                    )]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_AWS_ECS_AGENT_SETUP ]
+        id="ECSAgent"
+        priority=5
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content={
+                "files" : {
+                    "/etc/ecs/ecs.config" : {
+                        "content" : {
+                            "Fn::Join" : [
+                                "\n",
+                                [
+                                    {
+                                        "Fn::Sub" : [
+                                            r'ECS_CLUSTER=${clusterId}',
+                                            { "clusterId": ecsCluster }
+                                        ]
+                                    }
+                                    r'ECS_LOGLEVEL=warn',
+                                    r'ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=10m',
+                                    r'ECS_AVAILABLE_LOGGING_DRIVERS=["awslogs","fluentd","gelf","json-file","journald","syslog"]'
+                                ]
+                            ]
+                        },
+                        "mode" : "000644"
+                    }
+                } +
+                attributeIfContent(
+                    "/opt/hamlet_cfninit/${dockerVolumeDriverScriptName}.sh",
+                    dockerVolumeDriverScript,
+                    {
+                        "content" : {
+                            "Fn::Join" : [
+                                "\n",
+                                dockerVolumeDriverScript
+                            ]
+                        },
+                        "mode" : "000755"
+                    }
+                ) +
+                attributeIfContent(
+                    "/opt/hamlet_cfninit/${dockerLoggingDriverScriptName}.sh",
+                    dockerLoggingDriverScript,
+                    {
+                        "content" : {
+                            "Fn::Join" : [
+                                "\n",
+                                dockerLoggingDriverScript
+                            ]
+                        }
+                    }
+                ),
+                "services" : {
+                    "sysvinit" : {
+                        "docker" : {
+                            "enabled" : true,
+                            "ensureRunning" : true,
+                            "files" : [ ] +
+                            valueIfContent(
+                                [ "/opt/hamlet_cfninit/${dockerLoggingDriverScriptName}.sh" ],
+                                dockerLoggingDriverScript,
+                                []
+                            )
+                        }
+                    }
+                }
+            } +
+            attributeIfContent(
+                "users",
+                userInit
+            ) +
+            attributeIfContent(
+                "commands",
+                commands
+            )
+    /]
+[/#macro]

--- a/aws/extensions/computetask_awslinux_efsmount/extension.ftl
+++ b/aws/extensions/computetask_awslinux_efsmount/extension.ftl
@@ -1,0 +1,130 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_awslinux_efsmount"
+    aliases=[
+        "_computetask_awslinux_efsmount"
+    ]
+    description=[
+        "Mount efs component mount points using efs-utils"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_awslinux_efsmount_deployment_computetask occurrence ]
+
+    [#local solution = occurrence.Configuration.Solution ]
+
+    [#local files = {}]
+    [#local commands = {}]
+
+    [#list _context.Links as linkId,linkTarget]
+        [#local linkTargetCore = linkTarget.Core ]
+        [#local linkTargetAttributes = linkTarget.State.Attributes ]
+
+        [#switch linkTargetCore.Type]
+            [#case EFS_COMPONENT_TYPE ]
+            [#case EFS_MOUNT_COMPONENT_TYPE]
+
+                [#local mountId = linkTargetCore.Id]
+                [#local efsId = linkTargetAttributes.EFS]
+                [#local directory = linkTargetAttributes.DIRECTORY]
+                [#local osMount = linkId]
+                [#local accessPointId=   (linkTargetAttributes.ACCESS_POINT_ID)!"" ]
+
+                [#local createMount = true]
+                [#if directory == "/" ]
+                    [#local createMount = false ]
+                [/#if]
+
+                [#local scriptName = "efs_mount_${mountId}" ]
+
+                [#local script = [
+                    r'#!/bin/bash',
+                    'exec > >(tee /var/log/hamlet_cfninit/${scriptName}.log | logger -t ${scriptName} -s 2>/dev/console) 2>&1'
+                ]]
+
+                [#local efsOptions = [ "_netdev", "tls", "iam"]]
+
+                [#if accessPointId?has_content ]
+                    [#local efsOptions += [ "accesspoint=${accessPointId}" ]]
+                [/#if]
+
+                [#local efsOptions = efsOptions?join(",")]
+
+                [#if createMount ]
+                    [#local script += [
+                        r'# Create mount dir in EFS',
+                        r'temp_dir="$(mktemp -d -t efs.XXXXXXXX)"',
+                        r'mount -t efs "${efsId}:/" ${temp_dir} || exit $?',
+                        r'if [[ ! -d "${temp_dir}/' + directory + r' ]]; then',
+                        r'  mkdir -p "${temp_dir}/' + directory + r'"',
+                        r'  # Allow Full Access to volume (Allows for unkown container access )',
+                        r'  chmod -R ugo+rwx "${temp_dir}/' + directory + r'"',
+                        r'fi',
+                        r'umount ${temp_dir}'
+                    ]]
+                [/#if]
+
+                [#local mountPath = "/mnt/clusterstorage/${osMount}" ]
+
+                [#local script += [
+                    'mkdir -p "${mountPath}"',
+                    'mount -t efs -o "${efsOptions}" "${efsId}:${directory}" "${mountPath}"',
+                    'echo -e "${efsId}:${directory} ${mountPath} efs ${efsOptions} 0 0" >> /etc/fstab'
+                ]]
+
+                [#local files += {
+                    "/opt/hamlet_cfninit/${scriptName}.sh" : {
+                        "content" : {
+                            "Fn::Join" : [
+                                "\n",
+                                script
+                            ]
+                        },
+                        "mode" : "000755"
+                    }
+                }]
+
+                [#local commands += {
+                    scriptName : {
+                        "command" : "/opt/hamlet_cfninit/${scriptName}.sh",
+                        "ignoreErrors" : false
+                    }
+                }]
+
+                [#break]
+        [/#switch]
+    [/#list]
+
+    [#local content = {} ]
+    [#if files?has_content && commands?has_content ]
+        [#local content =
+            {
+                "packages" : {
+                    "yum" : {
+                        "amazon-efs-utils" : []
+                    }
+                },
+                "files" : files,
+                "commands" :  commands
+            }
+        ]
+    [/#if]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_EFS_MOUNT ]
+        id="EFSMounts"
+        priority=4
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content=content
+    /]
+[/#macro]

--- a/aws/extensions/computetask_awslinux_eip/extension.ftl
+++ b/aws/extensions/computetask_awslinux_eip/extension.ftl
@@ -1,0 +1,80 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_awslinux_eip"
+    aliases=[
+        "_computetask_awslinux_eip"
+    ]
+    description=[
+        "Uses the awscli to allocate an elastic ip"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_awslinux_eip_deployment_computetask occurrence ]
+
+    [#local eips = _context.ElasticIPs ]
+    [#local content = {}]
+
+    [#if eips?has_content]
+        [#local allocationIds = eips?map( eip -> getReference(eip, ALLOCATION_ATTRIBUTE_TYPE))]
+
+        [#local script = [
+            r'#!/bin/bash',
+            r'set -euo pipefail',
+            r'exec > >(tee /var/log/hamlet_cfninit/eip.log | logger -t codeontap-eip -s 2>/dev/console) 2>&1',
+            r'INSTANCE=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)',
+            { "Fn::Sub" : r'export AWS_DEFAULT_REGION="${AWS::Region}"' },
+            {
+                "Fn::Sub" : [
+                    r'available_eip="$(aws ec2 describe-addresses --filter "Name=allocation-id,Values=${AllocationIds}" --query ' + r"'Addresses[?AssociationId==`null`].AllocationId | [0]' " + '--output text )"',
+                    { "AllocationIds": { "Fn::Join" : [ ",", allocationIds ] }}
+                ]
+            },
+            r'if [[ -n "${available_eip}" && "${available_eip}" != "None" ]]; then',
+            r'  aws ec2 associate-address --instance-id ${INSTANCE} --allocation-id ${available_eip} --no-allow-reassociation',
+            r'else',
+            r'  >&2 echo "No elastic IP available to allocate"',
+            r'  exit 255',
+            r'fi'
+        ]]
+
+        [#local content = {
+            "files" : {
+                "/opt/hamlet_cfninit/eip_allocation.sh" : {
+                    "content" : {
+                        "Fn::Join" : [
+                            "\n",
+                            script
+                        ]
+                    },
+                    "mode" : "000755"
+                }
+            },
+            "commands" : {
+                "01AssignEIP" : {
+                    "command" : "/opt/hamlet_cfninit/eip_allocation.sh",
+                    "ignoreErrors" : false
+                }
+            }
+        }]
+
+    [/#if]
+
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_AWS_EIP ]
+        id="EIPAllocation"
+        priority=3
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content=content
+    /]
+[/#macro]

--- a/aws/extensions/computetask_awslinux_ospatching/extension.ftl
+++ b/aws/extensions/computetask_awslinux_ospatching/extension.ftl
@@ -1,0 +1,71 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_awslinux_ospatching"
+    aliases=[
+        "_computetask_awslinux_ospatching"
+    ]
+    description=[
+        "Creates a cron based yum update for security patching"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_awslinux_ospatching_deployment_computetask occurrence ]
+
+    [#local OSPatching = _context.InstanceOSPatching ]
+    [#local schedule = OSPatching.Schedule ]
+    [#local securityOnly = OSPatching.SecurityOnly ]
+
+    [#local updateCommand = "yum clean all && yum -y update"]
+
+    [#if OSPatching.Enabled ]
+        [#local content = {
+                "commands": {
+                    "InitialUpdate" : {
+                        "command" : updateCommand,
+                        "ignoreErrors" : false
+                    }
+                } +
+                securityOnly?then(
+                    {
+                        "DailySecurity" : {
+                            "command" : 'echo \"${schedule} ${updateCommand} --security >> /var/log/update.log 2>&1\" >crontab.txt && crontab crontab.txt',
+                            "ignoreErrors" : false
+                        }
+                    },
+                    {
+                        "DailyUpdates" : {
+                            "command" : 'echo \"${schedule} ${updateCommand} >> /var/log/update.log 2>&1\" >crontab.txt && crontab crontab.txt',
+                            "ignoreErrors" : false
+                        }
+                    }
+                )
+            }]
+    [#else]
+        [#local content = {
+            "copmmands" : {
+                "PatchWarning" : {
+                    "command" : 'echo "OS Patching Disabled" >> /var/log/update.log',
+                    "ignoreErrors" : false
+                }
+            }
+        }]
+    [/#if]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_OS_SECURITY_PATCHING ]
+        id="OSPatching"
+        priority=1
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content=content
+    /]
+[/#macro]

--- a/aws/extensions/computetask_awslinux_sshkeys/extension.ftl
+++ b/aws/extensions/computetask_awslinux_sshkeys/extension.ftl
@@ -1,0 +1,92 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_linux_sshkeys"
+    aliases=[
+        "_computetask_linux_sshkeys"
+    ]
+    description=[
+        "Add additional SSH keys to the default ec2-user account"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_linux_sshkeys_deployment_computetask occurrence ]
+
+    [#local SSHPublicKeysContent = "" ]
+
+    [#list _context.Links as linkId,linkTarget]
+        [#local linkTargetCore = linkTarget.Core ]
+        [#local linkTargetConfiguration = linkTarget.Configuration ]
+        [#local linkTargetResources = linkTarget.State.Resources ]
+        [#local linkTargetAttributes = linkTarget.State.Attributes ]
+        [#local linkTargetRoles = linkTarget.State.Roles]
+
+        [#switch linkTargetCore.Type]
+            [#case USER_COMPONENT_TYPE]
+                [#local SSHPublicKeys = linkTargetConfiguration.Solution.SSHPublicKeys ]
+                [#local linkEnvironment = linkTargetConfiguration.Environment.General ]
+                [#list SSHPublicKeys as id,publicKey ]
+                    [#if (linkEnvironment[publicKey.SettingName])?has_content ]
+                        [#local SSHPublicKeysContent += linkEnvironment[publicKey.SettingName] + " " + id ]
+                        [#if (SSHPublicKeys?keys)?seq_index_of(id) != ((SSHPublicKeys?keys)?size - 1)]
+                            [#local SSHPublicKeysContent += ""]
+                        [/#if]
+                    [/#if]
+                [/#list]
+                [#break]
+        [/#switch]
+    [/#list]
+
+    [#local content = {}]
+    [#if SSHPublicKeysContent?has_content ]
+        [#local content = {
+            "files" :{
+                "/home/ec2-user/.ssh/authorized_keys_hamlet" : {
+                    "content" : {
+                        "Fn::Join" : [
+                            "",
+                            [
+                                SSHPublicKeysContent
+                            ]
+                        ]
+                    },
+                    "mode" : "000600",
+                    "group" : "ec2-user",
+                    "owner" : "ec2-user"
+                }
+            },
+            "commands": {
+                "01UpdateSSHDConfig" : {
+                    "command" : "sed -i 's#^\\(AuthorizedKeysFile.*$\\)#\\1 .ssh/authorized_keys_hamlet#' /etc/ssh/sshd_config",
+                    "ignoreErrors" : false
+                }
+            },
+            "services" : {
+                "sysvinit" :{
+                    "sshd" : {
+                        "ensureRunning" : true,
+                        "files" : [ "/home/ec2-user/.ssh/authorized_keys_hamlet" ]
+                    }
+                }
+            }
+        }]
+    [/#if]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_USER_ACCESS ]
+        id="SSHKeys"
+        priority=5
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content=content
+    /]
+
+[/#macro]

--- a/aws/extensions/computetask_awslinux_ssm/extension.ftl
+++ b/aws/extensions/computetask_awslinux_ssm/extension.ftl
@@ -1,0 +1,44 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_awslinux_ssm"
+    aliases=[
+        "_computetask_awslinux_ssm"
+    ]
+    description=[
+        "Install and enable the System Set Manager agent"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_awslinux_ssm_deployment_computetask occurrence ]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_GENERAL_TASK ]
+        id="SSMAgent"
+        priority=1
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content={
+            "packages" : {
+                "yum" : {
+                    "amazon-ssm-agent" : []
+                }
+            },
+            "commands" : {
+                "StartSSMAgent" : {
+                    "command" : "start amazon-ssm-agent || status amazon-ssm-agent",
+                    "ignoreErrors" : false
+                }
+            }
+        }
+    /]
+
+[/#macro]

--- a/aws/extensions/computetask_awslinux_vpc_lb/extension.ftl
+++ b/aws/extensions/computetask_awslinux_vpc_lb/extension.ftl
@@ -1,0 +1,139 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_awslinux_vpc_lb"
+    aliases=[
+        "_computetask_awslinux_vpc_lb"
+    ]
+    description=[
+        "Uses the awscli to register with a vpc laod balancer"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_awslinux_vpc_lb_deployment_computetask occurrence ]
+
+    [#local files = {}]
+    [#local commands = {}]
+
+    [#list _context.Links as linkId,link]
+        [#local linkTarget = getLinkTarget(occurrence, link) ]
+
+        [@debug message="Link Target" context=linkTarget enabled=false /]
+
+        [#if !linkTarget?has_content]
+            [#continue]
+        [/#if]
+
+        [#local linkTargetCore = linkTarget.Core ]
+        [#local linkTargetConfiguration = linkTarget.Configuration ]
+        [#local linkTargetResources = linkTarget.State.Resources ]
+        [#local linkTargetAttributes = linkTarget.State.Attributes ]
+
+        [#local sourceSecurityGroupIds = []]
+        [#local sourceIPAddressGroups = [] ]
+
+        [#switch linkTargetCore.Type]
+            [#case LB_PORT_COMPONENT_TYPE]
+
+                [#switch linkTargetAttributes["ENGINE"]]
+
+                    [#case "application"]
+                    [#case "network"]
+                        [#local configSets += getInitConfigLBTargetRegistration(linkTargetCore.Id, linkTargetAttributes["TARGET_GROUP_ARN"])]
+
+                        [#local portid = linkTargetCore.Id ]
+                        [#local targetGroupArn = linkTargetAttributes["TARGET_GROUP_ARN"]]
+
+                        [#local scriptName = "register_targetgroup_${portId}" ]
+                        [#local files += {
+                            "/opt/hamlet_cfninit/${scriptName}.sh" : {
+                                "content" : {
+                                    "Fn::Join" : [
+                                        "\n",
+                                        [
+                                            r'#!/bin/bash',
+                                            r'set -euo pipefail',
+                                            'exec > >(tee /var/log/hamlet_cfninit/${scriptName}.log | logger -t ${scriptName} -s 2>/dev/console) 2>&1',
+                                            {
+                                                "Fn::Sub" : [
+                                                    r'aws --region "${AWS::Region}" elbv2 register-targets --target-group-arn "${TargeGroupArn}" --targets "Id=$(curl http://169.254.169.254/latest/meta-data/instance-id)"',
+                                                    { "TargeGroupArn": targetGroupArn }
+                                                ]
+                                            }
+                                        ]
+                                    ]
+                                },
+                                "mode" : "000755"
+                            }
+                        }]
+
+                        [#local commands += {
+                            scriptName : {
+                                "command" : "/opt/hamlet_cfninit/${scriptName}.sh",
+                                "ignoreErrors" : false
+                            }
+                        }]
+
+                        [#break]
+
+                    [#case "classic" ]
+                        [#local lbId =  linkTargetAttributes["LB"] ]
+                        [#local scriptName = "register_classiclb_${lbId}" ]
+
+                        [#local files +=  {
+                            "/opt/hamlet_cfninit/${scriptName}.sh" : {
+                                "content" : {
+                                    "Fn::Join" : [
+                                        "\n",
+                                        [
+                                            r'#!/bin/bash',
+                                            r'set -euo pipefail',
+                                            'exec > >(tee /var/log/hamlet_cfninit/${scriptName}.log | logger -t ${scriptName} -s 2>/dev/console) 2>&1',
+                                            {
+                                                "Fn::Sub" : [
+                                                    r'aws --region "${AWS::Region}" elb register-instances-with-load-balancer --load-balancer-name "${LoadBalancer}" --instances "$(curl http://169.254.169.254/latest/meta-data/instance-id)"',
+                                                    { "LoadBalancer": getReference(lbId) }
+                                                ]
+                                            }
+                                        ]
+                                    ]
+                                },
+                                "mode" : "000755"
+                            }
+                        }]
+                        [#local commands += {
+                            scriptName : {
+                                "command" : "/opt/hamlet_cfninit/${scriptName}.sh",
+                                "ignoreErrors" : false
+                            }
+                        }]
+
+                        [#break]
+                [/#switch]
+                [#break]
+        [/#switch]
+    [/#list]
+
+    [#local content = {}]
+    [#if files?has_content && commands?has_content ]
+        [#local content = {
+            "files" : files,
+            "commands" : commands
+        }]
+    [/#if]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_OS_SECURITY_PATCHING ]
+        id="LoadBalancerRegistration"
+        priority=8
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content=content
+    /]
+[/#macro]

--- a/aws/extensions/computetask_linux_filedir/extension.ftl
+++ b/aws/extensions/computetask_linux_filedir/extension.ftl
@@ -1,0 +1,122 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_linux_filedir"
+    aliases=[
+        "_computetask_linux_filedir"
+    ]
+    description=[
+        "Uses linux commands to create files and directories"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_linux_filedir_deployment_computetask occurrence ]
+
+    [#local files = _context.Files ]
+    [#local directories = _context.Directories ]
+
+    [#local initFiles = {} ]
+    [#list files as fileName,file ]
+
+        [#local fileMode = (file.mode?length == 3)?then(
+                                    file.mode?left_pad(6, "0"),
+                                    file.mode )]
+
+        [#local initFiles +=
+            {
+                fileName : {
+                    "content" : {
+                        "Fn::Join" : [
+                            "\n",
+                            file.content
+                        ]
+                    },
+                    "group" : file.group,
+                    "owner" : file.owner,
+                    "mode"  : fileMode
+                }
+            }]
+    [/#list]
+
+    [#local initDirFile = [
+        '#!/bin/bash',
+        'exec > >(tee /var/log/hamlet_cfninit/dirsfiles.log | logger -t codeontap-dirsfiles -s 2>/dev/console) 2>&1'
+    ]]
+
+    [#list directories as directoryName,directory ]
+
+        [#local mode = directory.mode ]
+        [#local owner = directory.owner ]
+        [#local group = directory.group ]
+
+        [#local initDirFile += [
+            'if [[ ! -d "${directoryName}" ]]; then',
+            '   mkdir --parents --mode="${mode}" "${directoryName}"',
+            '   chown ${owner}:${group} "${directoryName}"',
+            'else',
+            '   chown -R ${owner}:${group} "${directoryName}"',
+            '   chmod ${mode} "${directoryName}"',
+            'fi'
+        ]]
+    [/#list]
+
+
+    [#local content = {}]
+    [#if files?has_content || directories?has_content ]
+        [#local content = {
+            "commands" : {
+                "status" : {
+                    "command" : r'echo "Direcotry and File Creation" >> /var/log/hamlet_cfninit/dirsfiles.log'
+                }
+            } } +
+            attributeIfContent(
+                "CreateDirs",
+                directories,
+                {
+                    "files" : {
+                        "/opt/hamlet_cfninit/create_dirs.sh" : {
+                            "content" : {
+                                "Fn::Join" : [
+                                    "\n",
+                                    initDirFile
+                                ]
+                            },
+                            "mode" : "000755"
+                        }
+                    },
+                    "commands" : {
+                        "CreateDirScript" : {
+                            "command" : "/opt/hamlet_cfninit/create_dirs.sh",
+                            "ignoreErrors" : false
+                        }
+                    }
+                }
+            ) +
+            attributeIfContent(
+                "CreateFiles",
+                files,
+                {
+                    "files" : initFiles
+                }
+
+            )]
+    [/#if]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_FILE_DIR_CREATION ]
+        id="FileDirectories"
+        priority=3
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content=content
+    /]
+
+[/#macro]

--- a/aws/extensions/computetask_linux_hamletenv/extension.ftl
+++ b/aws/extensions/computetask_linux_hamletenv/extension.ftl
@@ -1,0 +1,85 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_linux_hamletenv"
+    aliases=[
+        "_computetask_linux_hamletenv"
+    ]
+    description=[
+        "Uses the shared profile configuration to set default environment varaibles"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_linux_hamletenv_deployment_computetask occurrence ]
+
+    [#local baselineLinks = _context.BaselineLinks]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+    [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
+    [#local envVariables = getFinalEnvironment(occurrence, _context ).Environment ]
+
+    [#local role = (occurrence.Configuration.Settings.Product["Role"].Value)!""]
+
+    [#local envContent = [
+        r'# Set environment variables from hamlet configuration',
+        r'export cot_request="'       + getCLORequestReference()        + '"',
+        r'export cot_configuration="' + getCLOConfigurationReference()  + '"',
+        r'export cot_accountRegion="' + accountRegionId                 + '"',
+        r'export cot_tenant="'        + tenantId                        + '"',
+        r'export cot_account="'       + accountId                       + '"',
+        r'export cot_product="'       + productId                       + '"',
+        r'export cot_region="'        + regionId                        + '"',
+        r'export cot_segment="'       + segmentId                       + '"',
+        r'export cot_environment="'   + environmentId                   + '"',
+        r'export cot_tier="'          + occurrence.Core.Tier.Id         + '"',
+        r'export cot_component="'     + occurrence.Core.Component.Id    + '"',
+        r'export cot_role="'          + role                            + '"',
+        r'export cot_credentials="'   + credentialsBucket               + '"',
+        r'export cot_code="'          + codeBucket                      + '"',
+        r'export cot_logs="'          + operationsBucket                + '"',
+        r'export cot_backups="'       + dataBucket                      + '"'
+    ]]
+
+    [#list envVariables as key,value]
+        [#local envContent +=
+            [
+                'export ${key}="${value}"'
+            ]
+        ]
+    [/#list]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES ]
+        id="HamletEnv"
+        priority=2
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content={
+                "files" : {
+                    "/etc/profile.d/hamlet_env.sh" : {
+                        "content" : {
+                            "Fn::Join" : [
+                                "\n",
+                                envContent
+                            ]
+                        },
+                        "mode" : "000644"
+                    }
+                },
+                "commands": {
+                    "01Directories" : {
+                        "command" : "mkdir --parents --mode=0755 /var/log/codeontap",
+                        "ignoreErrors" : false
+                    }
+                }
+            }
+    /]
+[/#macro]

--- a/aws/extensions/computetask_linux_hamletenv/extension.ftl
+++ b/aws/extensions/computetask_linux_hamletenv/extension.ftl
@@ -31,22 +31,22 @@
 
     [#local envContent = [
         r'# Set environment variables from hamlet configuration',
-        r'export cot_request="'       + getCLORequestReference()        + '"',
-        r'export cot_configuration="' + getCLOConfigurationReference()  + '"',
-        r'export cot_accountRegion="' + accountRegionId                 + '"',
-        r'export cot_tenant="'        + tenantId                        + '"',
-        r'export cot_account="'       + accountId                       + '"',
-        r'export cot_product="'       + productId                       + '"',
-        r'export cot_region="'        + regionId                        + '"',
-        r'export cot_segment="'       + segmentId                       + '"',
-        r'export cot_environment="'   + environmentId                   + '"',
-        r'export cot_tier="'          + occurrence.Core.Tier.Id         + '"',
-        r'export cot_component="'     + occurrence.Core.Component.Id    + '"',
-        r'export cot_role="'          + role                            + '"',
-        r'export cot_credentials="'   + credentialsBucket               + '"',
-        r'export cot_code="'          + codeBucket                      + '"',
-        r'export cot_logs="'          + operationsBucket                + '"',
-        r'export cot_backups="'       + dataBucket                      + '"'
+        r'export hamlet_request="'       + getCLORequestReference()        + '"',
+        r'export hamlet_configuration="' + getCLOConfigurationReference()  + '"',
+        r'export hamlet_accountRegion="' + accountRegionId                 + '"',
+        r'export hamlet_tenant="'        + tenantId                        + '"',
+        r'export hamlet_account="'       + accountId                       + '"',
+        r'export hamlet_product="'       + productId                       + '"',
+        r'export hamlet_region="'        + regionId                        + '"',
+        r'export hamlet_segment="'       + segmentId                       + '"',
+        r'export hamlet_environment="'   + environmentId                   + '"',
+        r'export hamlet_tier="'          + occurrence.Core.Tier.Id         + '"',
+        r'export hamlet_component="'     + occurrence.Core.Component.Id    + '"',
+        r'export hamlet_role="'          + role                            + '"',
+        r'export hamlet_credentials="'   + credentialsBucket               + '"',
+        r'export hamlet_code="'          + codeBucket                      + '"',
+        r'export hamlet_logs="'          + operationsBucket                + '"',
+        r'export hamlet_backups="'       + dataBucket                      + '"'
     ]]
 
     [#list envVariables as key,value]

--- a/aws/extensions/computetask_linux_scriptsdeployment/extension.ftl
+++ b/aws/extensions/computetask_linux_scriptsdeployment/extension.ftl
@@ -1,0 +1,106 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_linux_scriptsdeployment"
+    aliases=[
+        "_computetask_linux_scriptsdeployment"
+    ]
+    description=[
+        "Runs a deployment from a scripts deployment"
+    ]
+    supportedTypes=[
+        COMPUTECLUSTER_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_linux_scriptsdeployment_deployment_computetask occurrence ]
+
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local scriptsFile = _context.ScriptsFile ]
+    [#local envVariables = getFinalEnvironment(occurrence, _context).Environment ]
+    [#local shutDownOnCompletion=solution.UseInitAsService ]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_RUN_SCRIPTS_DEPLOYMENT ]
+        id="RunScriptsDeployment"
+        priority=100
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content={
+            "packages" : {
+                "yum" : {
+                    "aws-cli" : [],
+                    "unzip" : []
+                }
+            },
+            "files" :{
+                "/opt/hamlet_cfninit/fetch_scripts.sh" : {
+                    "content" : {
+                        "Fn::Join" : [
+                            "\n",
+                            [
+                                r'#!/bin/bash -ex',
+                                r'exec > >(tee /var/log/hamlet_cfninit/fetch-scripts.log | logger -t codeontap-scripts-fetch -s 2>/dev/console) 2>&1',
+                                {
+                                    "Fn::Sub" : [
+                                        r'aws --region "${Region}" s3 cp --quiet "s3://${ScriptsFile}" /opt/hamlet/scripts',
+                                        {
+                                            "Region" : { "Fn::Ref" : "AWS::Region" },
+                                            "ScriptsFile" : scriptsFile
+                                        }
+                                    ]
+                                },
+                                r' if [[ -f /opt/hamlet/scripts/scripts.zip ]]; then',
+                                r'unzip /opt/hamlet/scripts/scripts.zip -d /opt/hamlet/scripts/',
+                                r'chmod -R 0544 /opt/hamlet/scripts/',
+                                r'else',
+                                r'exit 1',
+                                r'fi'
+                            ]
+                        ]
+                    },
+                    "mode" : "000755"
+                },
+                "/opt/hamlet_cfninit/run_scripts.sh" : {
+                    "content" : {
+                        "Fn::Join" : [
+                            "\n",
+                            [
+                                r'#!/bin/bash -ex',
+                                r'exec > >(tee /var/log/hamlet_cfninit/fetch.log|logger -t codeontap-scripts-init -s 2>/dev/console) 2>&1',
+                                r'[ -f /opt/hamlet/scripts/init.sh ] &&  /opt/hamlet/scripts/init.sh'
+                            ]
+                        ]
+                    },
+                    "mode" : "000755"
+                }
+            },
+            "commands" : {
+                "01RunInitScript" : {
+                    "command" : "/opt/hamlet_cfninit/fetch_scripts.sh",
+                    "ignoreErrors" : false
+                },
+                "02RunInitScript" : {
+                    "command" : "/opt/hamlet_cfninit/run_scripts.sh",
+                    "cwd" : "/opt/hamlet/scripts/",
+                    "ignoreErrors" : false
+                } +
+                attributeIfContent(
+                    "env",
+                    envVariables,
+                    envVariables
+                )
+            } + shutDownOnCompletion?then(
+                {
+                    "03ShutDownInstance" : {
+                        "command" : "shutdown -P +10",
+                        "ignoreErrors" : false
+                    }
+                },
+                {}
+            )
+        }
+    /]
+[/#macro]

--- a/aws/extensions/computetask_linux_userbootstrap/extension.ftl
+++ b/aws/extensions/computetask_linux_userbootstrap/extension.ftl
@@ -1,0 +1,138 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_linux_userbootstrap"
+    aliases=[
+        "_computetask_linux_userbootstrap"
+    ]
+    description=[
+        "Uses linux commands to create files and directories"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_linux_userbootstrap_deployment_computetask occurrence ]
+
+    [#local environment = getFinalEnvironment(occurrence, _context ).Environment ]
+
+    [#local files = {}]
+    [#local commands = {}]
+    [#local userBootstrapPackages = {}]
+
+    [#local bootstrapProfile = _context.BootstrapProfile ]
+
+    [#list bootstrapProfile.BootStraps as bootstrapName ]
+        [#local bootstrap = bootstraps[bootstrapName]]
+
+        [#local scriptStore = scriptStores[bootstrap.ScriptStore ]]
+        [#local scriptStorePrefix = scriptStore.Destination.Prefix ]
+
+        [#list bootstrap.Packages!{} as provider,packages ]
+            [#local providerPackages = {}]
+            [#if packages?is_sequence ]
+                [#list packages as package ]
+                    [#local providerPackages +=
+                        {
+                            package.Name : [] +
+                                (package.Version)?has_content?then(
+                                    [ package.Version ],
+                                    []
+                                )
+                        }]
+                [/#list]
+            [/#if]
+            [#if providerPackages?has_content ]
+                [#local userBootstrapPackages +=
+                    {
+                        provider : providerPackages
+                    }]
+            [/#if]
+        [/#list]
+
+        [#local bootstrapDir = "/opt/hamlet/user/" + boostrapName ]
+        [#local bootstrapFetchFile = bootstrapDir + "/fetch.sh" ]
+        [#local bootstrapScriptsDir = bootstrapDir + "/scripts/" ]
+        [#local bootstrapInitFile = bootstrapScriptsDir + bootstrap.InitScript!"init.sh" ]
+
+
+        [#local files += {
+            bootstrapFetchFile: {
+                "content" : {
+                    "Fn::Join" : [
+                        "\n",
+                        [
+                            "#!/bin/bash -ex",
+                            "exec > >(tee /var/log/hamlet_cfninit/fetch.log | logger -t codeontap-fetch -s 2>/dev/console) 2>&1",
+                            {
+                                "Fn::Sub" : [
+                                    r'BOOTSTRAP_SCRIPTS_DIR="${BootstrapScriptsDir}"',
+                                    {
+                                        "BootstrapScriptsDir" : bootstrapScriptsDir
+                                    }
+                                ]
+                            },
+                            {
+                                "Fn::Sub" : [
+                                    r'aws --region "${Region}" s3 sync "s3://${CodeBucket}/${ScriptStorePrefix}" "${!BOOTSTRAP_SCRIPTS_DIR}"',
+                                    {
+                                        "Region" : { "Ref" : "AWS::Region" },
+                                        "CodeBucket" : codeBucket,
+                                        "ScriptStorePrefix" : scriptStorePrefix
+                                    }
+                                ]
+                            },
+                            r'find "${!BOOTSTRAP_SCRIPTS_DIR}" -type f -exec chmod u+rwx {} \\;'
+                        ]
+                    ]
+                },
+                "mode" : "000755"
+            }
+        } ]
+
+        [#local commands += {
+            "01Fetch_${bootstrapFetchFile}" : {
+                "command" : bootstrapFetchFile,
+                "ignoreErrors" : false
+            },
+            "02RunScript_${bootstrapInitFile}" : {
+                "command" : bootstrapInitFile,
+                "ignoreErrors" : false,
+                "cwd" : bootstrapScriptsDir
+            } +
+            attributeIfContent(
+                "env",
+                environment
+            )
+        }]
+
+    [/#list]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_USER_BOOTSTRAP ]
+        id="UserBootstrap"
+        priority=7
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content={} +
+        attributeIfContent(
+            "packages",
+            userBootstrapPackages
+        ) +
+        attributeIfContent(
+            "files",
+            files
+        ) +
+        attributeIfContent(
+            "commands",
+            commands
+        )
+    /]
+
+[/#macro]

--- a/aws/extensions/computetask_linux_volumemount/extension.ftl
+++ b/aws/extensions/computetask_linux_volumemount/extension.ftl
@@ -1,0 +1,167 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_linux_volumemount"
+    aliases=[
+        "_computetask_linux_volumemount"
+    ]
+    description=[
+        "Uses linux commands to format and mount volumes"
+    ]
+    supportedTypes=[
+        EC2_COMPONENT_TYPE,
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_linux_volumemount_deployment_computetask occurrence ]
+
+    [#local storageProfile = _context.StorageProfile ]
+    [#local volumes = (storageProfile.Volumes)!{}]
+
+    [#local files = {}]
+    [#local commands = {}]
+
+    [#-- Support for data volumes as linked components to single instances --]
+    [#if occurrence.Core.Type == EC2_COMPONENT_TYPE ]
+        [#list zones as zone]
+            [#if multiAZ || (zones[0].Id = zone.Id)]
+                [#local zoneEc2InstanceId = zoneResources[zone.Id]["ec2Instance"].Id ]
+                [#list (_context.VolumeMounts)![] as mountId,volumeMount ]
+                    [#local dataVolume = _context.DataVolumes[mountId]!{} ]
+                    [#if dataVolume?has_content ]
+                        [#local zoneVolume = (dataVolume[zone.Id].VolumeId)!"" ]
+                        [#if zoneVolume?has_content ]
+                            [@createEBSVolumeAttachment
+                                id=formatDependentResourceId(
+                                    AWS_EC2_EBS_ATTACHMENT_RESOURCE_TYPE,
+                                    zoneEc2InstanceId,
+                                    mountId
+                                )
+                                device=volumeMount.DeviceId
+                                instanceId=zoneEc2InstanceId
+                                volumeId=zoneVolume
+                            /]
+
+                            [#local volumes += {
+                                mountId : {
+                                    "MountPath" : volumeMount.MountPath,
+                                    "Device" : volumeMount.DeviceId
+                                }
+                            }]
+
+                        [/#if]
+                    [/#if]
+                [/#list]
+            [/#if]
+        [/#list]
+    [/#if]
+
+    [#list volumes as id,volume ]
+
+        [#local deviceId = ""]
+        [#local osMount = ""]
+
+        [#if (volume.Enabled)!true
+                && ((volume.MountPath)!"")?has_content
+                && ((volume.Device)!"")?has_content ]
+
+            [#local deviceId = volume.Device]
+            [#local osMount = volume.MountPath]
+
+        [#else]
+            [#continue]
+        [/#if]
+
+        [#local scriptName = "data_volume_mount_" + replaceAlphaNumericOnly(deviceId) ]
+
+        [#local script = [
+            r'#!/bin/bash',
+            r'set -euo pipefail',
+            'exec > >(tee /var/log/hamlet_cfninit/${scriptName}.log | logger -t ${scriptName} -s 2>/dev/console) 2>&1',
+
+            'device_id="${deviceId}"',
+            'os_mount="${osMount}"',
+
+            r'# Ensure device exists',
+            r'if [[ ! -b "${device_id}" ]]; then'
+            r'  echo "${device_id} not available"',
+            r'  exit 1',
+            r'fi',
+
+            r'# Create filesystem if required',
+            r'if [[ -z "$(file  -sL $device_id | grep "ext" || test $? =1 )" ]]; then',
+            r'  mkfs -t ext4 "${device_id}"',
+            r'else',
+            r'  echo "Using existing filesystem on ${device_id}"',
+            r'fi',
+
+            r'# Mount device to mount point',
+            r'for local_mount_point in $(findmnt -frnuo TARGET --source "${device_id}" || test $? = 1 ); do',
+            r'  if [[ "${local_mount_point}" == "${os_mount}" ]]; then',
+            r'      echo "${device_id} already mounted to ${os_mount}"',
+            r'      exit 0',
+            r'  else',
+            r'      echo "${device_id} is not mounted to ${os_mount}"',
+            r'  fi',
+            r'done',
+            r'mkdir -p "${os_mount}"',
+            r'mount "${device_id}" "${os_mount}"',
+
+            r'# Permanent mount',
+            r'if [[ -z "$( grep "${device_id}" /etc/fstab || test $? = 1 )" ]]; then',
+            r'  if [[ -n "$( findmnt -frnuo SOURCE --source "${device_id}" || test $? = 1 )" ]]; then',
+            r'      echo -e "${device_id} ${os_mount} ext4 defaults 0 0" >> /etc/fstab',
+            r'    else',
+            r'        echo "device ${device_id} is not mounted"',
+            r'        exit 1',
+            r'    fi',
+            r'else',
+            r'  echo "permanent mount setup ${device_id} to ${os_mount}"',
+            r'fi'
+        ]]
+
+        [#local files += {
+            "/opt/hamlet_cfninit/${scriptName}.sh" : {
+                "content" : {
+                    "Fn::Join" : [
+                        "\n",
+                        script
+                    ]
+                },
+                "mode" : "000755"
+            }
+        }]
+
+        [#local commands += {
+            scriptName : {
+                "command" : "/opt/hamlet_cfninit/${scriptName}.sh",
+                "ignoreErrors" : false
+            }
+        }]
+
+    [/#list]
+
+
+    [#local content = {}]
+    [#if files?has_content && commands?has_content ]
+        [#local content = {
+            "files" : files,
+            "commands" : commands
+        }]
+    [/#if]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[ COMPUTE_TASK_DATA_VOLUME_MOUNTING ]
+        id="VolumeMount"
+        priority=1
+        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+        content=content
+    /]
+
+[/#macro]

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -1209,7 +1209,7 @@
             },
             {
                 "AutoScalingRollingUpdate" : {
-                    "WaitOnResourceSignals" : autoScalingConfig.WaitForSignal,
+                    "WaitOnResourceSignals" : (autoScalingConfig.WaitForSignal)!true,
                     "MinInstancesInService" : autoscalingMinUpdateInstances,
                     "MinSuccessfulInstancesPercent" : autoScalingConfig.MinSuccessInstances,
                     "PauseTime" : "PT" + autoScalingConfig.UpdatePauseTime,
@@ -1224,7 +1224,7 @@
             }
         )
         creationPolicy=
-            autoScalingConfig.WaitForSignal?then(
+            ((autoScalingConfig.WaitForSignal)!true)?then(
                 {
                     "ResourceSignal" : {
                         "Count" : desiredCapacity,


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds compute task definitions and extension implementations to replace the existing InitConfig scripts that we currently use in the AWS provider. 
- Adds  a new task which installs and starts the SSM agent. This is required to make SSM session manager available for ECS hosts 
- Adds a standard userdata script which calls cfn-init and uses cfn-signal to notify cloudformation of the cfn-init status
- Includes a fix to this script to ensure that the script doesn't exit at any failure to allow for quick feedback to cloudformation on the failure of an instance

## Motivation and Context

Mostly covered in https://github.com/hamlet-io/engine/pull/1629  but the idea is to allow for pluggable configuration of instances used as part of components. Extensions also allow for greater portability between different components and allow for users to build their own implementations of tasks as required. 

## How Has This Been Tested?

Tested locally

## Followup Actions

- [x] Requries: https://github.com/hamlet-io/engine/pull/1629
