### PR TITLE
feat: include build details in container image

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,12 +28,16 @@ jobs:
             --diff-url "https://github.com/${REPO}/compare/{previous}...{current}" \
             --issue-url "https://github.com/${REPO}/issues/{id}"
 
-      - name: Create Pull Request
+      - name: change log PR
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: "chore: changelog bump [skip actions]"
+          commit-message: "chore: changelog bump"
           delete-branch: true
           title: 'chore: update changelog'
-          body: 'Updates the changelog with the latest updates'
+          body: |
+            Updates the changelog with the latest updates
+            This is raised as a draft and should be merged before before tagging a release
           labels: 'chore'
           base: 'master'
+          branch: create-pull-request/changelog_bump
+          draft: true

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           REPO: ${{github.repository}}
         run: |
-          auto-changelog --unreleased  \
+          auto-changelog --unreleased --latest-version latest \
             --remote "https://github.com/${REPO}.git" \
             --diff-url "https://github.com/${REPO}/compare/{previous}...{current}" \
             --issue-url "https://github.com/${REPO}/issues/{id}"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,23 +25,31 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push latest
-        if: github.ref == 'refs/heads/master'
-        uses: docker/build-push-action@v2
-        with:
-          tags: "ghcr.io/${{ github.repository}}:latest"
-          push: true
-          target: base_package
+      - name: add build details
+        run: |
+          pip install --pre hamlet-cli
+          hamlet engine add-engine-source-build
 
-      - name: Get the tag name
-        if: startsWith(github.ref, 'refs/tags/')
-        id: get_tag_name
-        run: echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
+      - id: get_tag_name
+        name: image tag prefix
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo ::set-output name=TAG_NAME::latest
+            exit 0
+          fi
 
-      - name: Push Release
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
+            exit 0
+          fi
+
+          echo ::set-output name=TAG_NAME::test
+
+      - name: build and push container
         if: startsWith(github.ref, 'refs/tags/' )
         uses: docker/build-push-action@v2
         with:
+          context: .
           tags: "ghcr.io/${{github.repository}}:${{ steps.get_tag_name.outputs.TAG_NAME }}"
           push: true
           target: base_package


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds a the hamlet cli command to inject build details into the code repo this will then be read by the hamlet cli to give detailed info about engine sources

## Motivation and Context

When bundling the source code into a shared container its hard to know where the code came from. Injecting this into the container images allows us to always find the details as we need. This can also be used to inject other information in the future

## How Has This Been Tested?

Tested locally and will be tested with this pipeline 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

