### PR TITLE
refactor(ecs): move provider attributes

### DIFF
--- a/aws/components/ecs/id.ftl
+++ b/aws/components/ecs/id.ftl
@@ -74,6 +74,50 @@
     provider=AWS_PROVIDER
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=[]
+
+/]
+
+[@addResourceGroupAttributeValues
+    type=ECS_SERVICE_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names" : "Engine",
+            "Values" : [ "shared:fargate", "fargate" ]
+        },
+        {
+            "Names" : "NetworkMode",
+            "Values" : [ "shared:awsvpc", "awsvpc" ]
+        },
+        {
+            "Names" : "Placement",
+            "Children" : [
+                {
+                    "Names" : "ComputeProvider",
+                    "Children" : [
+                        {
+                            "Names" : "Default",
+                            "Children" : [
+                                {
+                                    "Names" : "Provider",
+                                    "Values" : [ "fargate", "fargate_spot" ]
+                                }
+                            ]
+                        },
+                        {
+                            "Names" : "Additional",
+                            "Children" : [
+                                {
+                                    "Names" : "Provider",
+                                    "Values" : [ "fargate", "fargate_spot" ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 /]
 
 [@addResourceGroupInformation
@@ -89,4 +133,19 @@
     provider=AWS_PROVIDER
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=[]
+/]
+
+[@addResourceGroupAttributeValues
+    type=ECS_TASK_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names" : "Engine",
+            "Values" : [ "shared:fargate", "fargate" ]
+        },
+        {
+            "Names" : "NetworkMode",
+            "Values" : [ "shared:awsvpc", "awsvpc" ]
+        }
+    ]
 /]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

Moves provider specific attributes to the provider. Uses the shared prefix to ensure backwards compatibility for existing deployments

## Motivation and Context

Makes the configuration options tidier for the shared provider and removes the need for other providers to handle the aws values 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1660
- https://github.com/hamlet-io/engine/pull/1661

### Dependent PRs:

- None

### Consumer Actions:

- None

