### PR TITLE
refactor(es): rename storage profile config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on:
   push:
+    branches:
+      - 'master'
+  pull_request:
 
 jobs:
   deploy_tests:
@@ -32,11 +35,3 @@ jobs:
           mkdir -p ~/.hamlet
           hamlet engine set-engine unicycle
           hamlet -i mock -p aws -p awstest -f cf deploy test-deployments -p '--junitxml=junit.xml' -o "${TEST_OUTPUT_DIR}"
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v2
-        with:
-          report_paths: 'hamlet_tests/junit.xml'
-          fail_on_failure: true
-          require_tests: true
-          check_name: Results

--- a/aws/components/es/setup.ftl
+++ b/aws/components/es/setup.ftl
@@ -81,8 +81,8 @@
 
     [#local esPolicyStatements = [] ]
 
-    [#local storageProfile = getStorage(occurrence, "ElasticSearch")]
-    [#local volume = (storageProfile.Volumes["codeontap"])!{}]
+    [#local storageProfile = getStorage(occurrence, ES_COMPONENT_TYPE)]
+    [#local volume = (storageProfile.Volumes["data"])!{}]
     [#local esCIDRs = getGroupCIDRs(solution.IPAddressGroups, true, occurrence) ]
 
     [#if !esCIDRs?has_content && !(esAuthentication == "SIG4ORIP") ]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- Uses the ES_COMPONENT_TYPE for storage profile lookups
- Removes codeontap as the data volume name and replaces it with an easier to understand data volume name

## Motivation and Context

Using the component type has become the standard for typed profiles and now that we have alternate names on the storage profiles we can use this. Updating the data volume also allows for this to be easier to understand


## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1706

### Dependent PRs:

- None

### Consumer Actions:

- None

