### PR TITLE
fix(lb): only validate cert when required

### DIFF
--- a/aws/services/lb/resource.ftl
+++ b/aws/services/lb/resource.ftl
@@ -215,7 +215,7 @@
     [/#if]
 
     [#local certificateArn = getExistingReference(certificateId, ARN_ATTRIBUTE_TYPE, regionId)]
-    [#if certificateId?has_content && !(certificateArn?has_content)]
+    [#if certificateId?has_content && !(certificateArn?has_content) && ((port.Certificate)!false) ]
         [@fatal
             message="LB Certificate ARN could not be found. Check the certificate exists and is in the correct region."
             context=


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description
Updates the certificate validation logic to only apply on ports which specifically require a certificate. This prevents failures when a hostname is setup but the certificate isn't required

## Motivation and Context

Template generation was failing when an http redirect was configured on a load balancer which had custom domain logic on one of its port mappings

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

