### PR TITLE
fix(lb): missing route table link

### DIFF
--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -20,7 +20,7 @@
         [#local networkResources = networkLinkTarget.State.Resources ]
         [#local vpcId = networkResources["vpc"].Id ]
         [#local routeTableLinkTarget = getLinkTarget(occurrence, networkLink + { "RouteTable" : occurrenceNetwork.RouteTable })]
-        [#local routeTableConfiguration = routeTableLinkTarget.Configuration.Solution ]
+        [#local routeTableConfiguration = (routeTableLinkTarget.Configuration.Solution)!{} ]
     [/#if]
 
     [#local publicFacing = (routeTableConfiguration.Public)!false ]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Catch and handle the condition of a missing routetable link in the load balancer state calculation.

## Motivation and Context
The code currently assumes it has a route table which fails when migrating installations that precede the changes made to the support for network gateways.

Add a default value so the state generation still proceeds, allowing earlier segment level components to be updated.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

