### PR TITLE
fix(secretsmanager): make secret string optional

### DIFF
--- a/aws/services/secretsmanager/resource.ftl
+++ b/aws/services/secretsmanager/resource.ftl
@@ -105,9 +105,10 @@
                 {
                     "GenerateSecretString" : generateSecretPolicy
                 },
-                {
-                    "SecretString" : secretString
-                }
+                attributeIfContent(
+                    "SecretString",
+                    secretString
+                )
             )
         tags=tags
     /]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Aligns the secret string configuration with the CFN schema to allow for generating empty secrets

## Motivation and Context

When creating secrets manager secrets you sometimes want to create empty secrets that you populate manually this allows you to keep all secret content away from the CMDB and allows for different teams to handle creating the secret store vs the secret itself.

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

