### PR TITLE
fix(s3): list permissions for s3 buckets

### DIFF
--- a/aws/services/s3/policy.ftl
+++ b/aws/services/s3/policy.ftl
@@ -156,7 +156,7 @@
             conditions)]
 [/#function]
 
-[#function s3ListPermission bucket key="" object="" principals="" conditions={}]
+[#function s3ListPermission bucket key="" object="*" principals="" conditions={}]
     [#return
         getS3Statement(
             "s3:List*",
@@ -164,7 +164,8 @@
             key,
             object,
             principals,
-            conditions) +
+            conditions
+        ) +
         getS3BucketStatement(
             [
                 "s3:ListBucket",


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description
adds a wildcard default  for the s3 list permissions so that sync and list actions work as expected

## Motivation and Context

Using the aws cli s3 sync command was failing when run from a container on a prefix that the container had access to

## How Has This Been Tested?

Tested on active deployment

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

