### PR TITLE
fix: MTA component SES config detection

### DIFF
--- a/aws/components/mta/setup.ftl
+++ b/aws/components/mta/setup.ftl
@@ -6,6 +6,11 @@
 [#macro aws_mta_cf_deployment_solution occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
+    [#-- Nothing to do if not running the template pass --]
+    [#if ! deploymentSubsetRequired(MTA_COMPONENT_TYPE, true) ]
+        [#return]
+    [/#if]
+
     [#local core = occurrence.Core ]
     [#local solution = occurrence.Configuration.Solution ]
     [#local attributes = occurrence.State.Attributes ]
@@ -114,7 +119,7 @@
                 [#break]
         [/#switch]
 
-        [#if actions?has_content && deploymentSubsetRequired(MTA_COMPONENT_TYPE, true)]
+        [#if actions?has_content]
             [@createSESReceiptRule
                 id=ruleId
                 name=ruleName


### PR DESCRIPTION


## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
To avoid triggering errors on an lg pass for the MTA component (mainly due to the cludgy way we deal with multiple regions right now), wrap setup processing on a deployment unit check. There is nothing to do if not executing the template pass.

## Motivation and Context
Customer deployments blocked.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

