### PR TITLE
fix(ecs): capacity provider association output

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -26,7 +26,7 @@
     [#local ecsInstanceLogGroupName = resources["lgInstanceLog"].Name]
     [#local ecsEIPs = (resources["eips"])!{} ]
 
-    [#local ecsCapacityProvierAssociationId = resources["ecsCapacityProvierAssociation"].Id ]
+    [#local ecsCapacityProvierAssociationId = resources["ecsCapacityProviderAssociation"].Id ]
     [#local ecsASGCapacityProviderId = resources["ecsASGCapacityProvider"].Id]
 
     [#local cliAutoScaleGroupId = formatId(ecsAutoScaleGroupId, "cli" ) ]
@@ -605,7 +605,7 @@
     [#local ecsClusterName = parentResources["cluster"].Name ]
     [#local ecsSecurityGroupId = parentResources["securityGroup"].Id ]
     [#local ecsASGCapacityProviderId = parentResources["ecsASGCapacityProvider"].Id]
-    [#local essASGCapacityProviderAssociationId = parentResources["ecsCapacityProvierAssociation"].Id ]
+    [#local essASGCapacityProviderAssociationId = parentResources["ecsCapacityProviderAssociation"].Id ]
 
     [#if ! (getExistingReference(ecsId)?has_content) ]
         [@fatal

--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -179,7 +179,7 @@
                     "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
                     "IncludeInDeploymentState" : false
                 },
-                "ecsCapacityProvierAssociation" : {
+                "ecsCapacityProviderAssociation" : {
                     "Id" : formatResourceId(AWS_ECS_CAPACITY_PROVIDER_ASSOCIATION_RESOURCE_TYPE, core.Id),
                     "Type" : AWS_ECS_CAPACITY_PROVIDER_ASSOCIATION_RESOURCE_TYPE
                 },

--- a/aws/services/ecs/resource.ftl
+++ b/aws/services/ecs/resource.ftl
@@ -51,7 +51,7 @@
 
 [#assign ECS_CAPACITY_PROVIDER_ASSOCIATION_OUTPUT_MAPPINGS =
     {
-        "REFERENCE_ATTRIBUTE_TYPE" : {
+        REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true
         }
     }


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

fixes issue with output mapping in capacity provider association which was preventing capacity provider usage

## Motivation and Context

Generation and deployment were successful but services couldn't check that the association was in place 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

