### PR TITLE
refactor: volume handling on ec2 instances

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -255,7 +255,7 @@
             [@createEC2LaunchConfig
                 id=bastionLaunchConfigId
                 processorProfile=processorProfile
-                storageProfile=storageProfile
+                storageProfile=_context.StorageProfile
                 securityGroupId=bastionSecurityGroupToId
                 instanceProfileId=bastionInstanceProfileId
                 resourceId=bastionAutoScaleGroupId

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -547,7 +547,7 @@
         [@createEC2LaunchConfig
             id=computeClusterLaunchConfigId
             processorProfile=processorProfile
-            storageProfile=storageProfile
+            storageProfile=_context.StorageProfile
             securityGroupId=computeClusterSecurityGroupId
             instanceProfileId=computeClusterInstanceProfileId
             resourceId=computeClusterAutoScaleGroupId

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -353,7 +353,7 @@
                         type="AWS::EC2::Instance"
                         metadata=getCFNInitFromComputeTasks(computeTaskConfig)
                         properties=
-                            getBlockDevices(storageProfile) +
+                            getBlockDevices(_context.StorageProfile) +
                             {
                                 "DisableApiTermination" : false,
                                 "EbsOptimized" : false,

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -560,7 +560,7 @@
         [@createEC2LaunchConfig
             id=ecsLaunchConfigId
             processorProfile=processorProfile
-            storageProfile=storageProfile
+            storageProfile=_context.StorageProfile
             instanceProfileId=ecsInstanceProfileId
             securityGroupId=ecsSecurityGroupId
             resourceId=ecsAutoScaleGroupId

--- a/aws/extensions/computetask_linux_volumemount/extension.ftl
+++ b/aws/extensions/computetask_linux_volumemount/extension.ftl
@@ -33,6 +33,8 @@
     [#-- Support for data volumes as linked components to single instances --]
     [#if occurrence.Core.Type == EC2_COMPONENT_TYPE ]
 
+        [#-- These volumes are provided through DataVolumes which are an indepdent component --]
+        [#-- These are attached to instances through links and VolumeMount macro which applies the extra configuration required --]
         [#local zoneResources = occurrence.State.Resources.Zones]
         [#list zones as zone]
             [#if multiAZ || (zones[0].Id = zone.Id)]
@@ -57,6 +59,7 @@
 
                             [#local volumes += {
                                 mountId : {
+                                    "Enabled" : true,
                                     "MountPath" : volumeMount.MountPath,
                                     "Device" : volumeMount.DeviceId,
                                     "DataVolume" : true
@@ -75,9 +78,7 @@
         [#local deviceId = ""]
         [#local osMount = ""]
 
-        [#if (volume.Enabled)!true
-                && ((volume.MountPath)!"")?has_content
-                && ((volume.Device)!"")?has_content ]
+        [#if volume.Enabled && volume.MountPath?? && volume.Device?? ]
 
             [#local deviceId = volume.Device]
             [#local osMount = volume.MountPath]

--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -366,19 +366,19 @@
                     "codeontap": {
                         "Enabled" : true,
                         "Device": "/dev/sdp",
-                        "Size": "30",
+                        "Size": 30,
                         "MountPath" : "/codeontap"
                     },
                     "cache" : {
                         "Enabled" : false,
                         "Device" : "/dev/xvdc",
-                        "Size" : "30",
+                        "Size" : 30,
                         "MountPath" : "/cache"
                     },
                     "temp" : {
                         "Enabled" : false,
                         "Device" : "/dev/xvdt",
-                        "Size" : "30",
+                        "Size" : 30,
                         "MountPath" : "/temp"
                     }
                 }
@@ -392,7 +392,7 @@
                     "dockerVolume" : {
                         "Enabled" : false,
                         "Device" : "/dev/xvdv",
-                        "Size" : "50",
+                        "Size" : 50,
                         "MountPath" : "/var/lib/docker/volumes"
                     }
                 }

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -111,7 +111,7 @@
         [#if (storageProfile.Volumes)?has_content]
             [#local ebsVolumes = [] ]
             [#list storageProfile.Volumes?values as volume]
-                [#if volume?is_hash]
+                [#if volume?is_hash && volume.Enabled ]
                     [#local ebsVolumes +=
                         [
                             {
@@ -120,8 +120,16 @@
                                     "DeleteOnTermination" : true,
                                     "Encrypted" : false,
                                     "VolumeSize" : (volume.Size)?number,
-                                    "VolumeType" : "gp2"
-                                }
+                                    "VolumeType" : volume.Type
+                                } +
+                                attributeIfTrue(
+                                    "Iops",
+                                    (
+                                        ["gp3", "io1", "io2" ]?seq_contains(volume.Type) &&
+                                        volume.Iops??
+                                    ),
+                                    (volume.Iops)!"HamletFatal: Iops not defined for provisioned iops storage"
+                                )
                             }
                         ]
                     ]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description

- Uses the context StorageProfile to align with its use in extensions
- Adds support for configuring volume types and Iops on block devices
- Fixes volume state handling in the volume mount extension
- Fixes types in the masterdata to align the configuration schema

## Motivation and Context

fixes #338 
This adds better handling inline with the configuration provided by the component schema. Some properties in the Storage Profile don't appear to have been implemented 

Adds enabled checks on volumes to ensure they are handled as described 

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1712

### Dependent PRs:

- None

### Consumer Actions:

- None

