### PR TITLE
feat: Contentnode image source

### DIFF
--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -31,6 +31,10 @@
                                 "Provider" : "awstest",
                                 "Name" : "computecluster"
                             },
+                            "contentnode" : {
+                                "Provider" : "awstest",
+                                "Name" : "contentnode"
+                            },
                             "ec2" : {
                                 "Provider" : "awstest",
                                 "Name" : "ec2"

--- a/awstest/modules/contentnode/module.ftl
+++ b/awstest/modules/contentnode/module.ftl
@@ -1,0 +1,76 @@
+[#ftl]
+
+[@addModule
+    name="contentnode"
+    description="Testing module for the aws handling of contentnodes"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_contentnode  ]
+
+    [#-- ! TODO(roleyfoley): Testing not performed as we can't tests scripts at the moment --]
+
+    [#-- Mobile App --]
+    [@loadModule
+        settingSets=[
+            {
+                "Type" : "Settings",
+                "Scope" : "Accounts",
+                "Namespace" : "mockacct-shared",
+                "Settings" : {
+                    "Registries": {
+                        "contentnode": {
+                            "EndPoint": "account-registry-abc123",
+                            "Prefix": "contentnode/"
+                        }
+                    }
+                }
+            },
+            {
+                "Type" : "Builds",
+                "Scope" : "Products",
+                "Namespace" : "mockedup-integration-aws-contentnode-base",
+                "Settings" : {
+                    "COMMIT" : "123456789#MockCommit#",
+                    "FORMATS" : [ "contentnode" ]
+                }
+            }
+        ]
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "contentnodebasecontenthub" : {
+                            "contenthub" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-contentnode-base-contenthub"
+                                    }
+                                },
+                                "Prefix" : "/"
+                            }
+                        },
+                        "contentnodebase" : {
+                            "contentnode" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-contentnode-base"
+                                    }
+                                },
+                                "Links" : {
+                                    "contenthub" : {
+                                        "Tier" : "app",
+                                        "Component" : "contentnodebasecontenthub",
+                                        "Instance" : "",
+                                        "Version" : ""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for providing your own image for contentnodes 
adds basic template generation as a test for the component

## Motivation and Context

Part of https://github.com/hamlet-io/engine/issues/1486 which makes it possible for users to manage their images outsidef ot hamlet 


## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

