### PR TITLE
feat: awslinux2 support for ec2 instances

### DIFF
--- a/aws/extensions/computetask_awslinux_ssm/extension.ftl
+++ b/aws/extensions/computetask_awslinux_ssm/extension.ftl
@@ -21,6 +21,44 @@
 
 [#macro shared_extension_computetask_awslinux_ssm_deployment_computetask occurrence ]
 
+    [#local commands = {}]
+    [#local services = {}]
+
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local operatingSystem = solution.ComputeInstance.OperatingSystem]
+
+    [#switch operatingSystem.Family ]
+        [#case "linux" ]
+            [#switch operatingSystem.Distribution ]
+                [#case "awslinux" ]
+                    [#switch operatingSystem.MajorVersion ]
+                        [#case "2"]
+                            [#local services += {
+                                "sysvinit" : {
+                                    "amazon-ssm-agent" : {
+                                        "ensureRunning" : true,
+                                        "enabled" : true,
+                                        "packages" : { "yum" : [ "amazon-ssm-agent" ]}
+                                    }
+                                }
+                            }]
+                            [#break]
+                        [#case "1" ]
+
+                            [#local commands += {
+                                "StartSSMAgent" : {
+                                    "command" : "start amazon-ssm-agent || status amazon-ssm-agent",
+                                    "ignoreErrors" : false
+                                }
+                            }]
+                            [#break]
+                    [/#switch]
+                    [#break]
+            [/#switch]
+            [#break]
+        [#break]
+    [/#switch]
+
     [@computeTaskConfigSection
         computeTaskTypes=[ COMPUTE_TASK_GENERAL_TASK ]
         id="SSMAgent"
@@ -31,14 +69,16 @@
                 "yum" : {
                     "amazon-ssm-agent" : []
                 }
-            },
-            "commands" : {
-                "StartSSMAgent" : {
-                    "command" : "start amazon-ssm-agent || status amazon-ssm-agent",
-                    "ignoreErrors" : false
-                }
             }
-        }
+        } +
+        attributeIfContent(
+            "commands",
+            commands
+        ) +
+        attributeIfContent(
+            "services",
+            services
+        )
     /]
 
 [/#macro]

--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -399,6 +399,16 @@
             "ElasticSearch": {},
             "ComputeCluster": {},
             "bastion": {}
+        },
+        "ecs_awslinux2" : {
+            "ECS" : {
+                "Volumes" : {
+                    "root" : {
+                        "Device" : "/dev/xvda",
+                        "Size" : 50
+                    }
+                }
+            }
         }
     },
     "Processors": {
@@ -862,6 +872,75 @@
                                 "Severity": "Error",
                                 "Statistic": "Average",
                                 "Periods": 2
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "_awslinux2" : {
+            "Modes" : {
+                "*" : {
+                    "ecs" : {
+                        "Profiles" : {
+                            "Storage" : "ecs_awslinux2"
+                        },
+                        "ComputeInstance" : {
+                            "OperatingSystem" : {
+                                "Family" : "linux",
+                                "Distribution" : "awslinux",
+                                "MajorVersion" : "2"
+                            },
+                            "Image" : {
+                                "Source" : "aws:SSMParam",
+                                "aws:Source:SSMParam" : {
+                                    "Name" : "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+                                }
+                            }
+                        }
+                    },
+                    "computecluster" : {
+                        "ComputeInstance" : {
+                            "OperatingSystem" : {
+                                "Family" : "linux",
+                                "Distribution" : "awslinux",
+                                "MajorVersion" : "2"
+                            },
+                            "Image" : {
+                                "Source" : "aws:SSMParam",
+                                "aws:Source:SSMParam" : {
+                                    "Name" : "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
+                                }
+                            }
+                        }
+                    },
+                    "bastion" : {
+                        "ComputeInstance" : {
+                            "OperatingSystem" : {
+                                "Family" : "linux",
+                                "Distribution" : "awslinux",
+                                "MajorVersion" : "2"
+                            },
+                            "Image" : {
+                                "Source" : "aws:SSMParam",
+                                "aws:Source:SSMParam" : {
+                                    "Name" : "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
+                                }
+                            }
+                        }
+                    },
+                    "ec2" : {
+                        "ComputeInstance" : {
+                            "OperatingSystem" : {
+                                "Family" : "linux",
+                                "Distribution" : "awslinux",
+                                "MajorVersion" : "2"
+                            },
+                            "Image" : {
+                                "Source" : "aws:SSMParam",
+                                "aws:Source:SSMParam" : {
+                                    "Name" : "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
+                                }
                             }
                         }
                     }

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -149,7 +149,6 @@
         id=id
         type="AWS::AutoScaling::LaunchConfiguration"
         properties=
-            getBlockDevices(storageProfile) +
             {
                 "KeyName" : getExistingReference(keyPairId, NAME_ATTRIBUTE_TYPE),
                 "InstanceType": processorProfile.Processor,
@@ -167,7 +166,8 @@
                 "IamInstanceProfile" : getReference(instanceProfileId),
                 "AssociatePublicIpAddress" : publicIP,
                 "UserData" : getUserDataFromComputeTasks(computeTaskConfig)
-            }
+            } +
+            getBlockDevices(storageProfile)
         outputs={}
         outputId=outputId
         dependencies=dependencies


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds a deployment profile `_awslinux2` will uses the latest aws linux 2 AMI through SSM parameter store and set OS configuration for extensions to use. This can be applied either on components  or layers based on user requirements to migrate ec2 based components to awslinux2
- Updates extensions to support some of the differences between awslinux and awslinux2
- Fixes a bug in the storage setup which was not including block devices

The ECS storage profile has been updated to reflect the update to the AMI storage which now hosts everything on the root volume. If the device is specified in the block devices with a size larger than the ami on initial boot the file system will be resized to fit the size of the volume which includes the docker storage. 

## Motivation and Context

This allows for a transition to awslinux 2 from our current default of awslinux 1 which is in the process of being deprecated. The ECS optimised image no longer receives updates so the main priority is to get that introduced 

Implementation of https://github.com/hamlet-io/engine/issues/1488 
closes: https://github.com/hamlet-io/engine/issues/171

## How Has This Been Tested?

Tested locally 

## Followup Actions

- Requires: https://github.com/hamlet-io/engine/pull/1642 
