### PR TITLE
feat(datapipeline): support for external image sources

### DIFF
--- a/aws/components/datapipeline/setup.ftl
+++ b/aws/components/datapipeline/setup.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 [#macro aws_datapipeline_cf_deployment_generationcontract_application occurrence ]
-    [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue", "cli", "config"] /]
+    [@addDefaultGenerationContract subsets=["pregeneration", "prologue", "template", "epilogue", "cli", "config"] /]
 [/#macro]
 
 [#macro aws_datapipeline_cf_deployment_application occurrence ]

--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -35,6 +35,10 @@
                                 "Provider" : "awstest",
                                 "Name" : "contentnode"
                             },
+                            "datapipeline" : {
+                                "Provider" : "awstest",
+                                "Name" : "datapipeline"
+                            },
                             "ec2" : {
                                 "Provider" : "awstest",
                                 "Name" : "ec2"

--- a/awstest/modules/datapipeline/module.ftl
+++ b/awstest/modules/datapipeline/module.ftl
@@ -1,0 +1,122 @@
+[#ftl]
+
+[@addModule
+    name="datapipeline"
+    description="Testing module for the aws hosting of datapipelines"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_datapipeline ]
+
+    [#-- Data Pipeline --]
+    [@loadModule
+        settingSets=[
+            {
+                "Type" : "Settings",
+                "Scope" : "Accounts",
+                "Namespace" : "mockacct-shared",
+                "Settings" : {
+                    "Registries": {
+                        "pipeline": {
+                            "EndPoint": "account-registry-abc123",
+                            "Prefix": "pipeline/"
+                        }
+                    }
+                }
+            },
+            {
+                "Type" : "Builds",
+                "Scope" : "Products",
+                "Namespace" : "mockedup-integration-aws-datapipeline-base",
+                "Settings" : {
+                    "COMMIT" : "123456789#MockCommit#",
+                    "FORMATS" : ["pipeline"]
+                }
+            }
+        ]
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "datapipelinebase" : {
+                            "datapipeline" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : ["aws-datapipeline-base"]
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Testing" : [ "datapipelinebase" ]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "datapipelinebasecli" : {
+                    "OutputSuffix" : "cli.json",
+                    "Structural" : {
+                        "JSON" : {
+                            "Match" : {
+                                "pipelineName" : {
+                                    "Path"  : "datapipelineXappXdatapipelinebase.createPipeline.name",
+                                    "Value" : "mockedup-integration-application-datapipelinebase"
+                                },
+                                "pipelineId" : {
+                                    "Path" : "datapipelineXappXdatapipelinebase.createPipeline.uniqueId",
+                                    "Value" : "datapipelineXappXdatapipelinebase"
+                                }
+                            }
+                        }
+                    }
+                },
+                "datapipelinebaseconfig" : {
+                    "OutputSuffix" : "config.json",
+                    "Structural" : {
+                        "JSON" : {
+                            "Match" : {
+                                "vpcId" : {
+                                    "Path"  : "values.my_VPC_ID",
+                                    "Value" : "##MockOutputXvpcXsegmentXvpcX##"
+                                },
+                                "PipelineName" : {
+                                    "Path" : "values.my_ROLE_PIPELINE_NAME",
+                                    "Value" : "mockedup-integration-application-datapipelinebase-pipeline"
+                                }
+                            }
+                        }
+                    }
+                },
+                "datapipelinebasetemplate" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "instanceProfile" : {
+                                    "Name" : "instanceProfileXappXdatapipelinebase",
+                                    "Type" : "AWS::IAM::InstanceProfile"
+                                },
+                                "securityGroup" : {
+                                    "Name" : "securityGroupXappXdatapipelinebase",
+                                    "Type" : "AWS::EC2::SecurityGroup"
+                                }
+                            },
+                            "Output" : [
+                                "securityGroupXappXdatapipelinebase"
+                            ]
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "datapipelinebase" : {
+                    "datapipeline" : {
+                        "TestCases" : [ "datapipelinebasecli" ,"datapipelinebaseconfig", "datapipelinebasetemplate" ]
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds support for pulling a pipeline image from an external url instead of using a push to the registry 
- Adds basic tests for the datapipeline component

## Motivation and Context

https://github.com/hamlet-io/engine/issues/1486 is the main motivation which aims to standardise the way we manage images for components which need them

## How Has This Been Tested?

Tested locally and using tests added in PR 

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1688

### Dependent PRs:

- None

### Consumer Actions:

- None

