### PR TITLE
feat(lambda): check env size

### DIFF
--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -248,6 +248,23 @@
 
     [#local _context += finalEnvironment ]
 
+    [#-- AWS has a 4k limit on the size of the environment - check how close we are --]
+    [#local envSize = getJSON(finalEnvironment)?length]
+    [#local sizeRemedy = "One solution might be to limit the attributes included on links via the IncludeInContext attribute" ]
+    [#-- Not clear what AWS counts in the 4k limit but this should be close --]
+    [#if envSize > 4096]
+        [@fatal
+            message="Lambda environment size of " + envSize?c + " exceeds the AWS limit of 4096"
+            detail=sizeRemedy
+        /]
+    [#-- It is a bit arbitrary as to what defines close --]
+    [#elseif envSize > 3896]
+        [@warn
+            message="Lambda environment size of " + envSize?c + " is close to the AWS limit of 4096"
+            detail=sizeRemedy
+        /]
+    [/#if]
+
     [#local roleId = formatDependentRoleId(fnId)]
     [#local managedPolicies =
         (vpcAccess)?then(

--- a/aws/services/lambda/resource.ftl
+++ b/aws/services/lambda/resource.ftl
@@ -88,7 +88,7 @@
                 "Role" : getReference(roleId, ARN_ATTRIBUTE_TYPE),
                 "Runtime" : settings.RunTime
             } +
-            attributeIfContent("Environment", settings.Environment!{}, {"Variables" : settings.Environment}) +
+            attributeIfContent("Environment", settings.Environment!{}) +
             attributeIfTrue("MemorySize", settings.MemorySize > 0, settings.MemorySize) +
             attributeIfTrue("Timeout", settings.Timeout > 0, settings.Timeout) +
             attributeIfTrue(


### PR DESCRIPTION

## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Generate a warning and fatal error when the size of the lambda environment approaches and exceeds the AWS limit of 4k.

## Motivation and Context
Fixes #317 

## How Has This Been Tested?
Local template genertaion

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

