### PR TITLE
fix(globaldb): handle secondary indexs pay per use

### DIFF
--- a/aws/components/globaldb/setup.ftl
+++ b/aws/components/globaldb/setup.ftl
@@ -15,6 +15,8 @@
     [#local tableKey = resources["table"].Key ]
     [#local tableSortKey = resources["table"].SortKey!"" ]
 
+    [#local billingMode = solution.Table.Billing ]
+
     [#-- Baseline component lookup --]
     [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption" ] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
@@ -42,6 +44,7 @@
         [#local globalSecondaryIndexes +=
             getGlobalSecondaryIndex(
                 value.Name,
+                billingMode,
                 value.Keys,
                 value.KeyTypes,
                 value.Capacity.Write,
@@ -84,7 +87,7 @@
             id=tableId
             name=tableName
             backupEnabled=solution.Table.Backup.Enabled
-            billingMode=solution.Table.Billing
+            billingMode=billingMode
             writeCapacity=solution.Table.Capacity.Write
             readCapacity=solution.Table.Capacity.Read
             attributes=dynamoTableKeyAttributes

--- a/aws/services/dynamodb/resource.ftl
+++ b/aws/services/dynamodb/resource.ftl
@@ -125,7 +125,7 @@
     ]
 [/#function]
 
-[#function getGlobalSecondaryIndex name keys keyTypes=[] writeCapacity=0 readCapacity=0 projectionType="all"]
+[#function getGlobalSecondaryIndex name billingMode keys keyTypes=[]  writeCapacity=0 readCapacity=0 projectionType="all"]
     [#local keySchema = [] ]
     [#list keys as key]
         [#-- type default is hash, then range --]
@@ -133,7 +133,11 @@
             getDynamoDbTableKey( key, keyTypes[key?index]!(valueIfTrue("hash",key?index == 0, "hash")) ) ]
     [/#list]
 
-    [#local provisionedThroughput = getProvisionedThroughput(writeCapacity, readCapacity) ]
+    [#local provisionedThroughput = {}]
+    [#if billingMode?lower_case == "provisioned" ]
+        [#local provisionedThroughput = getProvisionedThroughput(writeCapacity, readCapacity) ]
+    [/#if]
+
     [#return
         [
             {


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

removes provisioned throughput configuration on secondary indexes if the billing mode is not provisioned

## Motivation and Context

cloudformation was rejecting a deployment where the table was using pay per use billing and the secondary index had provisioned throughput configured 

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

