### PR TITLE
refactor: lb cert state

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -273,7 +273,7 @@
                 [#local path = "" ]
                 [#break]
         [/#switch]
-        [#local listenerRuleConditions = getListenerRulePathCondition(path) ]]
+        [#local listenerRuleConditions = getListenerRulePathCondition(path) ]
 
         [#if engine == "application" ]
             [#-- FQDN processing --]

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -178,6 +178,11 @@
         [#local defaultTargetGroupId = resources["defaulttg"].Id]
         [#local defaultTargetGroupName = resources["defaulttg"].Name]
 
+        [#local certificateId = ""]
+        [#if ((resources["certificate"])!{})?has_content ]
+            [#local certificateId = resources["certificate"].Id ]
+        [/#if]
+
         [#local ruleCleanupScript = []]
         [#local cliCleanUpRequired = getExistingReference(listenerId, "cleanup")?has_content ]
 
@@ -242,6 +247,8 @@
         [#local listenerRuleId = resources["listenerRule"].Id ]
         [#local listenerRulePriority = resources["listenerRule"].Priority ]
 
+        [#local fqdn = resources["listenerRule"].FQDN ]
+
         [#local listenerForwardRule = true]
 
         [#local listenerRuleActions = [] ]
@@ -266,19 +273,11 @@
                 [#local path = "" ]
                 [#break]
         [/#switch]
-        [#local listenerRuleConditions = getListenerRulePathCondition(path) ]
-
-        [#-- Certificate details if required --]
-        [#local certificateObject = getCertificateObject(solution.Certificate) ]
-        [#local hostName = getHostName(certificateObject, subOccurrence) ]
-        [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
-        [#local certificateId = formatDomainCertificateId(certificateObject, hostName) ]
+        [#local listenerRuleConditions = getListenerRulePathCondition(path) ]]
 
         [#if engine == "application" ]
             [#-- FQDN processing --]
             [#if solution.HostFilter ]
-                [#local fqdn = formatDomainName(hostName, primaryDomainObject)]
-
                 [#list resources["domainRedirectRules"]!{} as key, rule]
 
                     [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]

--- a/aws/services/acm/id.ftl
+++ b/aws/services/acm/id.ftl
@@ -31,13 +31,17 @@
 
 [#function formatDomainCertificateId certificateObject, hostName=""]
     [#local primaryDomain = getCertificatePrimaryDomain(certificateObject) ]
-    [#return
-        formatResourceId(
-            AWS_CERTIFICATE_RESOURCE_TYPE,
-            certificateObject.Wildcard?then(
-                "star",
-                hostName
-            ),
-            splitDomainName(primaryDomain.Name)
-        ) ]
+    [#if primaryDomain.Name?has_content ]
+        [#return
+            formatResourceId(
+                AWS_CERTIFICATE_RESOURCE_TYPE,
+                certificateObject.Wildcard?then(
+                    "star",
+                    hostName
+                ),
+                splitDomainName(primaryDomain.Name)
+            ) ]
+    [/#if]
+
+    [#return ""]
 [/#function]


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

refactor the certificate and fqdn process for load balancers

## Motivation and Context

This allows for deploying load balancers when domains or certificates have not been defined in a CMDB. When this is the case you can still use the HTTP endpoints which was currently being stopped. 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- https://github.com/hamlet-io/engine/pull/1748

### Consumer Actions:

- None

