### PR TITLE
feat: lb vpc link to apigateway

### DIFF
--- a/aws/components/lb/id.ftl
+++ b/aws/components/lb/id.ftl
@@ -10,7 +10,8 @@
             AWS_WEB_APPLICATION_FIREWALL_SERVICE,
             AWS_KINESIS_SERVICE,
             AWS_CLOUDWATCH_SERVICE,
-            AWS_IDENTITY_SERVICE
+            AWS_IDENTITY_SERVICE,
+            AWS_APIGATEWAY_SERVICE
         ]
 /]
 

--- a/aws/services/apigateway/id.ftl
+++ b/aws/services/apigateway/id.ftl
@@ -58,6 +58,13 @@
     resource=AWS_APIGATEWAY_USAGEPLAN_MEMBER_RESOURCE_TYPE
 /]
 
+[#assign AWS_APIGATEWAY_VPCLINK_RESOURCE_TYPE = "apiVPCLink" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_APIGATEWAY_SERVICE
+    resource=AWS_APIGATEWAY_VPCLINK_RESOURCE_TYPE
+/]
+
 [#function formatDependentAPIGatewayAuthorizerId resourceId extensions...]
     [#return formatDependentResourceId(
                 AWS_APIGATEWAY_AUTHORIZER_RESOURCE_TYPE,

--- a/aws/services/apigateway/resource.ftl
+++ b/aws/services/apigateway/resource.ftl
@@ -140,3 +140,34 @@
         dependencies=dependencies
     /]
 [/#macro]
+
+[#assign APIGATEWAY_VPCLINK_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_APIGATEWAY_VPCLINK_RESOURCE_TYPE
+    mappings=APIGATEWAY_VPCLINK_OUTPUT_MAPPINGS
+/]
+
+[#macro createAPIGatewayVPCLink id name networkLBId description="" dependencies=[] ]
+    [@cfResource
+        id=id
+        type="AWS::ApiGateway::VpcLink"
+        properties={
+            "Name" : name,
+            "TargetArns" : getReferences(asArray(networkLBId), ARN_ATTRIBUTE_TYPE)
+        } +
+        attributeIfContent(
+            "Description",
+            description
+        )
+        outputs=APIGATEWAY_VPCLINK_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- adds support for VPC links on apigateways. This allows the apigateway to access backends which are only hosted within a VPC.  A network load balancer can be shared across apigateways but the vpclink can only be defined once per load balancer. So to use this an inbound link from the network load balancer to an apigateway must be configured before an API gateway can link to one of the load balancers port mappings 
- adds support for defining or modifying open api spec as part of a fragment/extension ( https://github.com/hamlet-io/engine/pull/1675 ) 
- Refactors a cleanup script we run as part of load balancer deployments which was running when it didn't need to. 

## Motivation and Context

VPC link allows for APIGateways to be the only public facing endpoint when using containers, or ec2 services that are hosted within a VPC. Before this was available you had to make the load balancer endpoint public and route requests from the APIGateway to the public load balancer 

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1675

### Dependent PRs:

- None

### Consumer Actions:

- None

