### PR TITLE
refactor: remove direct references to region

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -972,7 +972,7 @@
                                 "\"" + core.Name + "\"" + " " +
                                 "\"" + accountId + "\"" + " " +
                                 "\"" + accountObject.ProviderId + "\"" + " " +
-                                "\"" + region + "\"" + " || return $?",
+                                "\"" + regionId + "\"" + " || return $?",
                         "#"
 
                     ]
@@ -997,7 +997,7 @@
                 [#local openapiContext =
                     {
                         "Account" : accountObject.ProviderId,
-                        "Region" : region,
+                        "Region" : regionId,
                         "CognitoPools" : cognitoPools,
                         "LambdaAuthorizers" : lambdaAuthorizers,
                         "PrivateHTTPEndpoints" : privateHTTPEndpoints,
@@ -1110,7 +1110,7 @@
                         "DEFINITION_FILE=$( get_openapi_definition_filename " +
                                 "\"" + core.Name + "\"" + " " +
                                 "\"" + accountId + "\"" + " " +
-                                "\"" + region + "\"" + " )",
+                                "\"" + regionId + "\"" + " )",
                         "#"
                     ] +
                     getLocalFileScript(

--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -533,7 +533,7 @@
                     "       # Invalidate distribution",
                     "       info \"Invalidating cloudfront distribution ... \"",
                     "       invalidate_distribution" +
-                    "       \"" + region + "\" " +
+                    "       \"" + regionId + "\" " +
                     "       \"" + getExistingReference(cfId) + "\" " +
                     "       \"" + invalidationPaths?join(" ") + "\" || return $?"
                     " ;;",

--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -170,7 +170,7 @@
                                         cmkKeyId,
                                         dataBucket,
                                         dataBucketPrefix,
-                                        region
+                                        regionId
                                 ),
                                 []
                             ) +

--- a/aws/components/datapipeline/setup.ftl
+++ b/aws/components/datapipeline/setup.ftl
@@ -338,13 +338,13 @@
                     r'       # Create Data pipeline',
                     r'       info "Applying cli level configurtion"',
                     r'       pipelineId="$(create_data_pipeline' +
-                    r'       "' + region + r'" ' +
+                    r'       "' + regionId + r'" ' +
                     r'       "${tmpdir}/cli-' +
                                 pipelineId + r'-' + pipelineCreateCommand + r'.json")"',
                     r'       # Add Pipeline Definition',
                     r'       info "Updating pipeline definition"',
                     r'       update_data_pipeline' +
-                    r'       "' + region + r'" ' +
+                    r'       "' + regionId + r'" ' +
                     r'       "${pipelineId}" ' +
                     r'       "${tmpdir}/pipeline/pipeline-definition.json" ' +
                     r'       "${tmpdir}/pipeline/pipeline-parameters.json" ' +

--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -250,7 +250,7 @@
                     [
                         "# Check Snapshot MasterUserName",
                         "check_rds_snapshot_username" +
-                        " \"" + region + "\" " +
+                        " \"" + regionId + "\" " +
                         " \"" + rdsManualSnapshot + "\" " +
                         " \"" + rdsUsername + "\" || return $?"
                     ],
@@ -262,7 +262,7 @@
                         "function create_deploy_snapshot() {",
                         "info \"Creating Pre-Deployment snapshot... \"",
                         "create_snapshot" +
-                        " \"" + region + "\" " +
+                        " \"" + regionId + "\" " +
                         " \"" + hostType + "\" " +
                         " \"" + rdsFullName + "\" " +
                         " \"" + rdsPreDeploySnapshotId + "\" || return $?"
@@ -287,7 +287,7 @@
                         "function convert_plaintext_snapshot() {",
                         "info \"Checking Snapshot Encryption... \"",
                         "encrypt_snapshot" +
-                        " \"" + region + "\" " +
+                        " \"" + regionId + "\" " +
                         " \"" + hostType + "\" " +
                         " \"" + rdsPreDeploySnapshotId + "\" " +
                         " \"" + cmkKeyArn + "\" || return $?",
@@ -793,14 +793,14 @@
                     "case $\{STACK_OPERATION} in",
                     "  create|update)"
                     "       rds_hostname=\"$(get_rds_hostname" +
-                    "       \"" + region + "\" " +
+                    "       \"" + regionId + "\" " +
                     "       \"" + hostType + "\" " +
                     "       \"" + rdsFullName + "\" || return $?)\""
                 ] +
                 auroraCluster?then(
                     [
                         "       rds_read_hostname=\"$(get_rds_hostname" +
-                        "       \"" + region + "\" " +
+                        "       \"" + regionId + "\" " +
                         "       \"" + hostType + "\" " +
                         "       \"" + rdsFullName + "\" " +
                         "       \"read\" || return $?)\""
@@ -815,12 +815,12 @@
                         "master_password=\"$(generateComplexString" +
                         " \"" + rdsPasswordLength + "\" )\"",
                         "encrypted_master_password=\"$(encrypt_kms_string" +
-                        " \"" + region + "\" " +
+                        " \"" + regionId + "\" " +
                         " \"$\{master_password}\" " +
                         " \"" + cmkKeyArn + "\" || return $?)\"",
                         "info \"Setting Master Password... \"",
                         "set_rds_master_password" +
-                        " \"" + region + "\" " +
+                        " \"" + regionId + "\" " +
                         " \"" + hostType + "\" " +
                         " \"" + rdsFullName + "\" " +
                         " \"$\{master_password}\" || return $?"
@@ -840,7 +840,7 @@
                         " \"" + (portObject.Port)?c + "\" " +
                         " \"" + rdsDatabaseName + "\" || return $?)\"",
                         "encrypted_rds_url=\"$(encrypt_kms_string" +
-                        " \"" + region + "\" " +
+                        " \"" + regionId + "\" " +
                         " \"$\{rds_url}\" " +
                         " \"" + cmkKeyArn + "\" || return $?)\""
                     ] +
@@ -855,7 +855,7 @@
                             " \"" + (portObject.Port)?c + "\" " +
                             " \"" + rdsDatabaseName + "\" || return $?)\"",
                             "encrypted_rds_read_url=\"$(encrypt_kms_string" +
-                            " \"" + region + "\" " +
+                            " \"" + regionId + "\" " +
                             " \"$\{rds_read_url}\" " +
                             " \"" + cmkKeyArn + "\" || return $?)\""
                         ],
@@ -882,11 +882,11 @@
                         "info \"Getting Master Password... \"",
                         "encrypted_master_password=\"" + rdsEncryptedPassword + "\"",
                         "master_password=\"$(decrypt_kms_string" +
-                        " \"" + region + "\" " +
+                        " \"" + regionId + "\" " +
                         " \"$\{encrypted_master_password}\" || return $?)\"",
                         "info \"Resetting Master Password... \"",
                         "set_rds_master_password" +
-                        " \"" + region + "\" " +
+                        " \"" + regionId + "\" " +
                         " \"" + hostType + "\" " +
                         " \"" + rdsFullName + "\" " +
                         " \"$\{master_password}\" || return $?",
@@ -899,7 +899,7 @@
                         " \"" + (portObject.Port)?c + "\" " +
                         " \"" + rdsDatabaseName + "\" || return $?)\"",
                         "encrypted_rds_url=\"$(encrypt_kms_string" +
-                        " \"" + region + "\" " +
+                        " \"" + regionId + "\" " +
                         " \"$\{rds_url}\" " +
                         " \"" + cmkKeyArn + "\" || return $?)\""
                     ] +
@@ -914,7 +914,7 @@
                             " \"" + (portObject.Port)?c + "\" " +
                             " \"" + rdsDatabaseName + "\" || return $?)\"",
                             "encrypted_rds_read_url=\"$(encrypt_kms_string" +
-                            " \"" + region + "\" " +
+                            " \"" + regionId + "\" " +
                             " \"$\{rds_read_url}\" " +
                             " \"" + cmkKeyArn + "\" || return $?)\""
                         ],

--- a/aws/components/externalnetwork/setup.ftl
+++ b/aws/components/externalnetwork/setup.ftl
@@ -147,13 +147,13 @@
                                                 r'       # Create Data pipeline',
                                                 r'       info "Applying cli level configurtion"',
                                                 r'       update_vpn_options ' +
-                                                r'       "' + region + r'" ' +
+                                                r'       "' + regionId + r'" ' +
                                                 r'       "${STACK_NAME}"' +
                                                 r'       "' + vpnConnectionId + r'" ' +
                                                 r'       "${tmpdir}/cli-' +
                                                             vpnConnectionId + "-" + vpnOptionsCommand + r'.json" || return $?'
                                                 r'      tunnel_ips=$(get_vpn_connection_tunnel_ips ' +
-                                                r'       "' + region + r'" ' +
+                                                r'       "' + regionId + r'" ' +
                                                 r'       "${STACK_NAME}"' +
                                                 r'       "' + vpnConnectionId + r'" )',
                                                 r'      tunnel_ip_1="${tunnel_ips[0]}"',
@@ -240,7 +240,7 @@
                                     [@addToDefaultBashScriptOutput
                                         content=[
                                             r'transitGatewayAttachment="$(get_transitgateway_vpn_attachment' +
-                                            r' "' + region + r'" ' +
+                                            r' "' + regionId + r'" ' +
                                             r' "${STACK_NAME}"' +
                                             r' "' + vpnConnectionId + r'" )"'
                                         ] +

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -447,13 +447,13 @@
                                                     r'       # Create Data pipeline',
                                                     r'       info "Applying cli level configurtion"',
                                                     r'       update_vpn_options ' +
-                                                    r'       "' + region + r'" ' +
+                                                    r'       "' + regionId + r'" ' +
                                                     r'       "${STACK_NAME}"' +
                                                     r'       "' + vpnConnectionId + r'" ' +
                                                     r'       "${tmpdir}/cli-' +
                                                                 vpnConnectionId + "-" + vpnOptionsCommand + r'.json" || return $?'
                                                     r'      tunnel_ips=$(get_vpn_connection_tunnel_ips ' +
-                                                    r'       "' + region + r'" ' +
+                                                    r'       "' + regionId + r'" ' +
                                                     r'       "${STACK_NAME}"' +
                                                     r'       "' + vpnConnectionId + r'" )',
                                                     r'      tunnel_ip_1="${tunnel_ips[0]}"',

--- a/aws/components/mobilenotifier/setup.ftl
+++ b/aws/components/mobilenotifier/setup.ftl
@@ -214,7 +214,7 @@
                             "       split_cli_file \"$\{CLI}\" \"$\{tmpdir}\" || return $?",
                             "       info \"Deploying SNS PlatformApp: " + core.SubComponent.Name + "\"",
                             "       platform_app_arn=\"$(deploy_sns_platformapp" +
-                            "       \"" + region + "\" " +
+                            "       \"" + regionId + "\" " +
                             "       \"" + platformAppName + "\" " +
                             "       \"" + platformArn + "\" " +
                             "       \"" + encryptionScheme + "\" " +
@@ -237,7 +237,7 @@
                             "       # Delete SNS Platform Application",
                             "       info \"Deleting SNS Platform App " + core.SubComponent.Name + "\" ",
                             "       delete_sns_platformapp" +
-                            "       \"" + region + "\" " +
+                            "       \"" + regionId + "\" " +
                             "       \"" + platformArn + "\" "
                             "   ;;",
                             "   esac"
@@ -257,7 +257,7 @@
                         "  create|update)",
                         "       info \"Cleaning up platforms that have been removed from config\"",
                         "       cleanup_sns_platformapps " +
-                        "       \"" + region + "\" " +
+                        "       \"" + regionId + "\" " +
                         "       \"" + platformAppName + "\" " +
                         "       '" + getJSON(deployedPlatformAppArns, false) + "' || return $?",
                         "       ;;",

--- a/aws/components/objectsql/setup.ftl
+++ b/aws/components/objectsql/setup.ftl
@@ -93,7 +93,7 @@
         [@addToDefaultBashScriptOutput
             content=
                 [
-                    "workgroup_deployed=\"$(aws --region " + region + " athena list-work-groups --query 'WorkGroups[?Name==`" + workGroupName + "`].Name' --output text)\"",
+                    "workgroup_deployed=\"$(aws --region " + regionId + " athena list-work-groups --query 'WorkGroups[?Name==`" + workGroupName + "`].Name' --output text)\"",
                     "case $\{STACK_OPERATION} in",
                     "  create|update)"
                     "       # Get cli config file",
@@ -101,12 +101,12 @@
                     "       info \"Setting up athena workgroup " + workGroupName + "\"",
                     "       if [[ -z \"$\{workgroup_deployed}\" ]]; then ",
                     "           info \"Creating Athena workgroup\"",
-                    "           aws --region " + region +
+                    "           aws --region " + regionId +
                     "           athena create-work-group --cli-input-json \"file://$\{tmpdir}/cli-" +
                                         workGroupCreateId + "-" + workGroupCreateCommand + ".json\" || exit $?",
                     "       else",
                     "           info \"Updating Athena workgroup" + workGroupName + "\"",
-                    "           aws --region " + region +
+                    "           aws --region " + regionId +
                     "           athena update-work-group --cli-input-json \"file://$\{tmpdir}/cli-" +
                                     workGroupUpdateId + "-" + workGroupUpdateCommand + ".json\" || exit $?",
                     "        fi"
@@ -122,7 +122,7 @@
                     "  delete)",
                     "       if [[ -n \"$\{workgroup_deployed}\" ]]; then ",
                     "           info \"Deleting Athena workgroup" + workGroupName + "\"",
-                    "           aws --region " + region + " athena delete-work-group --work-group \"" + workGroupName + "\" --recursive-delete-option || exit $?",
+                    "           aws --region " + regionId + " athena delete-work-group --work-group \"" + workGroupName + "\" --recursive-delete-option || exit $?",
                     "       fi",
                     " ;;",
                     "esac"

--- a/aws/components/spa/setup.ftl
+++ b/aws/components/spa/setup.ftl
@@ -158,7 +158,7 @@
                 "       # Invalidate distribution",
                 "       info \"Invalidating cloudfront distribution " + distributionId + " " + pathPattern + "\"",
                 "       invalidate_distribution" +
-                "       \"" + region + "\" " +
+                "       \"" + regionId + "\" " +
                 "       \"" + distributionId + "\" " +
                 "       \"" + pathPattern + "\" || return $?"
             ]]

--- a/aws/components/user/setup.ftl
+++ b/aws/components/user/setup.ftl
@@ -86,7 +86,7 @@
                 "case $\{STACK_OPERATION} in",
                 "  delete)",
                 "   manage_iam_userpassword" +
-                "   \"" + region + "\" " +
+                "   \"" + regionId + "\" " +
                 "   \"delete\" " +
                 "   \"" + userName + "\" || return $?",
                 "   ;;",
@@ -270,16 +270,16 @@
                     "function generate_iam_accesskey() {",
                     "info \"Generating IAM AccessKey... \"",
                     "access_key=\"$(create_iam_accesskey" +
-                    " \"" + region + "\" " +
+                    " \"" + regionId + "\" " +
                     " \"" + userName + "\" || return $?)\"",
                     "access_key_array=($access_key)",
                     "encrypted_secret_key=\"$(encrypt_kms_string" +
-                    " \"" + region + "\" " +
+                    " \"" + regionId + "\" " +
                     " \"$\{access_key_array[1]}\" " +
                     " \"" + cmkKeyArn + "\" || return $?)\"",
                     "smtp_password=\"$(get_iam_smtp_password \"$\{access_key_array[1]}\" )\"",
                     "encrypted_smtp_password=\"$(encrypt_kms_string" +
-                    " \"" + region + "\" " +
+                    " \"" + regionId + "\" " +
                     " \"$\{smtp_password}\" " +
                     " \"" + cmkKeyArn + "\" || return $?)\""
                 ] +
@@ -305,12 +305,12 @@
                     "user_password=\"$(generateComplexString" +
                     " \"" + userPasswordLength + "\" )\"",
                     "encrypted_user_password=\"$(encrypt_kms_string" +
-                    " \"" + region + "\" " +
+                    " \"" + regionId + "\" " +
                     " \"$\{user_password}\" " +
                     " \"" + cmkKeyArn + "\" || return $?)\"",
                     "info \"Setting User Password... \"",
                     "manage_iam_userpassword" +
-                    " \"" + region + "\" " +
+                    " \"" + regionId + "\" " +
                     " \"manage\" " +
                     " \"" + userName + "\" " +
                     " \"$\{user_password}\" || return $?"

--- a/aws/services/cw/resource.ftl
+++ b/aws/services/cw/resource.ftl
@@ -303,7 +303,7 @@
                 [#local widgetProperties =
                     {
                         "metrics" : widgetMetrics,
-                        "region" : region,
+                        "region" : regionId,
                         "stat" : "Sum",
                         "period": 300,
                         "view" : widget.asGraph?has_content?then(

--- a/aws/services/waf/resource.ftl
+++ b/aws/services/waf/resource.ftl
@@ -371,7 +371,7 @@
                     r' case ${STACK_OPERATION} in',
                     r'   create|update)',
                     r'       manage_waf_logging ' +
-                    r'          "' + region + r'"' +
+                    r'          "' + regionId + r'"' +
                     r'          "' + wafaclId + r'"' +
                     r'          "' + wafType + r'"' +
                     r'          "enable"' +
@@ -380,7 +380,7 @@
                     r'       ;;',
                     r'    delete)',
                     r'       manage_waf_logging ' +
-                    r'          "' + region + r'"' +
+                    r'          "' + regionId + r'"' +
                     r'          "' + wafaclId + r'"' +
                     r'          "' + wafType + r'"' +
                     r'          "disable"' +
@@ -396,7 +396,7 @@
                     r' case ${STACK_OPERATION} in',
                     r'    create|update|delete)',
                     r'       manage_waf_logging ' +
-                    r'          "' + region + r'"' +
+                    r'          "' + regionId + r'"' +
                     r'          "' + wafaclId + r'"' +
                     r'          "' + wafType + r'"' +
                     r'          "disable"' +


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Replace references to the command line option `region` with references to the `regionId` global variable set in setContext.

## Motivation and Context
There is a mix of use of `region` and `regionId` reflecting the fact that the composite assembly process initialises `region` while
`getContext` populates regionId.

With dynamic loading, references to region need to be made more dynamic so removal of direct references to the input value is the first step in preparing for this.

Once all known uses are modified, the variables used to pass in the layer values will be changed which will hopefully flush out any unidentified uses via null/missing exceptions.

## How Has This Been Tested?
The change is straightforward but the most efficient way to confirm is the running of templates in the normal course of business and rapidly addressing any exceptions.

There are a number of situations where `region` is actually a local variable in a function so global replace isn't an option.

## Related Changes
- https://github.com/hamlet-io/engine/pull/1716
- https://github.com/hamlet-io/engine-plugin-azure/pull/267

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

