### PR TITLE
fix(computecluster): remove wait resources

### DIFF
--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -21,9 +21,6 @@
     [#local computeClusterLogGroupId           = resources["lg"].Id]
     [#local computeClusterLogGroupName         = resources["lg"].Name]
 
-    [#local AutoScaleGroupWaitCondition       = resources["asgWaitCondition"].Id]
-    [#local AutoScaleGroupWaitHandle          = resources["asgWaitHandle"].Id ]
-
     [#local processorProfile = getProcessor(occurrence, "ComputeCluster")]
     [#local storageProfile   = getStorage(occurrence, "ComputeCluster")]
     [#local logFileProfile   = getLogFileProfile(occurrence, "ComputeCluster")]

--- a/aws/components/computecluster/state.ftl
+++ b/aws/components/computecluster/state.ftl
@@ -74,14 +74,6 @@
                         COMPUTE_TASK_AWS_LB_REGISTRATION
                     ]
                 },
-                "asgWaitHandle" : {
-                    "Id" : formatResourceId(AWS_CLOUDFORMATION_WAIT_HANDLE_RESOURCE_TYPE, core.Id, "asg" ),
-                    "Type" : AWS_CLOUDFORMATION_WAIT_HANDLE_RESOURCE_TYPE
-                },
-                "asgWaitCondition" : {
-                    "Id" : formatResourceId(AWS_CLOUDFORMATION_WAIT_CONDITION_RESOURCE_TYPE, core.Id, "asg" ),
-                    "Type" : AWS_CLOUDFORMATION_WAIT_CONDITION_RESOURCE_TYPE
-                },
                 "lg" : {
                     "Id" : formatLogGroupId(core.Id),
                     "Name" : core.FullAbsolutePath,


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Removes cloudformation wait resources that wern't required in the compute cluster component

## Motivation and Context

Fixes an issue in template generation as the cloudformation service isn't included in the compute cluster 

## How Has This Been Tested?

Tested locally 

## Related Changes

Regression in #296 

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

