### PR TITLE
fix(ecs): set launch type on scheduled tasks

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -1408,7 +1408,8 @@
 
                     [#local ecsParameters = {
                         "TaskCount" : schedule.TaskCount,
-                        "TaskDefinitionArn" : getReference(taskId, ARN_ATTRIBUTE_TYPE)
+                        "TaskDefinitionArn" : getReference(taskId, ARN_ATTRIBUTE_TYPE),
+                        "LaunchType" : "EC2"
                      }]
 
                     [#if networkMode == "awsvpc" ]
@@ -1427,7 +1428,8 @@
 
                     [#if engine == "fargate" ]
                         [#local ecsParameters += {
-                            "PlatformVersion" : solution["aws:FargatePlatform"]
+                            "PlatformVersion" : solution["aws:FargatePlatform"],
+                            "LaunchType" : "FARGATE"
                         }]
                     [/#if]
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description
fixes an issue where tasks started through events wern't starting as they didn't have a launch config set.

## Motivation and Context

This configuration was removed as part of the migration to capacity providers, however tasks haven't quite caught up to that yet. 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

