### PR TITLE
fix(ec2): fix load balancer registration for ec2

### DIFF
--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -270,7 +270,11 @@
                         [#local sourceSecurityGroupIds += [ linkTargetResources["sg"].Id ] ]
                         [#break]
                     [#case "network" ]
-                        [#local sourceIPAddressGroups = linkTargetConfiguration.IPAddressGroups + [ "_localnet" ] ]
+                        [#local sourceIPAddressGroups = combineEntities(
+                                                            sourceIPAddressGroups,
+                                                            linkTargetConfiguration.Solution.IPAddressGroups + [ "_localnet" ],
+                                                            UNIQUE_COMBINE_BEHAVIOUR
+                                                        )]
                         [#break]
                 [/#switch]
 

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -168,11 +168,16 @@
                         [#local sourceSecurityGroupIds += [ linkTargetResources["sg"].Id ] ]
                         [#break]
                     [#case "network" ]
-                        [#local sourceIPAddressGroups = linkTargetConfiguration.IPAddressGroups + [ "_localnet" ] ]
+                        [#local sourceIPAddressGroups = combineEntities(
+                                                            sourceIPAddressGroups,
+                                                            linkTargetConfiguration.Solution.IPAddressGroups + [ "_localnet" ],
+                                                            UNIQUE_COMBINE_BEHAVIOUR
+                                                        )]
                         [#break]
                 [/#switch]
+            [#break]
 
-        [#case DATAVOLUME_COMPONENT_TYPE]
+            [#case DATAVOLUME_COMPONENT_TYPE]
                 [#local linkVolumeResources = {}]
                 [#list linkTargetResources["Zones"] as zoneId, linkZoneResources ]
                     [#local linkVolumeResources += {

--- a/aws/extensions/computetask_awslinux_vpc_lb/extension.ftl
+++ b/aws/extensions/computetask_awslinux_vpc_lb/extension.ftl
@@ -45,9 +45,8 @@
 
                     [#case "application"]
                     [#case "network"]
-                        [#local configSets += getInitConfigLBTargetRegistration(linkTargetCore.Id, linkTargetAttributes["TARGET_GROUP_ARN"])]
 
-                        [#local portid = linkTargetCore.Id ]
+                        [#local portId = linkTargetCore.Id ]
                         [#local targetGroupArn = linkTargetAttributes["TARGET_GROUP_ARN"]]
 
                         [#local scriptName = "register_targetgroup_${portId}" ]
@@ -62,8 +61,11 @@
                                             'exec > >(tee /var/log/hamlet_cfninit/${scriptName}.log | logger -t ${scriptName} -s 2>/dev/console) 2>&1',
                                             {
                                                 "Fn::Sub" : [
-                                                    r'aws --region "${AWS::Region}" elbv2 register-targets --target-group-arn "${TargeGroupArn}" --targets "Id=$(curl http://169.254.169.254/latest/meta-data/instance-id)"',
-                                                    { "TargeGroupArn": targetGroupArn }
+                                                    r'aws --region "${Region}" elbv2 register-targets --target-group-arn "${TargeGroupArn}" --targets "Id=$(curl http://169.254.169.254/latest/meta-data/instance-id)"',
+                                                    {
+                                                        "TargeGroupArn": targetGroupArn,
+                                                        "Region" : { "Ref" : "AWS::Region" }
+                                                    }
                                                 ]
                                             }
                                         ]
@@ -97,8 +99,11 @@
                                             'exec > >(tee /var/log/hamlet_cfninit/${scriptName}.log | logger -t ${scriptName} -s 2>/dev/console) 2>&1',
                                             {
                                                 "Fn::Sub" : [
-                                                    r'aws --region "${AWS::Region}" elb register-instances-with-load-balancer --load-balancer-name "${LoadBalancer}" --instances "$(curl http://169.254.169.254/latest/meta-data/instance-id)"',
-                                                    { "LoadBalancer": getReference(lbId) }
+                                                    r'aws --region "${Region}" elb register-instances-with-load-balancer --load-balancer-name "${LoadBalancer}" --instances "$(curl http://169.254.169.254/latest/meta-data/instance-id)"',
+                                                    {
+                                                        "LoadBalancer": getReference(lbId),
+                                                        "Region" : { "Ref" : "AWS::Region" }
+                                                    }
                                                 ]
                                             }
                                         ]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Fixes some bugs from the extension migration for ec2 registration with
load balancers.

- remove an old call to the old config set scripts
- fix ip address group setup for network load balancers

## Motivation and Context

Ec2 instance generation process was failing when using a load balancer 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

