### PR TITLE
fix(ecs): service capacity provider usage

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -605,6 +605,7 @@
     [#local ecsClusterName = parentResources["cluster"].Name ]
     [#local ecsSecurityGroupId = parentResources["securityGroup"].Id ]
     [#local ecsASGCapacityProviderId = parentResources["ecsASGCapacityProvider"].Id]
+    [#local essASGCapacityProviderAssociationId = parentResources["ecsCapacityProvierAssociation"].Id ]
 
     [#if ! (getExistingReference(ecsId)?has_content) ]
         [@fatal
@@ -669,7 +670,8 @@
         [#local useCapacityProvider = true ]
 
         [#-- Provides warning for hosting updates this will still deploy but using fixed launch type --]
-        [#if ( engine == "ec2") && ( ! (getExistingReference(ecsASGCapacityProviderId)?has_content)) ]
+        [#-- Only use capacity providers when the assocation is in place --]
+        [#if ( engine == "ec2") && ( ! (getExistingReference(essASGCapacityProviderAssociationId)?has_content)) ]
             [#local useCapacityProvider = false ]
             [@warn
                 message="Could not find ECS Capacity provider for Ec2 - Update the solution ecs component"


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

fixes the selection process for determining when capacity providers can be used. This ensures that the ecs host can update the provider usage without running into dependency issues

## Motivation and Context

Capacity providers have been through a few different updates within hamlet and the AWS cloudformation support. As a result we have some inconsistent usage of the capacity providers which cause issues when updating the ecs solution component. This change ensures that only the latest implementation triggers  services to use capacity providers 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

