### PR TITLE
feat(globadb): support for change streams

### DIFF
--- a/aws/components/globaldb/setup.ftl
+++ b/aws/components/globaldb/setup.ftl
@@ -59,6 +59,26 @@
         [#local dynamoTableKeyAttributes += getDynamoDbTableAttribute(key, value)]
     [/#list]
 
+    [#-- setup stream for changes made to table --]
+    [#local streamViewType = ""]
+    [#switch solution.ChangeStream.ChangeView ]
+        [#case "KeysOnly" ]
+            [#local streamViewType="KEYS_ONLY"]
+            [#break]
+
+        [#case "NewItem" ]
+            [#local streamViewType="NEW_IMAGE"]
+            [#break]
+
+        [#case "OldItem"]
+            [#local streamViewType="OLD_IMAGE"]
+            [#break]
+
+        [#case "NewAndOldItem"]
+            [#local streamViewType="NEW_AND_OLD_IMAGES"]
+            [#break]
+    [/#switch]
+
     [#if deploymentSubsetRequired(GLOBALDB_COMPONENT_TYPE, true) ]
         [@createDynamoDbTable
             id=tableId
@@ -73,6 +93,8 @@
             kmsKeyId=kmsKeyId
             keys=dynamoTableKeys
             globalSecondaryIndexes=globalSecondaryIndexes
+            streamEnabled=solution.ChangeStream.Enabled
+            streamViewType=streamViewType
         /]
     [/#if]
 [/#macro]

--- a/aws/components/globaldb/state.ftl
+++ b/aws/components/globaldb/state.ftl
@@ -35,11 +35,22 @@
             attributeIfContent(
                 "TABLE_SORT_KEY",
                 sortKey
+            ) +
+            attributeIfTrue(
+                "STREAM_ARN",
+                solution.ChangeStream.Enabled,
+                getExistingReference(id, EVENTSTREAM_ATTRIBUTE_TYPE)
             ),
             "Roles" : {
                 "Inbound" : {},
                 "Outbound" : {
                     "default" : "consume",
+                    "stream" : arrayIfTrue(
+                                    dynamodbStreamRead(
+                                        getReference(id, ARN_ATTRIBUTE_TYPE)
+                                    ),
+                                    solution.ChangeStream.Enabled
+                                ),
                     "consume" : dynamoDbViewerPermission(
                                     getReference(id, ARN_ATTRIBUTE_TYPE)
                                 ) +
@@ -49,6 +60,12 @@
                                         globalSecondaryIndexes
                                     ),
                                     globalSecondaryIndexes
+                                ) +
+                                arrayIfTrue(
+                                    dynamodbStreamRead(
+                                        getReference(id, ARN_ATTRIBUTE_TYPE)
+                                    ),
+                                    solution.ChangeStream.Enabled
                                 ),
                     "produce" : dynamodbProducePermission(
                                     getReference(id, ARN_ATTRIBUTE_TYPE)
@@ -71,6 +88,12 @@
                                         globalSecondaryIndexes
                                     ),
                                     globalSecondaryIndexes
+                                ) +
+                                arrayIfTrue(
+                                    dynamodbStreamRead(
+                                        getReference(id, ARN_ATTRIBUTE_TYPE)
+                                    ),
+                                    solution.ChangeStream.Enabled
                                 )
                }
             }

--- a/aws/services/dynamodb/policy.ftl
+++ b/aws/services/dynamodb/policy.ftl
@@ -329,3 +329,22 @@ itself.
             conditions)
     ]
 [/#function]
+
+
+[#function dynamodbStreamRead tables="*" stream="*" principals="" conditions={} ]
+    [#return
+        getDynamodbStatement(
+            [
+                "dynamodb:DescribeStream",
+                "dynamodb:GetRecords",
+                "dynamodb:GetShardIterator",
+                "dynamodb:ListStreams"
+            ],
+            tables,
+            stream,
+            [],
+            principals,
+            conditions
+        )
+    ]
+[/#function]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds support for enabling streams on dynamo db tables which provide a stream of updates that have been made to the table
- Adds stream read policy for the tables and includes them as part of state if streams are enabled

## Motivation and Context

Extends the feature support between hamlet and whats available in hamlet. Streams are useful for triggering events based on changes to a table

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1683

### Dependent PRs:

- None

### Consumer Actions:

- None

