### PR TITLE
Add MaintenanceWindow support in AWS RDS

### DIFF
--- a/aws/components/cache/setup.ftl
+++ b/aws/components/cache/setup.ftl
@@ -135,6 +135,11 @@
 
         [#if !hibernate]
 
+            [#if ! testMaintenanceWindow(solution.MaintenanceWindow)]
+                [@fatal message="Maintenance window incorrectly configured" context=solution /]
+                [#return]
+            [/#if]
+
             [#list solution.Alerts?values as alert ]
 
                 [#local monitoredResources = getCWMonitoredResources(core.Id, resources, alert.Resource)]
@@ -181,6 +186,18 @@
                         "CacheSubnetGroupName": getReference(cacheSubnetGroupId),
                         "VpcSecurityGroupIds":[getReference(cacheSecurityGroupId)]
                     } +
+                    attributeIfContent(
+                        "PreferredMaintenanceWindow",
+                        solution.MaintenanceWindow.Configured?then(
+                                getAmazonCacheMaintenanceWindow(
+                                    solution.MaintenanceWindow.DayOfTheWeek,
+                                    solution.MaintenanceWindow.TimeOfDay,
+                                    solution.MaintenanceWindow.TimeZone
+                                ),
+                                ""
+                            )
+
+                    ) +
                     multiAZ?then(
                         {
                             "AZMode": "cross-az",

--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -491,6 +491,12 @@
         [/#switch]
 
         [#if !hibernate]
+
+            [#if ! testMaintenanceWindow(solution.MaintenanceWindow)]
+                [@fatal message="Maintenance window incorrectly configured" context=solution /]
+                [#return]
+            [/#if]
+            
             [#if auroraCluster ]
 
                 [#if solution.Cluster.ScalingPolicies?has_content ]
@@ -715,6 +721,15 @@
                     tags=rdsTags
                     deletionPolicy=deletionPolicy
                     updateReplacePolicy=updateReplacePolicy
+                    maintenanceWindow=
+                        solution.MaintenanceWindow.Configured?then(
+                            getAmazonRdsMaintenanceWindow(
+                                solution.MaintenanceWindow.DayOfTheWeek,
+                                solution.MaintenanceWindow.TimeOfDay,
+                                solution.MaintenanceWindow.TimeZone
+                                ),
+                            ""
+                        )
                 /]
 
                 [#list resources["dbInstances"]?values as dbInstance ]
@@ -744,6 +759,16 @@
                         enhancedMonitoringRoleId=monitoringRoleId!""
                         performanceInsights=solution.Monitoring.QueryPerformance.Enabled
                         performanceInsightsRetention=solution.Monitoring.QueryPerformance.RetentionPeriod
+                        maintenanceWindow=
+                            solution.MaintenanceWindow.Configured?then(
+                                getAmazonRdsMaintenanceWindow(
+                                    solution.MaintenanceWindow.DayOfTheWeek,
+                                    solution.MaintenanceWindow.TimeOfDay,
+                                    solution.MaintenanceWindow.TimeZone,
+                                    dbInstance?counter
+                                ),
+                                ""
+                            )
                     /]
                 [/#list]
 
@@ -781,6 +806,15 @@
                         enhancedMonitoringRoleId=monitoringRoleId!""
                         performanceInsights=solution.Monitoring.QueryPerformance.Enabled
                         performanceInsightsRetention=solution.Monitoring.QueryPerformance.RetentionPeriod
+                        maintenanceWindow=
+                            solution.MaintenanceWindow.Configured?then(
+                                getAmazonRdsMaintenanceWindow(
+                                    solution.MaintenanceWindow.DayOfTheWeek,
+                                    solution.MaintenanceWindow.TimeOfDay,
+                                    solution.MaintenanceWindow.TimeZone
+                                ),
+                                ""
+                            )
                     /]
             [/#if]
         [/#if]

--- a/aws/components/queuehost/setup.ftl
+++ b/aws/components/queuehost/setup.ftl
@@ -130,6 +130,11 @@
 
         [#if !hibernate]
 
+            [#if ! testMaintenanceWindow(solution.MaintenanceWindow)]
+                [@fatal message="Maintenance window incorrectly configured" context=solution /]
+                [#return]
+            [/#if]
+
             [#-- Monitoring and Alerts --]
             [#list solution.Alerts?values as alert ]
 
@@ -186,10 +191,13 @@
                 autoMinorVersionUpdate=solution.AutoMinorUpgrade
                 logging=true
                 maintenanceWindow=
-                    getAmazonMqMaintenanceWindow(
-                        solution.MaintenanceWindow.DayOfTheWeek,
-                        solution.MaintenanceWindow.TimeOfDay,
-                        solution.MaintenanceWindow.TimeZone
+                    solution.MaintenanceWindow.Configured?then(
+                        getAmazonMqMaintenanceWindow(
+                            solution.MaintenanceWindow.DayOfTheWeek,
+                            solution.MaintenanceWindow.TimeOfDay,
+                            solution.MaintenanceWindow.TimeZone
+                        ),
+                        {}
                     )
             /]
 

--- a/aws/components/secretstore/state.ftl
+++ b/aws/components/secretstore/state.ftl
@@ -1,5 +1,5 @@
 [#ftl]
-[#macro aws_queuehost_cf_state occurrence parent={} ]
+[#macro aws_secretstore_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution ]
 

--- a/aws/services/amazonmq/resource.ftl
+++ b/aws/services/amazonmq/resource.ftl
@@ -32,11 +32,14 @@
 
 
 [#function getAmazonMqMaintenanceWindow dayofWeek timeofDay timeZone="UTC" ]
+    [#local workDate = convertDayOfWeek2DateTime(dayofWeek, timeofDay, timeZone) ]
+    [#local dow = showDateTime(workDate, "EEEE", "UTC") ]
+    [#local time = showDateTime(workDate, "HH:mm", "UTC") ]
     [#return
         {
-            "DayOfWeek" : dayofWeek,
-            "TimeOfDay" : timeofDay,
-            "TimeZone" : timeZone
+            "DayOfWeek" : dow,
+            "TimeOfDay" : time,
+            "TimeZone" : "UTC"
         }
     ]
 [/#function]
@@ -98,9 +101,12 @@
                                 "SINGLE_INSTANCE"
             ),
             "HostInstanceType" : instanceType,
-            "MaintenanceWindowStartTime" : maintenanceWindow,
             "PubliclyAccessible" : false
         } +
+        attributeIfContent(
+            "MaintenanceWindowStartTime",
+            maintenanceWindow
+        ) +
         attributeIfTrue(
             "EncryptionOptions",
             encrypted,

--- a/aws/services/cache/resource.ftl
+++ b/aws/services/cache/resource.ftl
@@ -27,6 +27,15 @@
     }
 ]
 
+[#function getAmazonCacheMaintenanceWindow dayofWeek timeofDay timeZone="UTC" ]
+    [#local startTime = convertDayOfWeek2DateTime(dayofWeek, timeofDay, timeZone) ]
+
+    [#local endTime = addDateTime(startTime, "mm", 60) ]
+    [#local retval = (showDateTime(startTime, "EEE:HH:mm", "UTC")+"-"+showDateTime(endTime, "EEE:HH:mm", "UTC"))?lower_case ]
+
+    [#return retval ]
+[/#function]
+
 [@addOutputMapping
     provider=AWS_PROVIDER
     resourceType=AWS_CACHE_RESOURCE_TYPE

--- a/aws/services/rds/resource.ftl
+++ b/aws/services/rds/resource.ftl
@@ -69,6 +69,16 @@
     }
 /]
 
+[#function getAmazonRdsMaintenanceWindow dayofWeek timeofDay timeZone="UTC" offsetHrs=0 ]
+    [#local startTime = convertDayOfWeek2DateTime(dayofWeek, timeofDay, timeZone) ]
+
+    [#local startTime = addDateTime(startTime, "hh", offsetHrs) ]
+    [#local endTime = addDateTime(startTime, "mm", 30) ]
+    [#local retval = showDateTime(startTime, "EEE:HH:mm", "UTC")+"-"+showDateTime(endTime, "EEE:HH:mm", "UTC") ]
+
+    [#return retval ]
+[/#function]
+
 [#macro createRDSInstance id name
     engine
     processor
@@ -105,6 +115,7 @@
     enhancedMonitoringRoleId=""
     deletionPolicy="Snapshot"
     updateReplacePolicy="Snapshot"
+    maintenanceWindow=""
 ]
     [@cfResource
     id=id
@@ -123,6 +134,10 @@
             "OptionGroupName": getReference(optionGroupId),
             "CACertificateIdentifier" : caCertificate
         } +
+        attributeIfContent(
+            "PreferredMaintenanceWindow",
+            maintenanceWindow
+        ) +
         valueIfTrue(
             {
                 "AllocatedStorage": size?is_string?then(
@@ -228,6 +243,7 @@
     outputId=""
     deletionPolicy="Snapshot"
     updateReplacePolicy="Snapshot"
+    maintenanceWindow=""
 ]
     [#local availabilityZones = []]
     [#list zones as zone ]
@@ -251,6 +267,10 @@
                 "EngineVersion" : engineVersion,
                 "BackupRetentionPeriod" : retentionPeriod
             } +
+            attributeIfContent(
+                "PreferredMaintenanceWindow",
+                maintenanceWindow
+            ) +
             (!(snapshotArn?has_content) && encrypted)?then(
                 {
                     "StorageEncrypted" : true,

--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -27,6 +27,10 @@
                                 "Provider" : "awstest",
                                 "Name" : "bastion"
                             },
+                            "cache" : {
+                                "Provider" : "awstest",
+                                "Name" : "cache"
+                            },
                             "computecluster" : {
                                 "Provider" : "awstest",
                                 "Name" : "computecluster"

--- a/awstest/modules/apigateway/module.ftl
+++ b/awstest/modules/apigateway/module.ftl
@@ -85,6 +85,7 @@
                                         "DeploymentUnits" : ["aws-apigateway-base"]
                                     }
                                 },
+                                "Certificate": {},
                                 "Image" : {
                                     "Source" : "none"
                                 },

--- a/awstest/modules/cache/module.ftl
+++ b/awstest/modules/cache/module.ftl
@@ -1,0 +1,182 @@
+[#ftl]
+
+[@addModule
+    name="cache"
+    description="Testing module for the aws cache component"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_cache  ]
+
+    [#-- Base cache --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "queue": {
+                            "MultiAZ": false,
+                            "cache": {
+                                "Instances": {
+                                    "default": {
+                                        "Versions": {
+                                            "v1": {
+                                                "DeploymentUnits": [
+                                                    "aws-queue-base"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Testing" : [ "cachebase" ]
+                                },
+                                "Engine": "redis",
+                                "EngineVersion": "5.0.0",
+                                "Alerts": {
+                                    "HighCPUUsage": {
+                                        "Description": "Redis cache under high CPU load",
+                                        "Name": "HighCPUUsage",
+                                        "Metric": "EngineCPUUtilization",
+                                        "Threshold": 90,
+                                        "Severity": "error",
+                                        "Statistic": "Average",
+                                        "Periods": 2
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "cachebase" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "cacheCluster" : {
+                                    "Name" : "cacheXappXqueueXv1",
+                                    "Type" : "AWS::ElastiCache::CacheCluster"
+                                },
+                                "alarm" : {
+                                    "Name" : "alarmXcacheXappXqueueXv1XHighCPUUsage",
+                                    "Type" : "AWS::CloudWatch::Alarm"
+                                },
+                                "securityGroup" : {
+                                    "Name" : "securityGroupXcacheXappXqueueXv1",
+                                    "Type" : "AWS::EC2::SecurityGroup"
+                                }
+                            },
+                            "Output" : [
+                                "cacheXappXqueueXv1Xport",
+                                "cacheXappXqueueXv1",
+                                "cacheXappXqueueXv1Xdns",
+                                "alarmXcacheXappXqueueXv1XHighCPUUsage"
+                            ]
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "cachebase" : {
+                    "cache" : {
+                        "TestCases" : [ "cachebase" ]
+                    }
+                }
+            }
+        }
+    /]
+
+    [#-- Maintenance Window --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "queue": {
+                            "MultiAZ": false,
+                            "cache": {
+                                "Instances": {
+                                    "default": {
+                                        "Versions": {
+                                            "v1": {
+                                                "DeploymentUnits": [
+                                                    "aws-queue-maintenance"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Testing" : [ "cachemaintenance" ]
+                                },
+                                "Engine": "redis",
+                                "EngineVersion": "5.0.0",
+                                "MaintenanceWindow": {
+                                    "DayOfTheWeek": "Saturday",
+                                    "TimeOfDay": "1:30",
+                                    "TimeZone": "AEST"
+                                },
+                                "Alerts": {
+                                    "HighCPUUsage": {
+                                        "Description": "Redis cache under high CPU load",
+                                        "Name": "HighCPUUsage",
+                                        "Metric": "EngineCPUUtilization",
+                                        "Threshold": 90,
+                                        "Severity": "error",
+                                        "Statistic": "Average",
+                                        "Periods": 2
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "cachemaintenance" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "cacheCluster" : {
+                                    "Name" : "cacheXappXqueueXv1",
+                                    "Type" : "AWS::ElastiCache::CacheCluster"
+                                },
+                                "securityGroup" : {
+                                    "Name" : "securityGroupXcacheXappXqueueXv1",
+                                    "Type" : "AWS::EC2::SecurityGroup"
+                                }
+                            }
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "cacheMaintenanceWindow" : {
+                                    "Path"  : "Resources.cacheXappXqueueXv1.Properties.PreferredMaintenanceWindow",
+                                    "Value" : "fri:15:30-fri:16:30"
+                                },
+                                "cacheClusterTags" : {
+                                    "Path"  : "Resources.cacheXappXqueueXv1.Properties.Tags[10].Value",
+                                    "Value" : "mockedup-integration-application-queue-v1"
+                                },
+                                "securityGroupTags" : {
+                                    "Path"  : "Resources.securityGroupXcacheXappXqueueXv1.Properties.Tags[10].Value",
+                                    "Value" : "mockedup-integration-application-queue-v1"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "cachemaintenance" : {
+                    "cache" : {
+                        "TestCases" : [ "cachemaintenance" ]
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/awstest/modules/db/module.ftl
+++ b/awstest/modules/db/module.ftl
@@ -148,6 +148,30 @@
                                 "rdsXdbXpostgresdbgeneratedXdns",
                                 "rdsXdbXpostgresdbgeneratedXport"
                             ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "SecurityGroupTagName" : {
+                                    "Path"  : "Resources.securityGroupXdbXpostgresdbgenerated.Properties.Tags[10].Value",
+                                    "Value" : "mockedup-integration-database-postgresdbgenerated"
+                                },
+                                "SubnetGroupTagName" : {
+                                    "Path"  : "Resources.rdsSubnetGroupXdbXpostgresdbgenerated.Properties.Tags[10].Value",
+                                    "Value" : "mockedup-integration-database-postgresdbgenerated"
+                                },
+                                "DbTagName" : {
+                                    "Path"  : "Resources.rdsXdbXpostgresdbgenerated.Properties.Tags[10].Value",
+                                    "Value" : "mockedup-integration-database-postgresdbgenerated"
+                                },
+                                "OptionGroupTagName" : {
+                                    "Path"  : "Resources.rdsOptionGroupXdbXpostgresdbgeneratedXpostgres11.Properties.Tags[10].Value",
+                                    "Value" : "mockedup-integration-database-postgresdbgenerated"
+                                },
+                                "ParameterGroupTagName" : {
+                                    "Path"  : "Resources.rdsParameterGroupXdbXpostgresdbgeneratedXpostgres11.Properties.Tags[10].Value",
+                                    "Value" : "mockedup-integration-database-postgresdbgenerated"
+                                }
+                            }
                         }
                     }
                 }
@@ -156,6 +180,75 @@
                 "postgresdbgenerated" : {
                     "db" : {
                         "TestCases" : [ "postgresdbgenerated" ]
+                    }
+                }
+            }
+        }
+    /]
+
+    [#-- Maintenance Windows --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "db" : {
+                    "Components" : {
+                        "postgresdbmaintenance" : {
+                            "db" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : ["aws-db-postgres-maintenance"]
+                                    }
+                                },
+                                "MaintenanceWindow": {
+                                    "DayOfTheWeek": "Saturday",
+                                    "TimeOfDay": "01:00",
+                                    "TimeZone": "AEST"
+                                },
+                                "Engine" : "postgres",
+                                "EngineVersion" : "11",
+                                "Profiles" : {
+                                    "Testing" : [ "postgresdbmaintenance" ]
+                                },
+                                "GenerateCredentials" : {
+                                    "Enabled" : true,
+                                    "EncryptionScheme" : "kms"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "postgresdbmaintenance" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "rdsInstance" : {
+                                    "Name" : "rdsXdbXpostgresdbmaintenance",
+                                    "Type" : "AWS::RDS::DBInstance"
+                                }
+                            },
+                            "Output" : [
+                                "rdsXdbXpostgresdbmaintenanceXdns",
+                                "rdsXdbXpostgresdbmaintenanceXport"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "MaintenanceWindow" : {
+                                    "Path"  : "Resources.rdsXdbXpostgresdbmaintenance.Properties.PreferredMaintenanceWindow",
+                                    "Value" : "Fri:15:00-Fri:15:30"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "postgresdbmaintenance" : {
+                    "db" : {
+                        "TestCases" : [ "postgresdbmaintenance" ]
                     }
                 }
             }

--- a/awstest/modules/queuehost/module.ftl
+++ b/awstest/modules/queuehost/module.ftl
@@ -90,4 +90,99 @@
             }
         }
     /]
+
+    [#-- Maintenance Window --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "queuehostmaintenance" : {
+                            "queuehost" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-queuehost-maintenance"
+                                    }
+                                },
+                                "MaintenanceWindow": {
+                                    "DayOfTheWeek": "Saturday",
+                                    "TimeOfDay": "01:00",
+                                    "TimeZone": "AEST"
+                                },
+                                "Engine" : "rabbitmq",
+                                "EngineVersion" : "1.0.0",
+                                "Processor" : {
+                                    "Type" : "queue.m3.micro"
+                                },
+                                "Profiles" : {
+                                    "Testing" : [ "queuehostmaintenance" ]
+                                },
+                                "RootCredentials" : {
+                                    "SecretStore" : {
+                                        "Tier" : "app",
+                                        "Component" : "queuehostsecretstore",
+                                        "Instance" : "",
+                                        "Version" :""
+                                    }
+                                }
+                            }
+                        },
+                        "queuehostsecretstore" : {
+                            "secretstore" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-queuehost-secretstore"
+                                    }
+                                },
+                                "Engine" : "aws:secretsmanager"
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "queuehostmaintenance" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "queueHost" : {
+                                    "Name" : "mqBrokerXappXqueuehostmaintenance",
+                                    "Type" : "AWS::AmazonMQ::Broker"
+                                }
+                            },
+                            "Output" : [
+                                "mqBrokerXappXqueuehostbaseXdns",
+                                "securityGroupXmqBrokerXappXqueuehostbase",
+                                "secretXappXqueuehostbaseXroot"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "MaintenanceWindowDay" : {
+                                    "Path"  : "Resources.mqBrokerXappXqueuehostmaintenance.Properties.MaintenanceWindowStartTime.DayOfWeek",
+                                    "Value" : "Friday"
+                                },
+                                "MaintenanceWindowTime" : {
+                                    "Path"  : "Resources.mqBrokerXappXqueuehostmaintenance.Properties.MaintenanceWindowStartTime.TimeOfDay",
+                                    "Value" : "17:00"
+                                },
+                                "MaintenanceWindowTZ" : {
+                                    "Path"  : "Resources.mqBrokerXappXqueuehostmaintenance.Properties.MaintenanceWindowStartTime.TimeZone",
+                                    "Value" : "UTC"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "queuehostmaintenance" : {
+                    "queuehost" : {
+                        "TestCases" : [ "queuehostmaintenance" ]
+                    }
+                }
+            }
+        }
+    /]
 [/#macro]

--- a/awstest/modules/queuehost/module.ftl
+++ b/awstest/modules/queuehost/module.ftl
@@ -25,7 +25,7 @@
                                 "Engine" : "rabbitmq",
                                 "EngineVersion" : "1.0.0",
                                 "Processor" : {
-                                    "Type" : "queue.m3.micro"
+                                    "Type" : "mq.t3.micro"
                                 },
                                 "Profiles" : {
                                     "Testing" : [ "queuehostbase" ]
@@ -56,6 +56,9 @@
             "TestCases" : {
                 "queuehostbase" : {
                     "OutputSuffix" : "template.json",
+                    "Tools" : {
+                       "CFNLint" : true
+                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -112,7 +115,7 @@
                                 "Engine" : "rabbitmq",
                                 "EngineVersion" : "1.0.0",
                                 "Processor" : {
-                                    "Type" : "queue.m3.micro"
+                                    "Type" : "mq.t3.micro"
                                 },
                                 "Profiles" : {
                                     "Testing" : [ "queuehostmaintenance" ]
@@ -143,6 +146,9 @@
             "TestCases" : {
                 "queuehostmaintenance" : {
                     "OutputSuffix" : "template.json",
+                    "Tools" : {
+                       "CFNLint" : true
+                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -150,12 +156,7 @@
                                     "Name" : "mqBrokerXappXqueuehostmaintenance",
                                     "Type" : "AWS::AmazonMQ::Broker"
                                 }
-                            },
-                            "Output" : [
-                                "mqBrokerXappXqueuehostbaseXdns",
-                                "securityGroupXmqBrokerXappXqueuehostbase",
-                                "secretXappXqueuehostbaseXroot"
-                            ]
+                            }
                         },
                         "JSON" : {
                             "Match" : {
@@ -165,7 +166,7 @@
                                 },
                                 "MaintenanceWindowTime" : {
                                     "Path"  : "Resources.mqBrokerXappXqueuehostmaintenance.Properties.MaintenanceWindowStartTime.TimeOfDay",
-                                    "Value" : "17:00"
+                                    "Value" : "15:00"
                                 },
                                 "MaintenanceWindowTZ" : {
                                     "Path"  : "Resources.mqBrokerXappXqueuehostmaintenance.Properties.MaintenanceWindowStartTime.TimeZone",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
Support MaintenanceWindow in AWS RDS
Handle AEST as a timezone in queuehost MaintenanceWindow
Support MaintenanceWindow in AWS cache

## Motivation and Context
Fixes https://github.com/hamlet-io/engine/issues/159
Fixes https://github.com/hamlet-io/engine/issues/1664

## How Has This Been Tested?
Locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1741

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- Optionally add MaintenanceWindow specifying the starting block for the maintenance window

