### PR TITLE
fix(lambda): revert environment variable refactor

### DIFF
--- a/aws/services/lambda/resource.ftl
+++ b/aws/services/lambda/resource.ftl
@@ -88,7 +88,7 @@
                 "Role" : getReference(roleId, ARN_ATTRIBUTE_TYPE),
                 "Runtime" : settings.RunTime
             } +
-            attributeIfContent("Environment", settings.Environment!{}) +
+            attributeIfContent("Environment", (settings.Environment)!{}, { "Variables" : (settings.Environment)!{}}) +
             attributeIfTrue("MemorySize", settings.MemorySize > 0, settings.MemorySize) +
             attributeIfTrue("Timeout", settings.Timeout > 0, settings.Timeout) +
             attributeIfTrue(


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Reinstates the Variables subobject for lambda function environment configuration which was removed as part of a refactor

## Motivation and Context

In https://github.com/hamlet-io/engine-plugin-aws/pull/320 we removed the Variables section of the configuration it turns out we had a mistake in the structure of the attributeIfContent function when making this decision. The 3rd parameter sets the value if defined and the lambda cloudformation template requires Environment.Variable

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

