### PR TITLE
refactor!: remove use of segmentQualifier

### DIFF
--- a/aws/components/apigateway/state.ftl
+++ b/aws/components/apigateway/state.ftl
@@ -177,7 +177,7 @@ created in either case.
     [#local docsHostName = "" ]
 
     [#if certificatePresent ]
-        [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentQualifiers)]
+        [#local certificateObject = getCertificateObject(solution.Certificate!"")]
         [#local certificateDomains = getCertificateDomains(certificateObject) ]
         [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
         [#local hostName = getHostName(certificateObject, occurrence) ]

--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -26,7 +26,7 @@
 
     [#local securityProfile = getSecurityProfile(solution.Profiles.Security, CDN_COMPONENT_TYPE)]
 
-    [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers) ]
+    [#local certificateObject = getCertificateObject(solution.Certificate) ]
     [#local hostName = getHostName(certificateObject, occurrence) ]
     [#local certificateId = formatDomainCertificateId(certificateObject, hostName) ]
     [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]

--- a/aws/components/cdn/state.ftl
+++ b/aws/components/cdn/state.ftl
@@ -8,7 +8,7 @@
     [#local cfName = core.FullName]
 
     [#if isPresent(solution.Certificate) ]
-        [#local certificateObject = getCertificateObject(solution.Certificate!"", segmentQualifiers) ]
+        [#local certificateObject = getCertificateObject(solution.Certificate!"") ]
         [#local hostName = getHostName(certificateObject, occurrence) ]
         [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
         [#local fqdn = formatDomainName(hostName, primaryDomainObject)]

--- a/aws/components/filetransfer/setup.ftl
+++ b/aws/components/filetransfer/setup.ftl
@@ -42,7 +42,7 @@
 
     [#local certificateId = "" ]
     [#if isPresent(solution.Certificate) ]
-        [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers ) ]
+        [#local certificateObject = getCertificateObject(solution.Certificate ) ]
         [#local hostName = getHostName(certificateObject, subOccurrence) ]
         [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
         [#local certificateId = formatDomainCertificateId(certificateObject, hostName) ]

--- a/aws/components/filetransfer/state.ftl
+++ b/aws/components/filetransfer/state.ftl
@@ -7,7 +7,7 @@
     [#local fileServerId = formatResourceId(AWS_TRANSFER_SERVER_RESOURCE_TYPE, core.Id)]
 
     [#if isPresent(solution.Certificate) ]
-        [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers ) ]
+        [#local certificateObject = getCertificateObject(solution.Certificate ) ]
 
         [#local hostName = getHostName(certificateObject, occurrence) ]
         [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -224,9 +224,6 @@
         [#local sourcePort = (ports[source])!{} ]
         [#local destinationPort = (ports[destination])!{} ]
 
-        [#local sourcePortId = sourcePort.Id!source ]
-        [#local sourcePortName = sourcePort.Name!source ]
-
         [#if !(sourcePort?has_content && destinationPort?has_content)]
             [#continue ]
         [/#if]
@@ -272,7 +269,7 @@
         [#local listenerRuleConditions = getListenerRulePathCondition(path) ]
 
         [#-- Certificate details if required --]
-        [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers, sourcePortId, sourcePortName) ]
+        [#local certificateObject = getCertificateObject(solution.Certificate) ]
         [#local hostName = getHostName(certificateObject, subOccurrence) ]
         [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
         [#local certificateId = formatDomainCertificateId(certificateObject, hostName) ]

--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -188,7 +188,7 @@
 
     [#local domainRedirectRules = {} ]
     [#if (sourcePort.Certificate)!false ]
-        [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers, sourcePortId, sourcePortName ) ]
+        [#local certificateObject = getCertificateObject( solution.Certificate ) ]
 
         [#local hostName = getHostName(certificateObject, occurrence) ]
         [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]

--- a/aws/components/mta/setup.ftl
+++ b/aws/components/mta/setup.ftl
@@ -29,7 +29,7 @@
     [/#if]
 
     [#-- Get domain/host information --]
-    [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers)]
+    [#local certificateObject = getCertificateObject(solution.Certificate)]
     [#local certificateDomains = getCertificateDomains(certificateObject) ]
 
     [#-- Baseline component lookup to obtain the kms key --]

--- a/aws/components/mta/state.ftl
+++ b/aws/components/mta/state.ftl
@@ -26,7 +26,7 @@
     [/#if]
 
     [#-- Get domain/host information --]
-    [#local certificateObject = getCertificateObject(solution.Certificate, segmentQualifiers)]
+    [#local certificateObject = getCertificateObject(solution.Certificate)]
     [#local certificateDomains = getCertificateDomains(certificateObject) ]
     [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
     [#local hostName = getHostName(certificateObject, occurrence) ]

--- a/aws/components/serviceregistry/state.ftl
+++ b/aws/components/serviceregistry/state.ftl
@@ -4,7 +4,7 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
-    [#local domainObject = getCertificateObject(solution.Namespace, segmentQualifiers)]
+    [#local domainObject = getCertificateObject(solution.Namespace)]
     [#local domainName = getCertificatePrimaryDomain(domainObject).Name ]
 
     [#assign componentState =
@@ -36,7 +36,7 @@
     [#local parentAttributes = parent.State.Attributes ]
 
     [#local serviceHostObject = mergeObjects(parentSolution.Namespace, solution.ServiceName) ]
-    [#local domainObject = getCertificateObject( serviceHostObject, segmentQualifiers)]
+    [#local domainObject = getCertificateObject( serviceHostObject )]
 
     [#local serviceHost = getHostName(domainObject, occurrence)  ]
     [#local hostName = formatDomainName(serviceHost, parentAttributes["DOMAIN_NAME"] ) ]

--- a/aws/components/userpool/state.ftl
+++ b/aws/components/userpool/state.ftl
@@ -52,7 +52,7 @@
 
         [#local certificateArn = ""]
         [#if certificatePresent ]
-            [#local certificateObject = getCertificateObject(solution.HostedUI.Certificate!"", segmentQualifiers)]
+            [#local certificateObject = getCertificateObject(solution.HostedUI.Certificate!"")]
             [#local certificateDomains = getCertificateDomains(certificateObject) ]
             [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
             [#local hostName = getHostName(certificateObject, occurrence) ]


### PR DESCRIPTION
## Intent of Change
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
Remove all usage of the `segmentQualifier` global variable.

## Motivation and Context
With input pipeline processing performing qualification, there is no longer a need for component code to explicitly handle qualification.

BREAKING CHANGE: Move any LB port specific certificate configuration to the affected port configuration rather than qualifying it at the LB level.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- https://github.com/hamlet-io/engine/pull/1695

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
- Refactor solutions to place port specific certificate configuration on load balancers on the individual ports rather than using port qualifiers on the LB level certificate object.
