### PR TITLE
fix(ec2): param options for compute tasks

### DIFF
--- a/aws/components/ec2/id.ftl
+++ b/aws/components/ec2/id.ftl
@@ -47,8 +47,7 @@
                                 "_computetask_awslinux_cwlog",
                                 "_computetask_awslinux_efsmount",
                                 "_computetask_linux_userbootstrap",
-                                "_computetask_linux_scriptsdeployment"
-                                "_computetask_linux_vpc_lb"
+                                "_computetask_awslinux_vpc_lb"
                             ]
                         }
                     ]

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -321,7 +321,7 @@
                 [#local zoneEc2EIPAssociationId    = zoneResources[zone.Id]["ec2EIPAssociation"].Id]
 
                 [#local imageId = getEC2AMIImageId(solution.ComputeInstance.Image, zoneEc2InstanceId)]
-                [#local computeTaskConfig = getOccurrenceComputeTaskConfig(occurrence, _context, zoneEc2InstanceId, computeTaskExtensions, zoneEc2ComputeTasks, userComputeTasks)]
+                [#local computeTaskConfig = getOccurrenceComputeTaskConfig(occurrence, zoneEc2InstanceId, _context, computeTaskExtensions, zoneEc2ComputeTasks, userComputeTasks)]
 
                 [@cfResource
                     id=zoneEc2InstanceId

--- a/aws/extensions/computetask_awslinux_vpc_lb/extension.ftl
+++ b/aws/extensions/computetask_awslinux_vpc_lb/extension.ftl
@@ -130,7 +130,7 @@
     [/#if]
 
     [@computeTaskConfigSection
-        computeTaskTypes=[ COMPUTE_TASK_OS_SECURITY_PATCHING ]
+        computeTaskTypes=[ COMPUTE_TASK_AWS_LB_REGISTRATION ]
         id="LoadBalancerRegistration"
         priority=8
         engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE

--- a/aws/extensions/computetask_linux_volumemount/extension.ftl
+++ b/aws/extensions/computetask_linux_volumemount/extension.ftl
@@ -29,6 +29,8 @@
 
     [#-- Support for data volumes as linked components to single instances --]
     [#if occurrence.Core.Type == EC2_COMPONENT_TYPE ]
+
+        [#local zoneResources = occurrence.State.Resources.Zones]
         [#list zones as zone]
             [#if multiAZ || (zones[0].Id = zone.Id)]
                 [#local zoneEc2InstanceId = zoneResources[zone.Id]["ec2Instance"].Id ]

--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -27,6 +27,10 @@
                                 "Provider" : "awstest",
                                 "Name" : "bastion"
                             },
+                            "ec2" : {
+                                "Provider" : "awstest",
+                                "Name" : "ec2"
+                            },
                             "ecs" : {
                                 "Provider" : "awstest",
                                 "Name" : "ecs"

--- a/awstest/modules/ec2/module.ftl
+++ b/awstest/modules/ec2/module.ftl
@@ -1,0 +1,89 @@
+[#ftl]
+
+[@addModule
+    name="ec2"
+    description="Testing module for the aws ec2 component"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_ec2 ]
+
+    [#-- Base setup --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "ec2base" : {
+                            "ec2" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-ec2-base"
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Testing" : [ "ec2base" ]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "ec2base" : {
+                    "OutputSuffix" : "template.json",
+                    "Tools" : {
+                       "CFNLint" : true
+                    },
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "secGroup" : {
+                                    "Name" : "securityGroupXappXec2base",
+                                    "Type" : "AWS::EC2::SecurityGroup"
+                                },
+                                "ec2InstanceA" : {
+                                    "Name" : "ec2InstanceXappXec2baseXa",
+                                    "Type" : "AWS::EC2::Instance"
+                                },
+                                "eniAdaptorA" : {
+                                    "Name" : "eniXappXec2baseXaXeth0",
+                                    "Type" : "AWS::EC2::NetworkInterface"
+                                }
+                            },
+                            "Output" : [
+                                "securityGroupXappXec2base"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "NetworkInterfaceAttached" : {
+                                    "Path" : "Resources.ec2InstanceXappXec2baseXa.Properties.NetworkInterfaces[0].NetworkInterfaceId",
+                                    "Value" : "##MockOutputXeniXappXec2baseXaXeth0X##"
+                                },
+                                "NetworkInterfaceSubnet" : {
+                                    "Path" : "Resources.eniXappXec2baseXaXeth0.Properties.SubnetId",
+                                    "Value" : "##MockOutputXsubnetXappXaX##"
+                                }
+                            },
+                            "NotEmpty" : [
+                                "Resources.ec2InstanceXappXec2baseXa.Properties.ImageId",
+                                "Resources.ec2InstanceXappXec2baseXa.Properties.InstanceType",
+                                "Resources.ec2InstanceXappXec2baseXa.Metadata"
+                            ]
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "ec2base" : {
+                    "ec2" : {
+                        "TestCases" : [ "ec2base" ]
+                    }
+                }
+            }
+        }
+    /]
+
+[/#macro]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- fixes the function call order for compute task lookups
- fixes typos in computetask extensions which are only used in ec2
- adds ec2 base testing to catch this stuff

## Motivation and Context

Fixes issues in the ec2 components and makes sure they don't happen again 

## How Has This Been Tested?

Tested locally and with new test cases 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

