### PR TITLE
fix: account cmk deployment scope

### DIFF
--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -1047,7 +1047,8 @@
             "ResourceSets": {
                 "cmk" : {
                     "deployment:Unit" : "cmk",
-                    "deployment:Priority" : 20
+                    "deployment:Priority" : 20,
+                    "GroupDeploymentUnit" : false
                 },
                 "iam": {
                     "deployment:Unit": "iam",


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- sets the cmk resource set to not be a group deployment unit
- 
## Motivation and Context

Template generation was failing as it was checking for cmk that is created during this unit

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

