### PR TITLE
feat: adds support for healthchecks

### DIFF
--- a/aws/components/healthcheck/id.ftl
+++ b/aws/components/healthcheck/id.ftl
@@ -1,0 +1,13 @@
+[#ftl]
+
+[@addResourceGroupInformation
+    type=HEALTHCHECK_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    attributes=[]
+    services=
+        [
+            AWS_CLOUDWATCH_SERVICE,
+            AWS_ROUTE53_SERVICE
+        ]
+/]

--- a/aws/components/healthcheck/setup.ftl
+++ b/aws/components/healthcheck/setup.ftl
@@ -1,0 +1,524 @@
+[#ftl]
+[#macro aws_healthcheck_cf_deployment_generationcontract occurrence ]
+    [@addDefaultGenerationContract
+        subsets=[ "prologue", "template", "epilogue" ]
+    /]
+[/#macro]
+
+[#macro aws_healthcheck_cf_deployment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+    [#local resources = occurrence.State.Resources]
+    [#local links = solution.Links ]
+
+    [#-- Health checks as a single deployment are generally run from multiple regions to check availability over the internet --]
+    [#local checkRegionIds = []]
+    [#local regionIds = []]
+
+    [#list solution.Regions as region ]
+        [#switch region ]
+            [#case "_product" ]
+                [#local regionIds += [ regionId ]]
+                [#break]
+
+            [#case "_all"]
+                [#local regionIds += aws_cmdb_regions?keys ]
+                [#break]
+
+            [#default]
+                [#local regionIds += [
+                            (((aws_cmdb_regions[region])!{})
+                                ?has_content)
+                                ?then(
+                                    region,
+                                    ""
+                                )
+                        ]]
+        [/#switch]
+    [/#list]
+
+    [#list regionIds as region ]
+        [#if region?has_content ]
+            [#local checkRegionIds = combineEntities( checkRegionIds, region, UNIQUE_COMBINE_BEHAVIOUR )]
+        [/#if]
+    [/#list]
+
+    [#switch solution.Type ]
+        [#case "Simple" ]
+
+            [#local healthCheckId = resources["healthcheck"].Id ]
+            [#local healthCheckName = resources["healthcheck"].Name ]
+
+            [#local address = ""]
+
+            [#local destination = solution["Type:Simple"]["Destination"] ]
+            [#local destinationLink = (destination["Link"])!{} ]
+            [#local explicitAddress = (destination["Address"])!"" ]
+
+            [#if regionId != "us-east-1" ]
+                [@fatal
+                    message="Simple Health checks must be deployed to us-east-1 in AWS"
+                    context={
+                        "HealthCheckId" : occurrence.Core.Id,
+                        "Region" : regionId
+                    }
+                /]
+            [/#if]
+
+            [#if deploymentSubsetRequired(HEALTHCHECK_COMPONENT_TYPE, true) ]
+                [#if isPresent(destinationLink) && ! (explicitAddress?has_content) ]
+                    [#local destinationLinkTarget = getLinkTarget(occurrence, destinationLink )]
+
+                    [#local addressAttribute = solution["Type:Simple"]["Destination"]["LinkAttribute"] ]
+                    [#if destinationLinkTarget?has_content ]
+                        [#local address = (destinationLinkTarget.State.Attributes[addressAttribute])!"" ]
+                    [/#if]
+                [/#if]
+
+                [#if explicitAddress?has_content ]
+                    [#local address = explicitAddress ]
+                [/#if]
+
+                [#if ! (address?has_content) ]
+                    [@fatal
+                        message="Address could not be found for health check"
+                        detail="Check the destination has been deployed and LinkAttribute set or that the Address has been provided"
+                        context={
+                            "HealthCheckId" : core.Id,
+                            "Destination" : destination
+                        }
+                    /]
+                [/#if]
+
+                [#local portName = (solution["Type:Simple"]["Port"])!"" ]
+                [#local monitorPort = {}]
+                [#if portName?has_content ]
+                    [#local monitorPort = (ports[portName])!{} ]
+                [/#if]
+
+                [#if ! (monitorPort?has_content)]
+                    [@fatal
+                        message="Monitor port could not be found or was mssing"
+                        detail={ "Port" : portName }
+                        context={
+                            "HealthCheckId" : core.Id,
+                            "Configuration" : solution
+                        }
+                    /]
+                [/#if]
+
+                [#local searchString = solution["Type:Simple"]["HTTPSearchString"] ]
+                [#if solution["Type:Simple"]["HTTPSearchSetting"]?? ]
+                    [#local searchString =
+                        getOccurrenceSettingValue(occurrence, solution["Type:Simple"]["HTTPSearchSetting"], true) ]
+                [/#if]
+
+                [@createRoute53HealthCheck
+                    id=healthCheckId
+                    name=healthCheckName
+                    port=monitorPort
+                    addressType=destination.AddressType
+                    address=address
+                    regions=checkRegionIds
+                    searchString=searchString
+                /]
+            [/#if]
+            [#break]
+
+        [#case "Complex"]
+
+            [#local canaryId = resources["canary"].Id ]
+            [#local canaryName = resources["canary"].Name ]
+            [#local canaryTagName = resources["canary"].TagName ]
+            [#local roleId = resources["role"].Id ]
+
+            [#-- Baseline component lookup --]
+            [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption" ] )]
+            [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+
+            [#local cmkKeyId = baselineComponentIds["Encryption" ]]
+            [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+            [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
+
+            [#local scriptsPrefix = formatRelativePath(
+                                    getAppDataFilePrefix(occurrence),
+                                    "scripts"
+                                )]
+
+            [#local scriptFile = formatRelativePath(
+                                    scriptsPrefix,
+                                    solution["Type:Complex"]["Image"]["ScriptFileName"]
+            )]
+
+            [#local vpcAccess = solution.NetworkAccess ]
+            [#if vpcAccess ]
+                [#local networkLink = getOccurrenceNetwork(occurrence).Link!{} ]
+
+                [#local networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
+                [#if ! networkLinkTarget?has_content ]
+                    [@fatal message="Network could not be found" context=networkLink /]
+                    [#return]
+                [/#if]
+
+                [#local networkConfiguration = networkLinkTarget.Configuration.Solution]
+                [#local networkResources = networkLinkTarget.State.Resources ]
+
+                [#local networkProfile = getNetworkProfile(solution.Profiles.Network)]
+
+                [#local vpcId = networkResources["vpc"].Id ]
+                [#local vpc = getExistingReference(vpcId)]
+
+                [#local securityGroupId = resources["securityGroup"].Id ]
+                [#local securityGroupName = resources["securityGroup"].Name ]
+            [/#if]
+
+            [#local buildReference = getOccurrenceBuildReference(occurrence)]
+            [#local buildUnit = getOccurrenceBuildUnit(occurrence)]
+
+            [#local imageSource = solution["Type:Complex"].Image.Source]
+            [#if imageSource == "url" ]
+                [#local buildUnit = occurrence.Core.Name ]
+            [/#if]
+
+            [#if deploymentSubsetRequired("pregeneration", false) && imageSource == "url" ]
+                [@addToDefaultBashScriptOutput
+                    content=
+                        getImageFromUrlScript(
+                            regionId,
+                            productName,
+                            environmentName,
+                            segmentName,
+                            occurrence,
+                            solution.Image.UrlSource.Url,
+                            "scripts",
+                            "scripts.zip",
+                            solution.Image.UrlSource.ImageHash
+                        )
+                /]
+            [/#if]
+
+            [#local contextLinks = getLinkTargets(occurrence) ]
+            [#local _context =
+                {
+                    "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
+                    "Environment" : {},
+                    "S3Bucket" : getRegistryEndPoint("scripts", occurrence),
+                    "S3Key" :
+                        formatRelativePath(
+                            getRegistryPrefix("scripts", occurrence),
+                            getOccurrenceBuildProduct(occurrence,productName),
+                            getOccurrenceBuildScopeExtension(occurrence),
+                            buildUnit,
+                            buildReference,
+                            "scripts.zip"
+                        ),
+                    "Links" : contextLinks,
+                    "BaselineLinks" : baselineLinks,
+                    "DefaultCoreVariables" : false,
+                    "DefaultEnvironmentVariables" : false,
+                    "DefaultLinkVariables" : false,
+                    "DefaultBaselineVariables" : false,
+                    "Policy" : standardPolicies(occurrence, baselineComponentIds),
+                    "ManagedPolicy" : [],
+                    "Script" : []
+                }
+            ]
+            [#local _context = invokeExtensions( occurrence, _context )]
+
+            [#local finalEnvironment = getFinalEnvironment(occurrence, _context, solution.Environment) ]
+            [#local _context += finalEnvironment ]
+
+            [#if deploymentSubsetRequired(HEALTHCHECK_COMPONENT_TYPE, true)]
+                [#list _context.Links as linkName,linkTarget]
+
+                    [#if vpcAccess ]
+                        [@createSecurityGroupRulesFromLink
+                            occurrence=occurrence
+                            groupId=securityGroupId
+                            linkTarget=linkTarget
+                            inboundPorts=[]
+                            networkProfile=networkProfile
+                        /]
+                    [/#if]
+                [/#list]
+            [/#if]
+
+            [#local managedPolicies =
+                (vpcAccess)?then(
+                    ["arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"],
+                    []
+                ) +
+                (solution["Type:Complex"].Tracing.Configured && solution["Type:Complex"].Tracing.Enabled)?then(
+                    ["arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"],
+                    []
+                ) +
+                _context.ManagedPolicy ]
+
+            [#local linkPolicies = getLinkTargetsOutboundRoles(_context.Links) ]
+
+            [#-- Ensure policies are ignored as dependencies unless created as part of this template --]
+            [#local policyId = ""]
+            [#local linkPolicyId = ""]
+
+            [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
+
+                [#-- Create a role under which the function will run and attach required policies --]
+                [#-- The role is mandatory though there may be no policies attached to it --]
+                [@createRole
+                    id=roleId
+                    trustedServices=[
+                        "lambda.amazonaws.com"
+                    ]
+                    managedArns=managedPolicies
+                /]
+
+                [@createPolicy
+                    id=formatDependentPolicyId(canaryId, "base")
+                    roles=roleId
+                    name="base"
+                    statements=[
+                        getPolicyStatement(
+                            [
+                                "cloudwatch:PutMetricData"
+                            ]
+                            "*",
+                            "",
+                            {
+                                "StringEquals": {
+                                    "cloudwatch:namespace": "CloudWatchSynthetics"
+                                }
+                            }
+                        ),
+                        getPolicyStatement(
+                            [
+                                "logs:CreateLogStream",
+                                "logs:PutLogEvents",
+                                "logs:CreateLogGroup"
+                            ],
+                            {
+                                "Fn::Sub" : [
+                                    r'arn:aws:logs:${Region}:${AWSAccountId}:log-group:/aws/lambda/cwsyn-*',
+                                    {
+                                        "Region" : {
+                                            "Ref" : "AWS::Region"
+                                        },
+                                        "AWSAccountId" : {
+                                            "Ref" : "AWS::AccountId"
+                                        }
+                                    }
+                                ]
+                            }
+                        ),
+                        getPolicyStatement(
+                            [
+                                "s3:ListAllMyBuckets",
+                                "xray:PutTraceSegments"
+                            ],
+                            "*"
+                        ),
+                        getPolicyStatement(
+                            [
+                                "s3:PutObject"
+                            ],
+                            {
+                                "Fn::Sub" : [
+                                    r'arn:aws:s3:::cw-syn-results-${Account}-${Region}/canary/${Region}/*',
+                                    {
+                                        "Region" : {
+                                            "Ref" : "AWS::Region"
+                                        },
+                                        "Account" : {
+                                            "Ref" : "AWS::AccountId"
+                                        }
+                                    }
+                                ]
+                            }
+                        ),
+                        getPolicyStatement(
+                            [
+                                "s3:GetBucketLocation"
+                            ],
+                            {
+                                "Fn::Sub" : [
+                                    r'arn:aws:s3:::cw-syn-results-${Account}-${Region}',
+                                    {
+                                        "Region" : {
+                                            "Ref" : "AWS::Region"
+                                        },
+                                        "Account" : {
+                                            "Ref" : "AWS::AccountId"
+                                        }
+                                    }
+                                ]
+                            }
+                        )
+                    ]
+                /]
+
+                [#if _context.Policy?has_content]
+                    [#local policyId = formatDependentPolicyId(canaryId)]
+                    [@createPolicy
+                        id=policyId
+                        name=_context.Name
+                        statements=_context.Policy
+                        roles=roleId
+                    /]
+                [/#if]
+
+                [#if linkPolicies?has_content]
+                    [#local linkPolicyId = formatDependentPolicyId(canaryId, "links")]
+                    [@createPolicy
+                        id=linkPolicyId
+                        name="links"
+                        statements=linkPolicies
+                        roles=roleId
+                    /]
+                [/#if]
+            [/#if]
+
+
+            [#if deploymentSubsetRequired(HEALTHCHECK_COMPONENT_TYPE, true)]
+
+                [#if vpcAccess ]
+                    [@createSecurityGroup
+                        id=securityGroupId
+                        name=securityGroupName
+                        vpcId=vpcId
+                        occurrence=occurrence
+                    /]
+
+                    [@createSecurityGroupRulesFromNetworkProfile
+                        occurrence=occurrence
+                        groupId=securityGroupId
+                        networkProfile=networkProfile
+                        inboundPorts=[]
+                    /]
+                [/#if]
+
+                [#local script = ""]
+                [#local scriptBucket = ""]
+                [#local scriptFilePrefix = ""]
+
+                [#local handler = solution["Type:Complex"].Handler]
+
+                [#if imageSource == "none" ]
+                    [#if _context.Script?has_content ]
+
+                        [#local script = asArray(_context.Script)?join("\n")]
+
+                        [#-- Set the handler to the standard value that cloudwatch creates --]
+                        [#local handler = handler
+                                            ?keep_after_last(".")
+                                            ?ensure_starts_with("pageLoadBlueprint.") ]
+                    [/#if]
+                [/#if]
+
+                [#if ! (script?has_content) ]
+                    [#local scriptBucket = _context.S3Bucket ]
+                    [#local scriptFilePrefix = _context.S3Key ]
+                [/#if]
+
+                [@createCWCanary
+                    id=canaryId
+                    name=canaryName
+                    handler=solution["Type:Complex"].Handler
+                    artifactS3Url=formatRelativePath("s3://", dataBucket, getAppDataFilePrefix(occurrence))
+                    roleId=roleId
+                    runTime=solution["Type:Complex"].RunTime
+                    scheduleExpression=solution["Type:Complex"].Schedule
+                    memory=solution["Type:Complex"].Memory
+                    activeTracing=solution["Type:Complex"].Tracing.Enabled
+                    environment=finalEnvironment.Environment
+                    successRetention=solution.ReportRetention.Success
+                    failureRetention=solution.ReportRetention.Failure
+                    vpcEnabled=vpcAccess
+                    securityGroupIds=vpcAccess?then([ getReference(securityGroupId) ], [])
+                    subnets=vpcAccess?then(getSubnets(core.Tier, networkResources), [])
+                    vpcId=vpcAccess?then(vpcId, "")
+                    tags=getOccurrenceCoreTags(occurrence, canaryTagName)
+                    script=script
+                    s3Bucket=scriptBucket
+                    s3Key=scriptFilePrefix
+                /]
+
+            [/#if]
+
+            [#if deploymentSubsetRequired("prologue", false)]
+                [#-- Copy any asFiles needed by the task --]
+                [#local asFiles = getAsFileSettings(occurrence.Configuration.Settings.Product) ]
+                [#if asFiles?has_content]
+                    [@debug message="Asfiles" context=asFiles enabled=false /]
+                    [@addToDefaultBashScriptOutput
+                        content=
+                            findAsFilesScript("filesToSync", asFiles) +
+                            syncFilesToBucketScript(
+                                "filesToSync",
+                                regionId,
+                                operationsBucket,
+                                getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
+                                false
+                            )
+                    /]
+                [/#if]
+            [/#if]
+
+            [#if deploymentSubsetRequired("epilogue", false)]
+                [#-- Assume stack update was successful so delete other files --]
+                [#local asFiles = getAsFileSettings(occurrence.Configuration.Settings.Product) ]
+                [#if asFiles?has_content]
+                    [@debug message="Asfiles" context=asFiles enabled=false /]
+                    [@addToDefaultBashScriptOutput
+                        content=
+                            findAsFilesScript("filesToSync", asFiles) +
+                            syncFilesToBucketScript(
+                                "filesToSync",
+                                regionId,
+                                operationsBucket,
+                                getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
+                                true
+                            )
+                    /]
+                [/#if]
+            [/#if]
+            [#break]
+    [/#switch]
+
+
+    [#if deploymentSubsetRequired(HEALTHCHECK_COMPONENT_TYPE, true) ]
+        [#list solution.Alerts?values as alert ]
+
+            [#local monitoredResources = getCWMonitoredResources(core.Id, resources, alert.Resource)]
+            [#list monitoredResources as name,monitoredResource ]
+
+                [@debug message="Monitored resource" context=monitoredResource enabled=false /]
+
+                [#switch alert.Comparison ]
+                    [#case "Threshold" ]
+                        [@createAlarm
+                            id=formatDependentAlarmId(monitoredResource.Id, alert.Id )
+                            severity=alert.Severity
+                            resourceName=core.FullName
+                            alertName=alert.Name
+                            actions=getCWAlertActions(occurrence, solution.Profiles.Alert, alert.Severity )
+                            metric=getCWMetricName(alert.Metric, monitoredResource.Type, core.ShortFullName)
+                            namespace=getCWResourceMetricNamespace(monitoredResource.Type, alert.Namespace)
+                            description=alert.Description!alert.Name
+                            threshold=alert.Threshold
+                            statistic=alert.Statistic
+                            evaluationPeriods=alert.Periods
+                            period=alert.Time
+                            operator=alert.Operator
+                            reportOK=alert.ReportOk
+                            unit=alert.Unit
+                            missingData=alert.MissingData
+                            dimensions=getCWMetricDimensions(alert, monitoredResource, resources)
+                        /]
+                    [#break]
+                [/#switch]
+            [/#list]
+        [/#list]
+    [/#if]
+
+[/#macro]

--- a/aws/components/healthcheck/state.ftl
+++ b/aws/components/healthcheck/state.ftl
@@ -1,0 +1,80 @@
+[#ftl]
+
+[#macro aws_healthcheck_cf_state occurrence parent={} ]
+    [#local core = occurrence.Core ]
+    [#local solution = occurrence.Configuration.Solution ]
+
+    [#local segmentSeedId = formatSegmentSeedId() ]
+    [#local segmentSeed = getExistingReference(segmentSeedId)]
+
+    [#local resources = {}]
+    [#local attributes = {}]
+    [#local roles = {
+        "Inbound" : {},
+        "Outbound" : {}
+    }]
+
+    [#switch solution.Type ]
+        [#case "Simple" ]
+            [#local resources = {
+                "healthcheck" : {
+                    "Id" : formatResourceId(AWS_ROUTE53_HEALTHCHECK_RESOURCE_TYPE, core.Id),
+                    "Name" : core.FullName,
+                    "Type" : AWS_ROUTE53_HEALTHCHECK_RESOURCE_TYPE,
+                    "Monitored" : true
+                }
+            }]
+            [#break]
+        [#case "Complex"]
+
+            [#local canaryId = formatResourceId(AWS_CLOUDWATCH_CANARY_RESOURCE_TYPE, core.Id)]
+            [#local securityGroupId = formatDependentSecurityGroupId(canaryId)]
+
+            [#local resources += {
+                "canary" : {
+                    "Id" : formatResourceId(AWS_CLOUDWATCH_CANARY_RESOURCE_TYPE, core.Id),
+                    [#-- Name must be less than 21 chars --]
+                    "Name" : concatenate([ core.Component.RawName, segmentSeed], "_")
+                                ?truncate_c(21, "")
+                                ?lower_case,
+                    "TagName" : core.FullName,
+                    "Type" : AWS_CLOUDWATCH_CANARY_RESOURCE_TYPE
+                },
+                "role" : {
+                    "Id" : formatDependentRoleId(canaryId),
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
+                }
+            } +
+            attributeIfTrue(
+                "securityGroup",
+                solution.NetworkAccess,
+                {
+                    "Id" : securityGroupId,
+                    "Name" : core.FullName,
+                    "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
+                }
+            )]
+
+            [#local roles += {
+                "Inbound" : {
+                } +
+                attributeIfTrue(
+                    "networkacl",
+                    solution.NetworkAccess,
+                    {
+                        "SecurityGroups" : securityGroupId,
+                        "Description" : core.FullName
+                    }
+                )
+            }]
+    [/#switch]
+
+    [#assign componentState =
+        {
+            "Resources" : resources,
+            "Attributes" : attributes,
+            "Roles" : roles
+        }
+    ]
+[/#macro]

--- a/aws/services/cw/id.ftl
+++ b/aws/services/cw/id.ftl
@@ -38,6 +38,13 @@
     resource=AWS_CLOUDWATCH_ALARM_RESOURCE_TYPE
 /]
 
+[#assign AWS_CLOUDWATCH_CANARY_RESOURCE_TYPE = "canary" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_CLOUDWATCH_SERVICE
+    resource=AWS_CLOUDWATCH_CANARY_RESOURCE_TYPE
+/]
+
 [#assign AWS_EVENT_RULE_RESOURCE_TYPE = "event" ]
 [@addServiceResource
     provider=AWS_PROVIDER

--- a/aws/services/route53/id.ftl
+++ b/aws/services/route53/id.ftl
@@ -13,3 +13,10 @@
                 extensions)]
 [/#function]
 
+
+[#assign AWS_ROUTE53_HEALTHCHECK_RESOURCE_TYPE = "route53HealthCheck" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_ROUTE53_SERVICE
+    resource=AWS_ROUTE53_HEALTHCHECK_RESOURCE_TYPE
+/]

--- a/aws/services/route53/resource.ftl
+++ b/aws/services/route53/resource.ftl
@@ -1,0 +1,149 @@
+[#ftl]
+
+[#assign AWS_ROUTE53_HEALTHCHECK_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_ROUTE53_HEALTHCHECK_RESOURCE_TYPE
+    mappings=AWS_ROUTE53_HEALTHCHECK_OUTPUT_MAPPINGS
+/]
+
+[@addCWMetricAttributes
+    resourceType=AWS_ROUTE53_HEALTHCHECK_RESOURCE_TYPE
+    namespace="AWS/Route53"
+    dimensions={
+        "HealthCheckId" : {
+            "Output" : {
+                "Attribute" : REFERENCE_ATTRIBUTE_TYPE
+            }
+        }
+    }
+/]
+
+
+[#macro createRoute53HealthCheck
+        id
+        name
+        port
+        address
+        addressType
+        regions=[]
+        searchString=""
+        dependencies=[]
+    ]
+
+    [#local availableRegions = [
+        "us-east-1",
+        "us-west-1",
+        "us-west-2",
+        "eu-west-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-northeast-1",
+        "sa-east-1"
+    ]]
+
+    [#local selectedRegions = regions?filter(x -> availableRegions?seq_contains(x))]
+
+    [#if (selectedRegions)?size lt 3 ]
+        [@fatal
+            message="A minimum of 3 check regions required for health check"
+            context={
+                "ProvidedRegions" : regions,
+                "AvaiableRegions" : availableRegions,
+                "SelectedRegions" : selectedRegions
+            }
+        /]
+    [/#if]
+
+    [#local healthCheckConfig = {
+        "Port" : port.Port,
+        "FailureThreshold" : (port.HealthCheck.UnhealthyThreshold)?number,
+        "RequestInterval" : (port.HealthCheck.Interval)?number
+    } +
+    attributeIfTrue(
+        "IPAddress",
+        (addressType == "IP"),
+        address
+    ) +
+    attributeIfTrue(
+        "FullyQualifiedDomainName",
+        (addressType == "Hostname" ),
+        address
+    ) +
+    attributeIfContent(
+        "Regions",
+        selectedRegions
+    )]
+
+    [#switch (port.Protocol)?upper_case ]
+        [#case "TCP" ]
+            [#local healthCheckConfig += {
+                "Type" : "TCP"
+            }]
+            [#break]
+
+        [#case "HTTP" ]
+            [#if searchString?has_content ]
+                [#local healthCheckConfig += {
+                    "Type" : "HTTP_STR_MATCH",
+                    "SearchString" : searchString
+                }]
+            [#else]
+                [#local healthCheckConfig += {
+                    "Type" : "HTTP"
+                }]
+            [/#if]
+
+            [#local healthCheckConfig += {
+                "ResourcePath" : port.HealthCheck.Path
+            }]
+            [#break]
+
+        [#case "HTTPS"]
+            [#if searchString?has_content ]
+                [#local healthCheckConfig += {
+                    "Type" : "HTTPS_STR_MATCH",
+                    "SearchString" : searchString
+                }]
+            [#else]
+                [#local healthCheckConfig += {
+                    "Type" : "HTTPS"
+                }]
+            [/#if]
+
+            [#local healthCheckConfig += {
+                "ResourcePath" : port.HealthCheck.Path,
+                "EnableSNI" : true
+            }]
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Unsupported protocol for route53 health checks"
+                detail=port.Protocol
+                contex={
+                    "HealthCheckId" : id,
+                    "Port" : port
+                }
+            /]
+    [/#switch]
+
+    [@cfResource
+        id=id
+        type="AWS::Route53::HealthCheck"
+        properties=
+            {
+                "HealthCheckConfig" : healthCheckConfig,
+                "HealthCheckTags" : getCfTemplateCoreTags(name)
+            }
+        outputs=AWS_ROUTE53_HEALTHCHECK_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]

--- a/aws/services/service.ftl
+++ b/aws/services/service.ftl
@@ -73,7 +73,7 @@
 [#assign AWS_RESOURCE_ACCESS_SERVICE = "resourceaccess" ]
 [@addService provider=AWS_PROVIDER service=AWS_RESOURCE_ACCESS_SERVICE /]
 
-[#assign AWS_ROUTE53_SERVICE = "dns"]
+[#assign AWS_ROUTE53_SERVICE = "route53"]
 [@addService provider=AWS_PROVIDER service=AWS_ROUTE53_SERVICE /]
 
 [#assign AWS_SECRETS_MANAGER_SERVICE = "secretsmanager" ]

--- a/awstest/extensions/healthcheckcomplexbase/extension.ftl
+++ b/awstest/extensions/healthcheckcomplexbase/extension.ftl
@@ -1,0 +1,34 @@
+[#ftl]
+
+[@addExtension
+    id="healthcheckcomplexbase"
+    aliases=[
+        "_healthcheckcomplexbase"
+    ]
+    description=[
+        "Base script content for healthcheck"
+    ]
+    supportedTypes=[
+        HEALTHCHECK_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_healthcheckcomplexbase_deployment_setup occurrence ]
+
+    [@Settings
+        "LB_FQDN"
+    /]
+
+    [@HealthCheckScript
+        content=[
+            r'def basic_custom_script():',
+            r'    fail = False',
+            r'    if fail:',
+            r'        raise Exception("Failed basicCanary check.")',
+            r'    return "Successfully completed basicCanary checks."',
+            r'def handler(event, context):',
+            r'    return basic_custom_script()'
+        ]
+    /]
+
+[/#macro]

--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -39,9 +39,17 @@
                                 "Provider" : "awstest",
                                 "Name" : "db"
                             },
+                            "ecs" : {
+                                "Provider" : "awstest",
+                                "Name" : "ecs"
+                            },
                             "filetransfer" : {
                                 "Provider" : "awstest",
                                 "Name" : "filetransfer"
+                            },
+                            "healthcheck" : {
+                                "Provider" : "awstest",
+                                "Name" : "healthcheck"
                             },
                             "lb" : {
                                 "Provider" : "awstest",

--- a/awstest/modules/healthcheck/module.ftl
+++ b/awstest/modules/healthcheck/module.ftl
@@ -114,14 +114,12 @@
                         "CFN" : {
                             "Resource" : {
                                 "healthCheck" : {
-                                    "Name" : "transferServerXappXfiletransferbase",
-                                    "Type" : "AWS::Transfer::Server"
+                                    "Name" : "route53HealthCheckXappXhealthchecksimplebase",
+                                    "Type" : "AWS::Route53::HealthCheck"
                                 }
                             },
                             "Output" : [
-                                "transferServerXappXfiletransferbase",
-                                "transferServerXappXfiletransferbaseXarn",
-                                "transferServerXappXfiletransferbaseXname"
+                                "route53HealthCheckXappXhealthchecksimplebase"
                             ]
                         }
                     }
@@ -147,11 +145,11 @@
                             "Match" : {
                                 "CanaryName" : {
                                     "Path"  : "Resources.canaryXappXhealthcheckcomplexbase.Properties.Name",
-                                    "Value" : "mockoutputxseedxsegme"
+                                    "Value" : "healthcheckcomplexbas"
                                 },
                                 "ArtifactS3Location" : {
                                     "Path"  : "Resources.canaryXappXhealthcheckcomplexbase.Properties.ArtifactS3Location",
-                                    "Value" : "s3://##MockOutputXs3XsegmentXoperationsX##/appdata/mockedup/integration/application/healthcheckcomplexbase"
+                                    "Value" : "s3://##MockOutputXs3XsegmentXapplicationX##/appdata/mockedup/integration/application/healthcheckcomplexbase"
                                 },
                                 "EnvVars" : {
                                     "Path" : "Resources.canaryXappXhealthcheckcomplexbase.Properties.RunConfig.EnvironmentVariables.LB_FQDN",

--- a/awstest/modules/healthcheck/module.ftl
+++ b/awstest/modules/healthcheck/module.ftl
@@ -1,0 +1,179 @@
+[#ftl]
+
+[@addModule
+    name="healthcheck"
+    description="Testing module for the aws healthcheck component"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_healthcheck  ]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "elb" : {
+                    "Components" : {
+                        "healthchecklb" : {
+                            "lb" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-healthcheck-lb"
+                                    }
+                                },
+                                "Engine" : "application",
+                                "PortMappings" : {
+                                    "https" : {},
+                                    "http" : {}
+                                }
+                            }
+                        }
+                    }
+                },
+                "app" : {
+                    "Components" : {
+                        [#-- simple health checks must be in us-east-1 --]
+                        [#-- we can't control region through modules at the moment so can't include in testing --]
+                        [#-- TODO(roleyfoley): enable when placements fully control region --]
+                        "healthchecksimplebase" : {
+                            "healthcheck" : {
+                                "Enabled" : false,
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-healthcheck-simple-base"
+                                    }
+                                },
+                                "Type" : "Simple",
+                                "Type:Simple" : {
+                                    "Destination": {
+                                        "Link" : {
+                                            "Tier" : "elb",
+                                            "Component" : "healthchecklb",
+                                            "PortMapping" : "https",
+                                            "Instance" : "",
+                                            "Version" : ""
+                                        }
+                                    },
+                                    "Port" : "https"
+                                },
+                                "Profiles" : {
+                                    "Testing" : [ "healthchecksimplebase" ],
+                                    "Placement" : "healtchecksimple"
+                                }
+                            }
+                        },
+                        "healthcheckcomplexbase" : {
+                            "healthcheck" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-healthcheck-complex-base"
+                                    }
+                                },
+                                "Type" : "Complex",
+                                "Type:Complex" : {
+                                    "Image": {
+                                        "Source" : "none"
+                                    },
+                                    "Handler" : "handler",
+                                    "RunTime" : "syn-python-selenium-1.0"
+                                },
+                                "Extenions" : [ "_healthcheckcomplexbase" ],
+                                "Links" : {
+                                    "lb": {
+                                        "Tier" : "elb",
+                                        "Component" : "healthchecklb",
+                                        "PortMapping" : "https",
+                                        "Instance" : "",
+                                        "Version" : ""
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Testing" : [ "healthcheckcomplexbase" ]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "PlacementProfiles": {
+                "healtchecksimple": {
+                    "default": {
+                        "Provider": "aws",
+                        "Region": "us-east-1",
+                        "DeploymentFramework": "cf"
+                    }
+                }
+            },
+            "TestCases" : {
+                "healthchecksimplebase" : {
+                    "OutputSuffix" : "template.json",
+                    "Tools" : {
+                       "CFNLint" : true
+                    },
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "healthCheck" : {
+                                    "Name" : "transferServerXappXfiletransferbase",
+                                    "Type" : "AWS::Transfer::Server"
+                                }
+                            },
+                            "Output" : [
+                                "transferServerXappXfiletransferbase",
+                                "transferServerXappXfiletransferbaseXarn",
+                                "transferServerXappXfiletransferbaseXname"
+                            ]
+                        }
+                    }
+                },
+                "healthcheckcomplexbase" : {
+                    "OutputSuffix" : "template.json",
+                    "Tools" : {
+                       "CFNLint" : true
+                    },
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "canary" : {
+                                    "Name" : "canaryXappXhealthcheckcomplexbase",
+                                    "Type" : "AWS::Synthetics::Canary"
+                                }
+                            },
+                            "Output" : [
+                                "canaryXappXhealthcheckcomplexbase"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "CanaryName" : {
+                                    "Path"  : "Resources.canaryXappXhealthcheckcomplexbase.Properties.Name",
+                                    "Value" : "mockoutputxseedxsegme"
+                                },
+                                "ArtifactS3Location" : {
+                                    "Path"  : "Resources.canaryXappXhealthcheckcomplexbase.Properties.ArtifactS3Location",
+                                    "Value" : "s3://##MockOutputXs3XsegmentXoperationsX##/appdata/mockedup/integration/application/healthcheckcomplexbase"
+                                },
+                                "EnvVars" : {
+                                    "Path" : "Resources.canaryXappXhealthcheckcomplexbase.Properties.RunConfig.EnvironmentVariables.LB_FQDN",
+                                    "Value" : "healthchecklb-integration.mock.local"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "healthchecksimplebase" : {
+                    "healthcheck" : {
+                        "TestCases" : [ "healthchecksimplebase" ]
+                    }
+                },
+                "healthcheckcomplexbase" : {
+                    "healthcheck" : {
+                        "TestCases" : [ "healthcheckcomplexbase" ]
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Implements simple and complex healthchecks as part of the healthcheck component.

The simple check is performed by Route53 and runs distributed basic HTTP checks against a single endpoint. The check has to be run from at least 3 regions that support healthchecks and uses our standard port configuration to define the configuration of the check. A link to a destination is required for the check to work.

The simple check must be deployed to us-east-1 as cloudwatch metrics are sent to us-east-1 in a similar way to lambda@edge functions, which are run across all regions but metrics are stored in us-east-1 

The complex health check uses CloudWatch canary monitoring which uses lambda to perform scripted synthetic transactions using browser automation tools like selenium. The checks are deployed to a local region and run at a schedule

## Motivation and Context

AWS implementation of https://github.com/hamlet-io/engine/issues/1653 

This allows for transaction monitoring to be implemented as part of  hamlet solution and also allows for more complex monitoring scenarios 

## How Has This Been Tested?

Tested locally and using test suite

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1659

### Dependent PRs:

- None

### Consumer Actions:

- None

