### PR TITLE
Management ports timeout

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -139,7 +139,7 @@
                     occurrence=occurrence
                     groupId=bastionSecurityGroupToId
                     linkTarget=linkTarget
-                    inboundPorts=[ "ssh" ]
+                    inboundPorts=solution.ComputeInstance.ManagementPorts
                     networkProfile=networkProfile
                 /]
             [/#if]
@@ -201,11 +201,11 @@
                 occurrence=occurrence
                 groupId=bastionSecurityGroupToId
                 networkProfile=networkProfile
-                inboundPorts=[ "ssh" ]
+                inboundPorts=solution.ComputeInstance.ManagementPorts
             /]
 
             [#local bastionSSHNetworkRule = {
-                        "Ports" : [ "ssh" ],
+                        "Ports" : solution.ComputeInstance.ManagementPorts,
                         "IPAddressGroups" :
                             sshEnabled?then(
                                 combineEntities(

--- a/aws/components/bastion/state.ftl
+++ b/aws/components/bastion/state.ftl
@@ -73,7 +73,7 @@
                 },
                 "Outbound" : {
                     "networkacl" : {
-                        "Ports": [ "ssh" ],
+                        "Ports": solution.ComputeInstance.ManagementPorts,
                         "SecurityGroups" : securityGroupToId,
                         "Description" : core.FullName
                     }

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -254,7 +254,7 @@
                 occurrence=occurrence
                 groupId=computeClusterSecurityGroupId
                 linkTarget=linkTarget
-                inboundPorts=[ "ssh" ]
+                inboundPorts=solution.ComputeInstance.ManagementPorts
                 networkProfile=networkProfile
             /]
         [/#if]
@@ -508,7 +508,7 @@
             occurrence=occurrence
             groupId=computeClusterSecurityGroupId
             networkProfile=networkProfile
-            inboundPorts=[ "ssh" ]
+            inboundPorts=solution.ComputeInstance.ManagementPorts
         /]
 
         [#list ingressRules as ingressRule ]

--- a/aws/components/computecluster/state.ftl
+++ b/aws/components/computecluster/state.ftl
@@ -112,7 +112,7 @@
                 },
                 "Outbound" : {
                     "networkacl" : {
-                        "Ports" : [ "ssh" ],
+                        "Ports" : solution.ComputeInstance.ManagementPorts,
                         "SecurityGroups" : securityGroupId,
                         "Description" : core.FullName
                     }

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -344,6 +344,7 @@
                         conditionId=zoneWaitConditionId
                         handleId=zoneWaitHandleId
                         signalCount=1
+                        timeout=solution.StartupTimeout
                         waitDependencies=[ zoneEc2InstanceId ]
                     /]
 
@@ -384,7 +385,7 @@
                         creationPolicy={
                             "ResourceSignal" : {
                                 "Count" : 1,
-                                "Timeout" : "PT5M"
+                                "Timeout" : "PT${solution.StartupTimeout}S"
                             }
                         }
                     /]

--- a/aws/components/ec2/state.ftl
+++ b/aws/components/ec2/state.ftl
@@ -8,7 +8,7 @@
 
     [#local securityGroupId = formatComponentSecurityGroupId(core.Tier, core.Component)]
 
-    [#local availablePorts = [ "ssh" ]]
+    [#local availablePorts = solution.ComputeInstance.ManagementPorts ]
     [#list solution.Ports as id,port ]
         [#local availablePorts += [ port.Name ]]
     [/#list]

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -408,7 +408,7 @@
                 occurrence=occurrence
                 groupId=ecsSecurityGroupId
                 linkTarget=linkTarget
-                inboundPorts=[ "ssh" ]
+                inboundPorts=solution.ComputeInstance.ManagementPorts
                 networkProfile=networkProfile
             /]
 
@@ -425,7 +425,7 @@
             occurrence=occurrence
             groupId=ecsSecurityGroupId
             networkProfile=networkProfile
-            inboundPorts=[ "ssh" ]
+            inboundPorts=solution.ComputeInstance.ManagementPorts
         /]
 
         [#list resources.logMetrics!{} as logMetricName,logMetric ]

--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -203,7 +203,7 @@
                 },
                 "Outbound" : {
                     "networkacl" : {
-                        "Ports" : [ "ssh" ],
+                        "Ports" : solution.ComputeInstance.ManagementPorts,
                         "SecurityGroups" : sgGroupId,
                         "Description" : core.FullName
                     }

--- a/aws/extensions/computetask_linux_docker_compose/extension.ftl
+++ b/aws/extensions/computetask_linux_docker_compose/extension.ftl
@@ -31,6 +31,10 @@
             "command" : "chmod +x /usr/local/bin/docker-compose",
             "ignoreErrors" : false
         },
+        "03SymlinkBin" : {
+            "command" : "ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose",
+            "ignoreErrors" : false
+        },
         "04TestInstallation" : {
             "command" : "docker-compose --version",
             "ignoreErrors" : false


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Implements Management ports for all Ec2 based components in the AWS provider. This allows for the use of ports other than ssh for management 
- Adds support for configuring a startup timeout on the ec2 component inline with the other ec2 based components which use auto scale groups 
- Adds a minor feature to symlink the docker-compose install to align with the recommended install location and what is available on the awslinux2 PATH 

## Motivation and Context

Main motivation is for quality of life improvements when working with ec2 instances to make them as flexible as possible

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1698

### Dependent PRs:

- None

### Consumer Actions:

- None

