### PR TITLE
Various fix

### DIFF
--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -121,7 +121,7 @@
             "DefaultEnvironmentVariables" : true,
             "DefaultLinkVariables" : true,
             "DefaultBaselineVariables" : true,
-            "Policy" : [],
+            "Policy" : standardPolicies(occurrence, baselineComponentIds),
             "ManagedPolicy" : [],
             "ComputeTasks" : [],
             "Files" : {},

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -99,7 +99,7 @@
             "DefaultEnvironmentVariables" : false,
             "DefaultLinkVariables" : true,
             "DefaultBaselineVariables" : true,
-            "Policy" : [],
+            "Policy" : standardPolicies(occurrence, baselineComponentIds),
             "ManagedPolicy" : [],
             "ComputeTasks" : [],
             "Files" : {},

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -99,7 +99,7 @@
             "DefaultEnvironmentVariables" : true,
             "DefaultLinkVariables" : true,
             "DefaultBaselineVariables" : true,
-            "Policy" : [],
+            "Policy" : standardPolicies(occurrence, baselineComponentIds),
             "ManagedPolicy" : [],
             "ComputeTasks" : [],
             "Files" : {},

--- a/aws/components/healthcheck/state.ftl
+++ b/aws/components/healthcheck/state.ftl
@@ -38,7 +38,8 @@
                                 ?truncate_c(21, "")
                                 ?lower_case,
                     "TagName" : core.FullName,
-                    "Type" : AWS_CLOUDWATCH_CANARY_RESOURCE_TYPE
+                    "Type" : AWS_CLOUDWATCH_CANARY_RESOURCE_TYPE,
+                    "Monitored" : true
                 },
                 "role" : {
                     "Id" : formatDependentRoleId(canaryId),


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description

A set of minor fixes for ec2 and healthcheck 

- Rework the env setup configuration to allow for sourcing the environment and also including it in bashrc so that non-login shells can access the env vars
- Setup defaultPolicies for ec2 components to allow for user scripts to access these features
- Set a monitoring resource on the canary to make it easier to setup alerts

## Motivation and Context

Minor fixes from testing and using in real life

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1670

### Dependent PRs:

- None

### Consumer Actions:

- None

