### PR TITLE
fix(ecs): fix profile lookup for subcomponents

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -691,8 +691,8 @@
                 getSubnets(core.Tier, networkResources)[0..0]
             )]
 
-        [#local networkProfile = getNetworkProfile(occurrence)]
-        [#local loggingProfile = getLoggingProfile(occurrence)]
+        [#local networkProfile = getNetworkProfile(subOccurrence)]
+        [#local loggingProfile = getLoggingProfile(subOccurrence)]
 
         [#if engine == "fargate" && networkMode != "awsvpc" ]
             [@fatal


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

fixes an issue where the parent profile was looked up instead of the subcomponent for logging and network profiles

## Motivation and Context

regression when profiles were moved under a central function 

## How Has This Been Tested?

tested on local deployment

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

