### PR TITLE
fix: bastion eip

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -73,7 +73,7 @@
                 "DesiredCount" : sshActive?then(1,0)
     }]
 
-    [#if publicRouteTable ]
+    [#if sshEnabled && publicRouteTable ]
         [#if deploymentSubsetRequired("eip", true) &&
                 isPartOfCurrentDeploymentUnit(bastionEIPId)]
             [@createEIP


### PR DESCRIPTION


## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Ensure the bastion has been enabled at the segment level before generating an eip for it.

## Motivation and Context
eip was being generated even though the bastion was disabled at the segment level

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

