### PR TITLE
feat: add a scripted process to fetch available vpc endpoint services

### DIFF
--- a/aws/inputseeders/aws/endpoints_masterdata.sh
+++ b/aws/inputseeders/aws/endpoints_masterdata.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+profile="$1"; shift
+process="${1-true}"
+
+if [[ "${process}" == "true" ]]; then
+
+  [[ -z "${profile}" ]] && echo -e "\nScript requires a profile as the first parameter to use when querying AWS" && exit 1
+
+  # Ignore the directory used to collect the data
+  [[ ! -f .gitignore ]] && echo "endpoints/" > .gitignore
+
+  if [[ ! -d endpoints ]]; then
+    mkdir -p endpoints/gateway
+  fi
+
+  # List of regions
+  aws --profile "${profile}" --region ap-southeast-2 ec2 describe-regions | jq -r '.Regions | .[].RegionName' | dos2unix | sort > amis/regions.txt
+  readarray -t regions < endpoints/regions.txt
+
+  # Find network gateway endpoints for each region
+  declare -A gateway_endpoints
+
+  for region in "${regions[@]}"; do
+    aws --profile "${profile}" --region "${region}" ec2 describe-vpc-endpoints --filters 'Name=vpc-endpoint-type,Values=Gateway' 'Name=vpc-endpoint-state,Values=available' > "endpoints/gateway/${region}.json"
+    gateway_endpoints["${region}"]="$(jq -r ".VpcEndpoints" < "endpoints/gateway/${region}.json")"
+  done
+else
+  readarray -t regions < endpoints/regions.txt
+fi
+
+# Merge with current master file
+echo "Generating master gateway endpoints ftl file ..."
+
+index=0
+filter=".[${index}]"
+files=("")
+for region in "${regions[@]}"; do
+  index=$(( $index + 1 ))
+  filter="${filter} * .[$index]"
+  files+=("endpoints/gateway/${region}.json")
+done
+
+jq --indent 4 -s "${filter}" "${files[@]}" > endpoints/gateway.json


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
A that calls AWS cli to fetch available vpc endpoints with Gateway type. 
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
fixes hamlet-io/engine#665
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

