### PR TITLE
fix: link processing in awslinux vpx lb extension

### DIFF
--- a/aws/components/computecluster/id.ftl
+++ b/aws/components/computecluster/id.ftl
@@ -49,8 +49,8 @@
                                 "_computetask_awslinux_efsmount",
                                 "_computetask_awslinux_eip",
                                 "_computetask_linux_userbootstrap",
-                                "_computetask_linux_scriptsdeployment"
-                                "_computetask_linux_vpc_lb"
+                                "_computetask_linux_scriptsdeployment",
+                                "_computetask_awslinux_vpc_lb"
                             ]
                         }
                     ]

--- a/aws/extensions/computetask_awslinux_vpc_lb/extension.ftl
+++ b/aws/extensions/computetask_awslinux_vpc_lb/extension.ftl
@@ -22,8 +22,7 @@
     [#local files = {}]
     [#local commands = {}]
 
-    [#list _context.Links as linkId,link]
-        [#local linkTarget = getLinkTarget(occurrence, link) ]
+    [#list _context.Links as linkId,linkTarget]
 
         [@debug message="Link Target" context=linkTarget enabled=false /]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
A context object already [contains a link target](https://github.com/hamlet-io/engine-plugin-aws/blob/78ba39eaf8864744ad26b97b37bd861bae599e73/aws/components/ec2/setup.ftl#L91), so no need to call getLinkTarget method again in the extension.

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Fixes template generation for ec2 component with a non-empty Link object.
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally.
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

