### PR TITLE
fix(lb): handle missing fqdn

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -297,7 +297,9 @@
 
                 [/#list]
 
-                [#local listenerRuleConditions += getListenerRuleHostCondition(fqdn) ]
+                [#if fqdn?has_content]
+                    [#local listenerRuleConditions += getListenerRuleHostCondition(fqdn) ]
+                [/#if]
             [/#if]
 
             [#-- Redirect rule processing --]

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -297,10 +297,9 @@
 
                 [/#list]
 
-                [#if fqdn?has_content]
-                    [#local listenerRuleConditions += getListenerRuleHostCondition(fqdn) ]
-                [#else]
-                    [@fatal message="Missing FQDN" context=solution /]
+                [#local listenerRuleConditions += getListenerRuleHostCondition(fqdn) ]
+                [#if ! fqdn?has_content]
+                    [@fatal message="HostName/Certificate property is required when HostFilter:true " context=solution /]
                 [/#if]
             [/#if]
 

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -299,6 +299,8 @@
 
                 [#if fqdn?has_content]
                     [#local listenerRuleConditions += getListenerRuleHostCondition(fqdn) ]
+                [#else]
+                    [@fatal message="Missing FQDN" context=solution /]
                 [/#if]
             [/#if]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
Handle missing FQDN for LB

## Motivation and Context
Encountered this issue when testing for hamlet-io/engine-plugin-aws#254

## How Has This Been Tested?
Local generation and deployment to AWS

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

