### PR TITLE
feat: add all account units

### DIFF
--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -1043,18 +1043,65 @@
         "account": {
             "Level": "",
             "Priority": 10,
+            "District" : "account",
             "ResourceSets": {
+                "cmk" : {
+                    "deployment:Unit" : "cmk",
+                    "deployment:Priority" : 20
+                },
                 "iam": {
                     "deployment:Unit": "iam",
+                    "deployment:Priority" : 30,
                     "ResourceLabels": [
                         "iam"
                     ]
                 },
                 "lg": {
                     "deployment:Unit": "lg",
+                    "deployment:Priority" : 30,
                     "ResourceLabels": [
                         "lg"
                     ]
+                },
+                "audit" : {
+                    "deployment:Unit" : "audit",
+                    "deployment:Priority" : 40,
+                    "GroupDeploymentUnit" : false
+                },
+                "s3" : {
+                    "deployment:Unit" : "s3",
+                    "deployment:Priority" : 50,
+                    "GroupDeploymentUnit" : false
+                },
+                "apigateway" : {
+                    "deployment:Unit" : "apigateway",
+                    "deployment:Priority" : 100,
+                    "GroupDeploymentUnit" : false
+                },
+                "console" : {
+                    "deployment:Unit" : "console",
+                    "deployment:Priority" : 100,
+                    "GroupDeploymentUnit" : false
+                },
+                "ecs" : {
+                    "deployment:Unit" : "ecs",
+                    "deployment:Priority" : 100,
+                    "GroupDeploymentUnit" : false
+                },
+                "ses" : {
+                    "deployment:Unit" : "ses",
+                    "deployment:Priority" : 100,
+                    "GroupDeploymentUnit" : false
+                },
+                "sms" : {
+                    "deployment:Unit" : "sms",
+                    "deployment:Priority" : 100,
+                    "GroupDeploymentUnit" : false
+                },
+                "volumeencrypt" : {
+                    "deployment:Unit" : "volumeencrypt",
+                    "deployment:Priority" : 100,
+                    "GroupDeploymentUnit" : false
                 }
             },
             "CompositeTemplate": "accountTemplate"


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds all of the possible legacy account units as ResourceSets within the account deployment group. To support the legacy account setup we use Resource sets but disable the group filter.
- Defines a district for the account deployment group to control filtering of deployments

## Motivation and Context

Allows for the discovery of account units without having to read through the code or copy from existing products

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1737

### Dependent PRs:

- None

### Consumer Actions:

- None

