### PR TITLE
fix(apigateway): use correct link for CA lookup

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -310,7 +310,7 @@
 
                 [#local certificateAuthorityLinkAttribute = mutualTLSConfig.CertificateAuthority["Source:link"]["RootCACertAttribute"] ]
                 [#if certificateAuthorityLink?has_content ]
-                    [#local certificateAuthorityRootPublicCert = (linkTarget.State.Attributes[certificateAuthorityLinkAttribute])!"" ]
+                    [#local certificateAuthorityRootPublicCert = (certificateAuthorityLink.State.Attributes[certificateAuthorityLinkAttribute])!"" ]
 
                     [#if ! (certificateAuthorityRootPublicCert?has_content) ]
                         [@fatal


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Fixes the lookup of the certificate authority to use the correct link

## Motivation and Context

Lookup was using the last link in the link target list 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

