### PR TITLE
feat: template parameters

### DIFF
--- a/aws/components/template/setup.ftl
+++ b/aws/components/template/setup.ftl
@@ -131,7 +131,8 @@
                 "OpsDataBucketName" : operationsBucket,
                 "AppDataBucketName" : dataBucket,
                 "AppDataBucketPrefix" : getAppDataFilePrefix(occurrence),
-                "KmsKeyArn" : kmsKeyArn
+                "KmsKeyArn" : kmsKeyArn,
+                "Parameters" : parameters
             } +
             solution.NetworkAccess?then(
                 {
@@ -144,9 +145,8 @@
 
         [#-- Add in extension specifics including override of defaults --]
         [#local _context = invokeExtensions( occurrence, _context )]
-
-        [#local _context += getFinalEnvironment(occurrence, _context ) ]
-        [#local parameters += _context.Environment ]
+        [#local parameters += (getFinalEnvironment(occurrence, _context )["Environment"])!{} ]
+        [#local parameters += _context.Parameters ]
 
         [#-- Map Template outputs into our standard attributes --]
         [#local outputs = {}]

--- a/aws/services/secretsmanager/resource.ftl
+++ b/aws/services/secretsmanager/resource.ftl
@@ -78,7 +78,7 @@
         id
         name
         tags
-        kmsKeyId
+        kmsKeyId=""
         description=""
         generateSecret=true
         generateSecretPolicy={}
@@ -90,9 +90,13 @@
         type="AWS::SecretsManager::Secret"
         properties=
             {
-                "Name" : name,
-                "KmsKeyId" : getReference(kmsKeyId, ARN_ATTRIBUTE_TYPE)
+                "Name" : name
             } +
+            attributeIfContent(
+                "KmsKeyId",
+                kmsKeyId,
+                getReference(kmsKeyId, ARN_ATTRIBUTE_TYPE)
+            ) +
             attributeIfContent(
                 "Description",
                 description


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- adds support for parameters defined as part of the context along with settings 
- makes the KMS key optional on secrets components to align with the cloudformation defaults 

## Motivation and Context

Implement https://github.com/hamlet-io/engine/pull/1701 and to make it easier to implement parameters for template components

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1701

### Dependent PRs:

- None

### Consumer Actions:

- None

