### PR TITLE
yaml config support and alternatives 

### DIFF
--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -2,7 +2,11 @@
 [#macro aws_db_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract
         subsets=["prologue", "template", "epilogue"]
-        alternatives=["primary", "replace1", "replace2"]
+        alternatives=[
+            "primary",
+            { "subset" : "template", "alternative" : "replace1"},
+            { "subset" : "template", "alternative" : "replace2"}
+        ]
     /]
 [/#macro]
 

--- a/aws/components/sqs/setup.ftl
+++ b/aws/components/sqs/setup.ftl
@@ -2,7 +2,11 @@
 [#macro aws_sqs_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract
         subsets="template"
-        alternatives=["primary", "replace1", "replace2"]
+        alternatives=[
+            "primary",
+            { "subset" : "template", "alternative" : "replace1" },
+            { "subset" : "template", "alternative" : "replace2" }
+        ]
     /]
 [/#macro]
 


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description

Some minor features/refactors 

- Add support for setting the config as file output as a yaml file instead of json 
- For the db and sqs components use the more specific configuration option as replace templates are only required for template subsets

## Motivation and Context

Yaml support allows for integrating with lambda functions or services which can't be modified for json support

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1672

### Dependent PRs:

- None

### Consumer Actions:

- None

