### PR TITLE
feat(mobileapp): external image source support

### DIFF
--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -59,6 +59,10 @@
                                 "Provider" : "awstest",
                                 "Name" : "lb"
                             },
+                            "mobileapp" : {
+                                "Provider" : "awstest",
+                                "Name" : "mobileapp"
+                            },
                             "s3" : {
                                 "Provider" : "awstest",
                                 "Name" : "s3"

--- a/awstest/modules/mobileapp/module.ftl
+++ b/awstest/modules/mobileapp/module.ftl
@@ -1,0 +1,89 @@
+[#ftl]
+
+[@addModule
+    name="mobileapp"
+    description="Testing module for the aws hosting of mobile app builds"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_mobileapp  ]
+
+    [#-- Mobile App --]
+    [@loadModule
+        settingSets=[
+            {
+                "Type" : "Settings",
+                "Scope" : "Accounts",
+                "Namespace" : "mockacct-shared",
+                "Settings" : {
+                    "Registries": {
+                        "scripts": {
+                            "EndPoint": "account-registry-abc123",
+                            "Prefix": "scripts/"
+                        }
+                    }
+                }
+            },
+            {
+                "Type" : "Builds",
+                "Scope" : "Products",
+                "Namespace" : "mockedup-integration-aws-mobileapp-base",
+                "Settings" : {
+                    "COMMIT" : "123456789#MockCommit#",
+                    "FORMATS" : ["scripts"]
+                }
+            }
+        ]
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "mobileappbase" : {
+                            "mobileapp" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : ["aws-mobileapp-base"]
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Testing" : [ "mobileappbase" ]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "mobileappbase" : {
+                    "OutputSuffix" : "config.json",
+                    "Structural" : {
+                        "JSON" : {
+                            "Match" : {
+                                "BuildFormats" : {
+                                    "Path"  : "BuildConfig.APP_BUILD_FORMATS",
+                                    "Value" : "ios,android"
+                                },
+                                "BUILD_REFERENCE" : {
+                                    "Path" : "BuildConfig.BUILD_REFERENCE]",
+                                    "Value" : "123456789#MockCommit#"
+                                },
+                                "RELEASE_CHANNEL" : {
+                                    "Path" : "BuildConfig.RELEASE_CHANNEL",
+                                    "Value" : "integration"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "mobileappbase" : {
+                    "mobileapp" : {
+                        "TestCases" : [ "mobileappbase" ]
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for retrieving a mobile app source bundle from an external source 
Adds basic testing for mobile app component

## Motivation and Context

This provides users with the ability to use their own build processes but integrate with our deployment process.
Part of https://github.com/hamlet-io/engine/issues/1486

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1686

### Dependent PRs:

- None

### Consumer Actions:

- None

