### PR TITLE
feat(ec2): adds support for autoscale lifecycles

### DIFF
--- a/aws/components/bastion/id.ftl
+++ b/aws/components/bastion/id.ftl
@@ -37,7 +37,7 @@
                         {
                             "Names" : "Extensions",
                             "Default" : [
-                                "_computetask_awslinux_cfninit",
+                                "_computetask_awslinux_cfninit_asg",
                                 "_computetask_linux_hamletenv",
                                 "_computetask_linux_volumemount",
                                 "_computetask_awslinux_ospatching",

--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -153,6 +153,7 @@
                 policies=
                     [
                         getPolicyDocument(
+                            ec2AutoScaleGroupLifecyclePermission(bastionAutoScaleGroupName) +
                             ec2IPAddressUpdatePermission() +
                             s3ListPermission(codeBucket) +
                             s3ReadPermission(codeBucket) +

--- a/aws/components/bastion/state.ftl
+++ b/aws/components/bastion/state.ftl
@@ -34,6 +34,7 @@
                     "ComputeTasks" : [
                         COMPUTE_TASK_RUN_STARTUP_CONFIG,
                         COMPUTE_TASK_AWS_CFN_SIGNAL,
+                        COMPUTE_TASK_AWS_ASG_STARTUP_SIGNAL,
                         COMPUTE_TASK_DATA_VOLUME_MOUNTING,
                         COMPUTE_TASK_FILE_DIR_CREATION,
                         COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES,

--- a/aws/components/computecluster/id.ftl
+++ b/aws/components/computecluster/id.ftl
@@ -38,7 +38,7 @@
                         {
                             "Names" : "Extensions",
                             "Default" : [
-                                "_computetask_awslinux_cfninit",
+                                "_computetask_awslinux_cfninit_asg",
                                 "_computetask_linux_hamletenv",
                                 "_computetask_linux_volumemount",
                                 "_computetask_awslinux_ospatching",

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -153,6 +153,7 @@
             policies=
                 [
                     getPolicyDocument(
+                        ec2AutoScaleGroupLifecyclePermission(computeClusterAutoScaleGroupName) +
                         s3ReadPermission(
                             formatRelativePath(
                                 getRegistryEndPoint("scripts", occurrence),

--- a/aws/components/computecluster/state.ftl
+++ b/aws/components/computecluster/state.ftl
@@ -60,6 +60,7 @@
                     "ComputeTasks" : [
                         COMPUTE_TASK_RUN_STARTUP_CONFIG,
                         COMPUTE_TASK_AWS_CFN_SIGNAL,
+                        COMPUTE_TASK_AWS_ASG_STARTUP_SIGNAL,
                         COMPUTE_TASK_DATA_VOLUME_MOUNTING,
                         COMPUTE_TASK_FILE_DIR_CREATION,
                         COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES,

--- a/aws/components/ecs/id.ftl
+++ b/aws/components/ecs/id.ftl
@@ -39,7 +39,7 @@
                         {
                             "Names" : "Extensions",
                             "Default" : [
-                                "_computetask_awslinux_cfninit",
+                                "_computetask_awslinux_cfninit_asg",
                                 "_computetask_linux_hamletenv",
                                 "_computetask_linux_volumemount",
                                 "_computetask_awslinux_ospatching",

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -136,6 +136,7 @@
             policies=
                 [
                     getPolicyDocument(
+                            ec2AutoScaleGroupLifecyclePermission(ecsAutoScaleGroupName) +
                             s3ListPermission(codeBucket) +
                             s3ReadPermission(credentialsBucket, accountId + "/alm/docker") +
                             s3AccountEncryptionReadPermission(

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -16,6 +16,7 @@
     [#local ecsRoleId = resources["role"].Id ]
     [#local ecsInstanceProfileId = resources["instanceProfile"].Id ]
     [#local ecsAutoScaleGroupId = resources["autoScaleGroup"].Id ]
+    [#local ecsAutoScaleGroupName = resources["autoScaleGroup"].Name ]
     [#local ecsLaunchConfigId = resources["launchConfig"].Id ]
     [#local ecsSecurityGroupId = resources["securityGroup"].Id ]
     [#local ecsSecurityGroupName = resources["securityGroup"].Name ]
@@ -79,7 +80,7 @@
     [#local routeTableConfiguration = routeTableLinkTarget.Configuration.Solution ]
     [#local publicRouteTable = routeTableConfiguration.Public ]
 
-    [#local ecsAsgTags = getOccurrenceCoreTags(occurrence, ecsName, "", true)]
+    [#local ecsAsgTags = getOccurrenceCoreTags(occurrence, ecsAutoScaleGroupName, "", true)]
     [#local ecsTags = getOccurrenceCoreTags(occurrence, ecsName )]
 
     [#local environmentVariables = {}]

--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -146,6 +146,7 @@
                     "ComputeTasks" : [
                         COMPUTE_TASK_RUN_STARTUP_CONFIG,
                         COMPUTE_TASK_AWS_CFN_SIGNAL,
+                        COMPUTE_TASK_AWS_ASG_STARTUP_SIGNAL,
                         COMPUTE_TASK_DATA_VOLUME_MOUNTING,
                         COMPUTE_TASK_FILE_DIR_CREATION,
                         COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES,

--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -142,6 +142,7 @@
                 },
                 "autoScaleGroup" : {
                     "Id" : autoScaleGroupId,
+                    "Name" : core.FullName,
                     "Type" : AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE,
                     "ComputeTasks" : [
                         COMPUTE_TASK_RUN_STARTUP_CONFIG,

--- a/aws/computetasks/computetask.ftl
+++ b/aws/computetasks/computetask.ftl
@@ -11,6 +11,17 @@
     ]
 /]
 
+[#assign COMPUTE_TASK_AWS_ASG_STARTUP_SIGNAL = "aws_asg_startup_signal" ]
+[@addComputeTask
+    type=COMPUTE_TASK_AWS_ASG_STARTUP_SIGNAL
+    properties=[
+        {
+            "Type" : "Description",
+            "Value" : "Notify an autoscale group that the instance has completed a its lifecyle startup process"
+        }
+    ]
+/]
+
 [#assign COMPUTE_TASK_AWS_CLI = "aws_cli" ]
 [@addComputeTask
     type=COMPUTE_TASK_AWS_CLI

--- a/aws/extensions/computetask_awslinux_cfninit_asg/extension.ftl
+++ b/aws/extensions/computetask_awslinux_cfninit_asg/extension.ftl
@@ -1,0 +1,96 @@
+[#ftl]
+
+[@addExtension
+    id="computetask_awslinux_cfninit_asg"
+    aliases=[
+        "_computetask_awslinux_cfninit_asg"
+    ]
+    description=[
+        "Updates and runs the cfn init process based on the provided cfninit metadata and sends startup lifecycle event notification"
+    ]
+    supportedTypes=[
+        ECS_COMPONENT_TYPE,
+        COMPUTECLUSTER_COMPONENT_TYPE,
+        BASTION_COMPONENT_TYPE
+    ]
+    scopes=[
+        COMPUTETASK_EXTENSION_SCOPE
+    ]
+/]
+
+[#macro shared_extension_computetask_awslinux_cfninit_asg_deployment_computetask occurrence ]
+
+    [#local computeResourceId = (_context.ComputeResourceId)!"" ]
+
+    [@computeTaskConfigSection
+        computeTaskTypes=[
+            COMPUTE_TASK_RUN_STARTUP_CONFIG,
+            COMPUTE_TASK_AWS_CFN_SIGNAL,
+            COMPUTE_TASK_AWS_ASG_STARTUP_SIGNAL
+        ]
+        id="CFNInitASG"
+        priority=0
+        engine=AWS_EC2_USERDATA_COMPUTE_TASK_CONFIG_TYPE
+        content=[
+            r'#!/bin/bash',
+            r'set -uo pipefail',
+            "exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1",
+            "# Update cfn bootstrap commands",
+            "yum install -y aws-cfn-bootstrap",
+            "# Create staging dirs for cfninit scripts",
+            "mkdir -p /var/log/hamlet_cfninit/",
+            "mkdir -p /opt/hamlet_cfninit/",
+            "# Remainder of configuration via metadata",
+            {
+                "Fn::Sub" : [
+                    r'/opt/aws/bin/cfn-init -v --stack ${StackName} --resource ${Resource} --region ${Region} --configset ${ConfigSet}',
+                    {
+                        "StackName" : { "Ref" : "AWS::StackName" },
+                        "Region" : { "Ref" : "AWS::Region" },
+                        "Resource" : computeResourceId,
+                        "ConfigSet" : computeResourceId
+                    }
+                ]
+            },
+            r'init_status=$?',
+            "# Signal the status from cfn-init",
+            {
+                "Fn::Sub" : [
+                    r'/opt/aws/bin/cfn-signal -e ${!init_status} --stack ${StackName} --resource ${Resource} --region ${Region}',
+                    {
+                        "StackName" : { "Ref" : "AWS::StackName" },
+                        "Region" : { "Ref" : "AWS::Region" },
+                        "Resource" : computeResourceId
+                    }
+                ]
+            },
+            r'# Signal the status to the ASG',
+            r'instance_id="$(curl http://169.254.169.254/latest/meta-data/instance-id)"',
+            {
+                "Fn::Sub" : [
+                    r'asg_name="$(aws --region ${Region} autoscaling describe-auto-scaling-instances --instance-ids "${!instance_id}" --query "AutoScalingInstances[0].AutoScalingGroupName" --output text)"',
+                    {
+                        "Region" : { "Ref" : "AWS::Region" }
+                    }
+                ]
+            },
+            r'if [[ "${init_status}" == "0" ]]; then',
+            r'   echo "init process successful"',
+            r'   asg_result="CONTINUE"',
+            r'else',
+            r'   echo "init process failed"',
+            r'   asg_result="ABANDON"',
+            r'fi',
+            {
+                "Fn::Sub" : [
+                    r'aws --region ${Region} autoscaling complete-lifecycle-action  --lifecycle-hook-name ${HookName} --auto-scaling-group-name ${!asg_name} --instance-id ${!instance_id} --lifecycle-action-result ${!asg_result}'
+                    {
+                        "Region" : { "Ref" : "AWS::Region" },
+                        "HookName" : computeResourceId
+                    }
+                ]
+            }
+        ]
+    /]
+
+[/#macro]

--- a/aws/services/ec2/policy.ftl
+++ b/aws/services/ec2/policy.ftl
@@ -12,6 +12,30 @@
     ]
 [/#function]
 
+[#function ec2AutoScaleGroupLifecyclePermission asgName ]
+    [#return
+        [
+            getPolicyStatement(
+                [
+                    "autoscaling:CompleteLifecycleAction"
+                ],
+                "*",
+                "",
+                {
+                    "StringEquals" : {
+                        "autoscaling:ResourceTag/Name" : asgName
+                    }
+                }
+            ),
+            getPolicyStatement(
+                [
+                    "autoscaling:DescribeAutoScalingInstances"
+                ]
+            )
+        ]
+    ]
+[/#function]
+
 [#function ec2IPAddressUpdatePermission ]
     [#return
         [

--- a/aws/services/resource.ftl
+++ b/aws/services/resource.ftl
@@ -14,7 +14,6 @@
             ]
         }
     ]
-    [#return resourceType + resourceSeparator + resource]
 [/#function]
 
 [#function formatArn partition service region account resource asString=false]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds support for autoscale lifecycle hooks focussing on the startup process. This is similar to CFN init but handles the startup instances as part of scaling activities. The instance will be started and if a failure occurs or 10 minute timeout the scaling event will terminate the instance and start again
- Adds a default lifecycle hook for startup events with the ability to override that if required.
- Adds IAM policy to allow the instances to query the ASG they belong to and send the event

## Motivation and Context

The primary motivation is to ensure that instances startup correctly with the configuration that has been given to them via cloud tasks. 

## How Has This Been Tested?
Tested locally 

## Followup Actions

- [x] None
