### PR TITLE
fix: minor updates - vpcendpoint and ssh keys

### DIFF
--- a/aws/extensions/computetask_awslinux_sshkeys/extension.ftl
+++ b/aws/extensions/computetask_awslinux_sshkeys/extension.ftl
@@ -21,7 +21,7 @@
 
 [#macro shared_extension_computetask_linux_sshkeys_deployment_computetask occurrence ]
 
-    [#local SSHPublicKeysContent = "" ]
+    [#local SSHPublicKeysContent = [] ]
 
     [#list _context.Links as linkId,linkTarget]
         [#local linkTargetCore = linkTarget.Core ]
@@ -36,7 +36,7 @@
                 [#local linkEnvironment = linkTargetConfiguration.Environment.General ]
                 [#list SSHPublicKeys as id,publicKey ]
                     [#if (linkEnvironment[publicKey.SettingName])?has_content ]
-                        [#local SSHPublicKeysContent += linkEnvironment[publicKey.SettingName] + " " + id + "\n"]
+                        [#local SSHPublicKeysContent += [ "${linkEnvironment[publicKey.SettingName]} ${id}" ]]
                     [/#if]
                 [/#list]
                 [#break]
@@ -50,10 +50,8 @@
                 "/home/ec2-user/.ssh/authorized_keys_hamlet" : {
                     "content" : {
                         "Fn::Join" : [
-                            "",
-                            [
-                                SSHPublicKeysContent
-                            ]
+                            "\n",
+                            SSHPublicKeysContent
                         ]
                     },
                     "mode" : "000600",

--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -291,6 +291,7 @@
                 "vpcendpoint": {
                     "gateway": {
                         "deployment:Unit": "vpcendpoint",
+                        "deployment:Priority" : 110,
                         "Engine": "privateservice",
                         "DestinationPorts": [
                             "http",


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)


## Description

- update the deployment priority of the vpcendpoint to remove security group dependency betwen bastion and vpcendpoints when deleting stacks
- Use arrays for ssh key handling to make it easier to follow

## Motivation and Context

Help with deployment cleanups 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

