### PR TITLE
fix(adaptor): asfile settings handling

### DIFF
--- a/aws/components/adaptor/setup.ftl
+++ b/aws/components/adaptor/setup.ftl
@@ -7,7 +7,7 @@
     [/#if]
 
     [@addDefaultGenerationContract
-        subsets=["pregeneration", "config", "prologue", "epilogue" ]
+        subsets=["pregeneration", "config", "template", "prologue", "epilogue" ]
         converters=converters
     /]
 [/#macro]
@@ -22,6 +22,8 @@
 
     [#-- Baseline component lookup --]
     [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
 
     [#local buildReference = getOccurrenceBuildReference(occurrence)]
     [#local buildUnit = getOccurrenceBuildUnit(occurrence)]
@@ -116,7 +118,13 @@
                     []
                 ) +
                 asFiles?has_content?then(
-                     findAsFilesScript("settingsFiles", asFiles),
+                     findAsFilesScript("filesToSync", asFiles) +
+                        syncFilesToBucketScript(
+                            "filesToSync",
+                            regionId,
+                            operationsBucket,
+                            getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX")
+                        ),
                      []
                 ) +
                 getLocalFileScript(


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description

- Adds a copy script to make asFile settings available in the operationsBucket for use by an adaptor
- Adds template to the supported subsets to allow for resources to be created as part of adaptors

## Motivation and Context

The copy script makes it easy to consume asFile settings from an adaptor 
The template subset makes it possible to generate your own templates based on hamlet resources

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

