### PR TITLE
feat: support output suffixes on template setup

### DIFF
--- a/aws/components/template/setup.ftl
+++ b/aws/components/template/setup.ftl
@@ -152,19 +152,38 @@
         [#local outputs = {}]
 
         [#list solution.Attributes as id,attribute ]
-            [#local outputs = mergeObjects(
-                outputs,
-                {
-                    attribute.AttributeType : {
-                        "Value": {
-                            "Fn::GetAtt" : [
-                                templateId,
-                                concatenate( [ "Outputs", attribute.TemplateOutputKey ], ".")
-                            ]
-                        }
-                    }
 
-                })]
+            [#if attribute.IdSuffix?has_content ]
+                [#local attributeId = formatAttributeId(formatId(templateId, attribute.IdSuffix), attribute.AttributeType)]
+
+                [@cfOutput
+                    id=attributeId
+                    value={
+                        "Fn::GetAtt" : [
+                            templateId,
+                            concatenate( [ "Outputs", attribute.TemplateOutputKey ], ".")
+                        ]
+                    }
+                /]
+
+            [#else]
+                [#local outputs = mergeObjects(
+                    outputs,
+                    {
+                        attribute.AttributeType : {
+                            "Value": {
+                                "Fn::GetAtt" : [
+                                    templateId,
+                                    concatenate( [ "Outputs", attribute.TemplateOutputKey ], ".")
+                                ]
+                            }
+                        }
+
+                    }
+                )]
+            [/#if]
+
+
         [/#list]
 
         [@createCFNNestedStack


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for additonal outputs based on the IdSuffix value provided for template attributes

## Motivation and Context

Allows for handling multiple outputs as part of template generation

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

