### PR TITLE
refactor: use paramters for az - cfnlint

### DIFF
--- a/aws/components/cache/setup.ftl
+++ b/aws/components/cache/setup.ftl
@@ -201,12 +201,12 @@
                     multiAZ?then(
                         {
                             "AZMode": "cross-az",
-                            "PreferredAvailabilityZones" : awsZones,
+                            "PreferredAvailabilityZones" : getCFAWSAzReferences(awsZones),
                             "NumCacheNodes" : processorProfile.CountPerZone * zones?size
                         },
                         {
                             "AZMode": "single-az",
-                            "PreferredAvailabilityZone" : awsZones[0],
+                            "PreferredAvailabilityZone" : getCFAWSAzReference(awsZones[0]),
                             "NumCacheNodes" : processorProfile.CountPerZone
                         }
                     ) +

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -445,7 +445,7 @@
         id=id
         type="AWS::EC2::Volume"
         properties={
-            "AvailabilityZone" : zone.AWSZone,
+            "AvailabilityZone" : getCFAWSAzReference(zone.AWSZone),
             "VolumeType" : volumeType,
             "Size" : size
         } +

--- a/aws/services/rds/resource.ftl
+++ b/aws/services/rds/resource.ftl
@@ -164,7 +164,7 @@
             },
             ( multiAZ && !clusterMember ),
             {
-                "AvailabilityZone" : availabilityZone
+                "AvailabilityZone" : getCFAWSAzReference(availabilityZone)
             }
         ) +
         valueIfTrue(
@@ -262,7 +262,7 @@
                 "DBSubnetGroupName" : subnetGroupId,
                 "Port" : port,
                 "VpcSecurityGroupIds" : asArray(securityGroupId),
-                "AvailabilityZones" : availabilityZones,
+                "AvailabilityZones" : getCFAWSAzReferences(availabilityZones),
                 "Engine" : engine,
                 "EngineVersion" : engineVersion,
                 "BackupRetentionPeriod" : retentionPeriod


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

adds a set of AZ lookup and parameter reference functions which can be used to create the parameters with default values and to reference them in the template that they are being used in

## Motivation and Context

cfnlint doesn't recommended hard coding AZ values in templates. While we use generated templates we should try and comply with what cfn lint says and to allow for other cfn lint tests to pass

## How Has This Been Tested?

Tested on local template generation and with test suite

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

