### PR TITLE
feat: set larger default value for SQS MessageRetentionPeriod

### DIFF
--- a/aws/components/sqs/setup.ftl
+++ b/aws/components/sqs/setup.ftl
@@ -82,7 +82,7 @@
             maximumSize=solution.MaximumMessageSize
             retention=solution.MessageRetentionPeriod
             receiveWait=solution.ReceiveMessageWaitTimeSeconds
-            visibilityTimout=solution.VisibilityTimeout
+            visibilityTimeout=solution.VisibilityTimeout
             dlq=valueIfTrue(dlqId!"", dlqRequired, "")
             dlqReceives=
                 valueIfTrue(

--- a/aws/services/sqs/resource.ftl
+++ b/aws/services/sqs/resource.ftl
@@ -37,17 +37,17 @@
     }
 /]
 
-[#macro createSQSQueue id name delay="" maximumSize="" retention="" receiveWait="" visibilityTimout="" dlq="" dlqReceives=1 fifoQueue=false dependencies=""]
+[#macro createSQSQueue id name delay="" maximumSize="" retention=1209600 receiveWait="" visibilityTimeout="" dlq="" dlqReceives=1 fifoQueue=false dependencies=""]
     [@cfResource
         id=id
         type="AWS::SQS::Queue"
         properties=
             {
-                "QueueName" : name
+                "QueueName" : name,
+                "MessageRetentionPeriod" : retention
             } +
             attributeIfContent("DelaySeconds", delay) +
             attributeIfContent("MaximumMessageSize", maximumSize) +
-            attributeIfContent("MessageRetentionPeriod", retention) +
             attributeIfContent("ReceiveMessageWaitTimeSeconds", receiveWait) +
             attributeIfContent(
                 "RedrivePolicy",
@@ -56,7 +56,7 @@
                   "deadLetterTargetArn" : getReference(dlq, ARN_ATTRIBUTE_TYPE),
                   "maxReceiveCount" : dlqReceives
                 }) +
-            attributeIfContent("VisibilityTimeout", visibilityTimout) +
+            attributeIfContent("VisibilityTimeout", visibilityTimeout) +
             attributeIfTrue(
                 "FifoQueue",
                 fifoQueue,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)
- Refactor (non-breaking change which improves the structure or operation of the implementation)
## Description
<!--- Describe your changes in detail -->
Sets a default value for retention parameter of createSQSQueue macro to a maximum value of 1,209,600 seconds (14 days).
Fixes typo in visibilityTimeout parameter name.
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Resolves hamlet-io/engine#1228
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally.
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

