### PR TITLE
feat(userpool): add issuer url in state attributes

### DIFF
--- a/aws/components/userpool/state.ftl
+++ b/aws/components/userpool/state.ftl
@@ -143,7 +143,8 @@
                 "UI_INTERNAL_FQDN" : attrUIInternalFQDN,
                 "UI_BASE_URL" : attrUIBaseURL,
                 "UI_FQDN" : attrUIFQDN,
-                "API_AUTHORIZATION_HEADER" : attrLbAuthHeader
+                "API_AUTHORIZATION_HEADER" : attrLbAuthHeader,
+                "OIDC_ISSUER" : "https://cognito-idp.${attrUserPoolRegion}.amazonaws.com/${attrUserPoolId}"
             } +
             attributeIfContent(
                 "CLIENT",


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Provides the OIDC issuer url in the state of the user pool. This is specific URL that AWS generates and its used for accessing the OIDC configuration including the .well-known endpoints

## Motivation and Context

This is required for clients that use the well-known endpoint process to find the OIDC details of the userpool and saves having to configure all the different endpoints

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

