### PR TITLE
feat: aws implementation of firewall component

### DIFF
--- a/aws/components/firewall/id.ftl
+++ b/aws/components/firewall/id.ftl
@@ -1,0 +1,23 @@
+[#ftl]
+
+[@addResourceGroupInformation
+    type=FIREWALL_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_NETWORK_FIREWALL_SERVICE
+        ]
+/]
+
+[@addResourceGroupInformation
+    type=FIREWALL_RULE_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_NETWORK_FIREWALL_SERVICE
+        ]
+/]

--- a/aws/components/firewall/setup.ftl
+++ b/aws/components/firewall/setup.ftl
@@ -1,0 +1,355 @@
+[#ftl]
+
+[#macro aws_firewall_cf_deployment_generationcontract occurrence ]
+    [@addDefaultGenerationContract subsets=["template"] /]
+[/#macro]
+
+[#macro aws_firewall_cf_deployment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core ]
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local resources = occurrence.State.Resources ]
+
+    [#local loggingProfile = getLoggingProfile(occurrence)]
+
+    [#local firewallId = resources["firewall"].Id ]
+    [#local firewallName = resources["firewall"].Name ]
+
+    [#local firewallPolicyId = resources["policy"].Id ]
+    [#local firewallPolicyName = resources["policy"].Name ]
+
+    [#local firewallLoggingId = resources["firewalllogging"].Id ]
+
+    [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
+    [#local networkLink = occurrenceNetwork.Link!{} ]
+    [#local networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
+
+    [#if ! networkLinkTarget?has_content ]
+        [@fatal message="Network could not be found" context=networkLink /]
+        [#return]
+    [/#if]
+
+    [#local networkConfiguration = networkLinkTarget.Configuration.Solution]
+    [#local networkResources = networkLinkTarget.State.Resources ]
+
+    [#local subnets = []]
+    [#if multiAZ ]
+        [#local subnets = getSubnets(core.Tier, networkResources)]
+    [#else]
+        [#local subnets = getSubnets(core.Tier, networkResources, zones[0].Id )]
+    [/#if]
+
+    [@createNetworkFirewall
+        id=firewallId
+        name=firewallName
+        vpcId=networkResources["vpc"].Id
+        subnets=subnets
+        firewallPolicyId=firewallPolicyId
+        tags=getOccurrenceCoreTags(occurrence, core.FullName)
+    /]
+
+                            {
+                                "Fn::Join": [
+                                    ",",
+                                    tierSubnetIdRefs
+                                ]
+                            },
+
+    [@cfOutput
+        formatId(firewallId, INTERFACE_ATTRIBUTE_TYPE),
+        {
+            "Fn::Join": [
+                ",",
+                {
+                    "Fn::GetAtt": [
+                        firewallId,
+                        "EndpointIds"
+                    ]
+                }
+            ]
+        },
+        true
+    /]
+
+    [#local loggingS3Prefix = ""]
+    [#local loggingDestinationId = ""]
+
+    [#switch solution.Logging.DestinationType ]
+
+        [#case "log"]
+            [#local logGroupId = resources["lg"].Id ]
+            [#local logGroupName = resources["lg"].Name ]
+
+            [#local loggingDestinationId = logGroupId]
+
+            [@setupLogGroup
+                occurrence=occurrence
+                logGroupId=logGroupId
+                logGroupName=logGroupName
+                loggingProfile=loggingProfile
+            /]
+            [#break]
+
+        [#case "s3"]
+            [#local s3LinkTarget = getLinkTarget(occurrence, solution.Logging["destinationType:s3"].Link) ]
+
+            [#switch s3LinkTarget.Core.Type ]
+                [#case S3_COMPONENT_TYPE ]
+                [#case BASELINE_DATA_COMPONENT_TYPE]
+                    [#local loggingDestinationId = (s3LinkTarget.State.Resources["bucket"].Id)!"" ]
+                    [#local loggingS3Prefix  = getContextPath(occurrence, solution.Logging["destinationType:s3"].Prefix) ]
+
+                [#default]
+                    [@fatal
+                        message="Invalid firewall logging destination for destination type"
+                        context={
+                            "FirewallId" : core.RawId,
+                            "DestinationType" : solution.Logging.DestinationType,
+                            "LinkComponentType" : s3LinkTarget.Core.Type,
+                            "SupportedTypes" : [
+                                S3_COMPONENT_TYPE,
+                                BASELINE_DATA_COMPONENT_TYPE
+                            ]
+                        }
+                    /]
+            [/#switch]
+            [#break]
+
+        [#case "datafeed"]
+            [#local datafeedLinkTarget = getLinkTarget(occurrence, solution.Logging["destinationType:datafeed"].Link) ]
+
+            [#switch datafeedLinkTarget.Core.Type ]
+                [#case DATAFEED_COMPONENT_TYPE ]
+                    [#local loggingDestinationId = (datafeedLinkTarget.State.Resources["stream"].Id)!"" ]
+                    [#break]
+
+                [#default]
+                    [@fatal
+                        message="Invalid firewall logging destination for destination type"
+                        context={
+                            "FirewallId" : core.RawId,
+                            "DestinationType" : solution.Logging.DestinationType,
+                            "LinkComponentType" : datafeedLinkTarget.Core.Type,
+                            "SupportedTypes" : [
+                                DATAFEED_COMPONENT_TYPE
+                            ]
+                        }
+                    /]
+            [/#switch]
+            [#break]
+    [/#switch]
+
+    [#local logType = ""]
+    [#switch solution.Logging.Events]
+        [#case "all"]
+            [#local logType = "flow"]
+            [#break]
+
+        [#case "alert-only"]
+            [#local logType = "alert"]
+            [#break]
+    [/#switch]
+
+    [#local logConfig = getNetworkFirewallLoggingConfiguration(
+                            logType,
+                            solution.Logging.DestinationType,
+                            loggingDestinationId,
+                            loggingS3Prefix)]
+
+    [@createNetworkFirewallLogging
+        id=firewallLoggingId
+        firewallId=firewallId
+        logDestinationConfigs=logConfig
+    /]
+
+    [#local statefulRuleGroupIds = []]
+
+    [#local statelessRuleGroupRefs = []]
+    [#local statelessDefaultActions = []]
+    [#local statelessFragmentDefaultActions = []]
+    [#local statelessCustomActions = []]
+
+    [#list (occurrence.Occurrences)![] as subOccurrence ]
+        [#local subCore = subOccurrence.Core ]
+        [#local subSolution = subOccurrence.Configuration.Solution ]
+        [#local subResources = subOccurrence.State.Resources ]
+
+        [#local ruleGroupId = subResources["rulegroup"].Id ]
+        [#local ruleGroupName = subResources["rulegroup"].Name ]
+
+        [#local createRuleGroup = true]
+
+        [#local ruleGroupArgs = {
+            "httpDomainFilter" : {},
+            "statefulComplexRule" : "",
+            "statefulSimpleRules" : [],
+            "statelessRule" : {},
+            "variables" : {}
+        }]
+
+        [#switch subSolution.Inspection]
+            [#case "Stateful"]
+                [#switch subSolution.Type ]
+                    [#case "NetworkTuple" ]
+                        [#local ruleGroupArgs += {
+                            "statefulSimpleRules" : ruleGroupArgs.statefulSimpleRules + getNetworkFirewallRuleGroupSimpleStatefulRules(
+                                subSolution.Action,
+                                getGroupCIDRs(subSolution.NetworkTuple.Destination.IPAddressGroups),
+                                ports[subSolution.NetworkTuple.Destination.Port],
+                                getGroupCIDRs(subSolution.NetworkTuple.Source.IPAddressGroups),
+                                ports[subSolution.NetworkTuple.Source.Port],
+                                "any"
+                            )
+                        }]
+                        [#break]
+
+                    [#case "HostFilter"]
+                        [#local domains = subSolution.HostFilter.Hosts ]
+                        [#list (subSolution.HostFilter.LinkEndpoints)?values as linkEndpoint ]
+                            [#local linkTarget = getLinkTarget(linkEndpoint.Link)]
+                            [#if linkTarget?has_content
+                                    && ((linkTarget.State.Attributes[linkEndpoint.Attribute])!"")?has_content]
+                                [#local domains = combineEntities(
+                                                    domains,
+                                                    [ linkTarget.State.Attributes[linkEndpoint.Attribute] ],
+                                                    MERGE_COMBINE_BEHAVIOUR) ]
+                            [/#if]
+                        [/#list]
+
+                        [#local hostfilterAction = ""]
+                        [#switch subSolution.Action ]
+                            [#case "pass"]
+                                [#local hostfilterAction = "allow"]
+                                [#break]
+
+                            [#case "drop"]
+                                [#local hostfilterAction = "deny"]
+                                [#break]
+
+                            [#default]
+                                [@fatal
+                                    message="Invalid action for HostFilter network Rule"
+                                    context={
+                                        "FirewallId" : core.RawId,
+                                        "RuleId" : subCore.RawId,
+                                        "Action" : subSolution.Action,
+                                        "PermittedActions" : [ "pass", "drop" ]
+                                    }
+                                /]
+                        [/#switch]
+
+                        [#local ruleGroupArgs += {
+                            "httpDomainFilter" : getNetworkFirewallRuleGroupHTTPDomainFiltering(
+                                hostfilterAction,
+                                domains,
+                                subSolution.HostFilter.Protocols
+                            )
+                        }]
+                        [#break]
+
+                    [#default]
+                        [@fatal
+                            message="Stateful rule inspection does not support rule type"
+                            context={
+                                "FirewallId" : core.RawId,
+                                "RuleId" : subCore.RawId,
+                                "Type" : subSolution.Type
+                            }
+                        /]
+                [/#switch]
+                [#break]
+
+            [#case "Stateless"]
+                [#switch subSolution.Type]
+                    [#case "NetworkTuple"]
+
+                        [#local statelessAction = ""]
+                        [#if subSolution.Priority?is_string && (subSolution.Priority)?lower_case == "default" ]
+                            [#local priority = 1 ]
+                            [#local statelessAction = subSolution.Action ]
+
+                            [#switch subSolution.Action ]
+                                [#case "drop"]
+                                    [#local statelessDefaultActions += ["aws:drop"]]
+                                    [#break]
+                                [#case "pass"]
+                                    [#local statelessDefaultActions += ["aws:pass"]]
+                                    [#break]
+                                [#case "inspect"]
+                                    [#local statelessDefaultActions += ["aws:forward_to_sfe"]]
+                                    [#break]
+
+                                [#default]
+                                    [@fatal
+                                        message="Invalid network friewall stateless default action"
+                                        context={
+                                            "FirewallId" : core.RawId,
+                                            "RuleId" : subCore.RawId,
+                                            "Action" : subSolution.Action,
+                                            "PossibleActions" : [ "drop", "pass", "inspect"]
+                                        }
+                                    /]
+                            [/#switch]
+
+                            [#local createRuleGroup = false ]
+
+                        [#else]
+                            [#local priority = subSolution.Priority]
+                            [#local statelessRuleGroupRefs += [ getNetworkFirewallPolicyStatelessRuleReference(ruleGroupId, subSolution.Priority)] ]
+                            [#local statelessAction = subSolution.Action]
+
+                            [#local ruleGroupArgs += {
+                                "statelessRule" : getFirewallRuleGroupStatelessRule(
+                                                    priority,
+                                                    statelessAction,
+                                                    getGroupCIDRs(subSolution.NetworkTuple.Source.IPAddressGroups),
+                                                    ports[subSolution.NetworkTuple.Source.Port],
+                                                    getGroupCIDRs(subSolution.NetworkTuple.Destination.IPAddressGroups),
+                                                    ports[subSolution.NetworkTuple.Destination.Port]
+                                                )
+                            }]
+                        [/#if]
+                        [#break]
+                [/#switch]
+                [#break]
+        [/#switch]
+
+        [#if createRuleGroup ]
+            [@createNetworkFirewallRuleGroup
+                id=ruleGroupId
+                name=ruleGroupName
+                type=subSolution.Inspection
+                capacity=100
+                ruleGroup=getNetworkFirewallRuleGroup?with_args(ruleGroupArgs?values)()
+                tags=getOccurrenceCoreTags(subOccurrence, subCore.FullName)
+            /]
+        [/#if]
+
+    [/#list]
+
+    [#if ! statelessDefaultActions?has_content ]
+        [@fatal
+            message="Missing default stateless action rule - add a stateless rule with default priority"
+            context={
+                "FirewallId" : core.RawId
+            }
+        /]
+    [/#if]
+
+    [@createNetworkFirewallPolicy
+        id=firewallPolicyId
+        name=firewallPolicyName
+        statefulRuleGroupIds=statefulRuleGroupIds
+        statelessRuleGroupRefs=statelessRuleGroupRefs
+        statelessCustomActions=statelessCustomActions
+        statelessDefaultActions=statelessDefaultActions
+        statelessFragmentDefaultActions=
+            statelessFragmentDefaultActions?has_content?then(
+                statelessFragmentDefaultActions,
+                statelessDefaultActions
+            )
+        tags=getOccurrenceCoreTags(occurrence, core.FullName)
+    /]
+
+[/#macro]

--- a/aws/components/firewall/state.ftl
+++ b/aws/components/firewall/state.ftl
@@ -1,0 +1,132 @@
+[#ftl]
+
+[#macro aws_firewall_cf_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local resources = {}]
+    [#local attributes = {}]
+
+    [#switch (solution.Engine)!"" ]
+        [#case "network" ]
+
+            [#local firewallId = formatResourceId(AWS_NETWORK_FIREWALL_RESOURCE_TYPE, core.Id)]
+
+            [#local resources += {
+                "firewall" : {
+                    "Id" : firewallId,
+                    "Name" : core.FullName,
+                    "Type" : AWS_NETWORK_FIREWALL_RESOURCE_TYPE
+                },
+                "firewalllogging" : {
+                    "Id" : formatResourceId(AWS_NETWORK_FIREWALL_LOGGING_RESOURCE_TYPE, core.Id),
+                    "Type" : AWS_NETWORK_FIREWALL_LOGGING_RESOURCE_TYPE
+                },
+                "policy" : {
+                    "Id" : formatResourceId(AWS_NETWORK_FIREWALL_POLICY_RESOURCE_TYPE, core.Id),
+                    "Name" : core.FullName,
+                    "Type" : AWS_NETWORK_FIREWALL_POLICY_RESOURCE_TYPE
+                }
+            }]
+
+            [#if solution.Logging.DestinationType == "log"]
+                [#local resources += {
+                    "lg" : {
+                        "Id" : formatDependentLogGroupId(firewallId),
+                        "Name" : core.FullAbsolutePath
+                    }
+                }]
+            [/#if]
+
+            [#local attributes += {
+                "ARN" : getExistingReference(firewallId, ARN_ATTRIBUTE_TYPE),
+                "INTERFACES" : getExistingReference(firewallId, INTERFACE_ATTRIBUTE_TYPE)
+            }]
+
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Unsupported Firewall engine type"
+                context={
+                    "Id" : core.RawId,
+                    "Engine" : (solution.Engine)!""
+                }
+            /]
+    [/#switch]
+
+
+    [#assign componentState =
+        {
+            "Resources" : resources,
+            "Attributes" : attributes,
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+
+[/#macro]
+
+
+[#macro aws_firewallrule_cf_state occurrence parent={} ]
+    [#local parentCore = parent.Core]
+    [#local parentSolution = parent.Configuration.Solution]
+
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local resources = {}]
+    [#local attributes = {}]
+
+    [#switch parentSolution.Engine ]
+        [#case "network"]
+            [#switch solution.Type]
+                [#case "NetworkTuple"]
+                [#case "HostFilter"]
+                [#case "Complex"]
+                    [#local resources += {
+                        "rulegroup" : {
+                            "Id" : formatResourceId(AWS_NETWORK_FIREWALL_RULEGROUP_RESOURCE_TYPE, core.Id),
+                            "Name" : core.FullName,
+                            "Type" : AWS_NETWORK_FIREWALL_RULEGROUP_RESOURCE_TYPE
+                        }
+                    }]
+                    [#break]
+
+                [#default]
+                    [@fatal
+                        message="Network Engine doens't support the provided rule type"
+                        context={
+                            "FirewallId" : parentCore.RawId,
+                            "Engine" : parentSolution.Engine,
+                            "RuleId" : core.RawId,
+                            "RuleType" : solution.Type
+                        }
+                    /]
+
+            [/#switch]
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Firewall engine not supported on aws provider"
+                context={
+                    "FirewallId" : parentCore.RawId,
+                    "Engine" : parentSolution.Engine
+                }
+            /]
+    [/#switch]
+
+    [#assign componentState =
+        {
+            "Resources" : resources,
+            "Attributes" : attributes,
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]

--- a/aws/services/networkfirewall/id.ftl
+++ b/aws/services/networkfirewall/id.ftl
@@ -1,0 +1,31 @@
+[#ftl]
+
+[#-- Resources --]
+[#assign AWS_NETWORK_FIREWALL_RESOURCE_TYPE = "networkfirewall" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_NETWORK_FIREWALL_SERVICE
+    resource=AWS_NETWORK_FIREWALL_RESOURCE_TYPE
+/]
+
+
+[#assign AWS_NETWORK_FIREWALL_POLICY_RESOURCE_TYPE = "networkfirewallpolicy" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_NETWORK_FIREWALL_SERVICE
+    resource=AWS_NETWORK_FIREWALL_POLICY_RESOURCE_TYPE
+/]
+
+[#assign AWS_NETWORK_FIREWALL_LOGGING_RESOURCE_TYPE = "networkfirewalllogging" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_NETWORK_FIREWALL_SERVICE
+    resource=AWS_NETWORK_FIREWALL_LOGGING_RESOURCE_TYPE
+/]
+
+[#assign AWS_NETWORK_FIREWALL_RULEGROUP_RESOURCE_TYPE = "networkfirewallrulegroup" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_NETWORK_FIREWALL_SERVICE
+    resource=AWS_NETWORK_FIREWALL_RULEGROUP_RESOURCE_TYPE
+/]

--- a/aws/services/networkfirewall/resource.ftl
+++ b/aws/services/networkfirewall/resource.ftl
@@ -1,0 +1,503 @@
+[#ftl]
+
+[#assign AWS_NETWORK_FIREWALL_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : {
+             "UseRef" : true
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_NETWORK_FIREWALL_RESOURCE_TYPE
+    mappings=AWS_NETWORK_FIREWALL_OUTPUT_MAPPINGS
+/]
+
+[@addCWMetricAttributes
+    resourceType=AWS_NETWORK_FIREWALL_RESOURCE_TYPE
+    namespace="AWS/NetworkFirewall"
+    dimensions={
+        "FirewallName" : {
+            "ResourceProperty" : "Name"
+        }
+    }
+/]
+
+[#assign AWS_NETWORK_FIREWALL_POLICY_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : {
+             "UseRef" : true
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_NETWORK_FIREWALL_POLICY_RESOURCE_TYPE
+    mappings=AWS_NETWORK_FIREWALL_POLICY_OUTPUT_MAPPINGS
+/]
+
+[#assign AWS_NETWORK_FIREWALL_LOGGING_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_NETWORK_FIREWALL_LOGGING_RESOURCE_TYPE
+    mappings=AWS_NETWORK_FIREWALL_LOGGING_OUTPUT_MAPPINGS
+/]
+
+[#assign AWS_NETWORK_FIREWALL_RULEGROUP_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : {
+            "Attribute" : "RuleGroupArn"
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_NETWORK_FIREWALL_RULEGROUP_RESOURCE_TYPE
+    mappings=AWS_NETWORK_FIREWALL_RULEGROUP_OUTPUT_MAPPINGS
+/]
+
+[#macro createNetworkFirewall id name
+        vpcId
+        subnets
+        firewallPolicyId
+        tags={}
+        description=""
+        dependencies=[] ]
+
+    [@cfResource
+        id=id
+        type="AWS::NetworkFirewall::Firewall"
+        properties={
+            "VpcId" : getReference(vpcId),
+            "FirewallName" : name,
+            "FirewallPolicyArn" : getArn(firewallPolicyId),
+            "SubnetMappings" : asArray(subnets)?map( subnetId -> { "SubnetId" : subnetId})
+        } +
+        attributeIfContent(
+            "Description",
+            description
+        )
+        tags=tags
+        outputs=AWS_NETWORK_FIREWALL_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#function getNetworkFirewallPolicyStatelessRuleReference id priority=100 ]
+    [#return
+        {
+            "ResourceArn" : getArn(id),
+            "Priority" : priority
+        }
+    ]
+[/#function]
+
+[#function getNetworkFirewallPolicyStatelessCustomAction name type metricDimensions ]
+    [#return
+        {
+            "ActionName" : name,
+            "ActionDefinition" : {} +
+            attributeIfTrue(
+                "PublishMetricAction",
+                (type == "metric"),
+                {
+                    "Dimensions" : asArray(metricDimensions)?map(dimension -> { "Value" : dimension })
+                }
+            )
+        }
+    ]
+[/#function]
+
+[#macro createNetworkFirewallPolicy id name
+        statefulRuleGroupIds=[]
+        statelessRuleGroupRefs=[]
+        statelessCustomActions=[]
+        statelessDefaultActions=[]
+        statelessFragmentDefaultActions=[]
+        tags={}
+        description=""
+        dependencies=[] ]
+
+    [@cfResource
+        id=id
+        type="AWS::NetworkFirewall::FirewallPolicy"
+        properties={
+            "FirewallPolicyName" : name,
+            "FirewallPolicy" : {} +
+                attributeIfContent(
+                    "StatefulRuleGroupReferences",
+                    statefulRuleGroupIds,
+                    asArray(statefulRuleGroupIds)?map(ruleId -> { "ResourceArn" : getArn(ruleId)})
+                ) +
+                attributeIfContent(
+                    "StatelessRuleGroupReferences",
+                    asArray(statelessRuleGroupRefs)
+                ) +
+                attributeIfContent(
+                    "StatelessCustomActions",
+                    asArray(statelessCustomActions)
+                ) +
+                attributeIfContent(
+                    "StatelessDefaultActions",
+                    statelessDefaultActions,
+                    asArray(statelessDefaultActions)
+                ) +
+                attributeIfContent(
+                    "StatelessFragmentDefaultActions",
+                    asArray(statelessFragmentDefaultActions)
+                )
+        } +
+        attributeIfContent(
+            "Description",
+            description
+        )
+        tags=tags
+        outputs=AWS_NETWORK_FIREWALL_POLICY_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#function getNetworkFirewallLoggingConfiguration logType destinationType destinationId s3Prefix ]
+
+    [#local logDestination = {}]
+
+    [#switch destinationType ]
+        [#case "log" ]
+            [#local destinationType = "CloudWatchLogs"]
+            [#local logDestination = {
+                "logGroup" : getReference(destinationId)
+            }]
+            [#break]
+        [#case "datafeed" ]
+            [#local destinationType = "KinesisDataFirehose"]
+            [#local logDestination = {
+                "deliveryStream" : getReference(destinationId, NAME_ATTRIBUTE_TYPE)
+            }]
+            [#break]
+        [#case "s3"]
+            [#local destinationType = "S3"]
+            [#local logDestination = {
+                "bucketName" : getReference(destinationId, NAME_ATTRIBUTE_TYPE),
+                "prefix" : formatRelativePath(s3Prefix)
+            }]
+            [#break]
+        [#default]
+            [@fatal
+                message="Invalid network firewall logging destination type"
+                context={
+                    "provided" : destinationType
+                }
+            /]
+    [/#switch]
+
+    [#switch logType?upper_case ]
+        [#case "FLOW"]
+        [#case "ALERT"]
+            [#local logType = logType?upper_case]
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Invalid network firewall log type"
+                context={
+                    "provided" : logType
+                }
+            /]
+    [/#switch]
+
+    [#return
+        {
+            "LogDestinationType" : destinationType,
+            "LogType" : logType,
+            "LogDestination" : logDestination
+        }
+    ]
+[/#function]
+
+[#macro createNetworkFirewallLogging id
+        firewallId
+        logDestinationConfigs
+        dependencies=[]]
+    [@cfResource
+        id=id
+        type="AWS::NetworkFirewall::LoggingConfiguration"
+        properties={
+            "FirewallArn" : getArn(firewallId),
+            "LoggingConfiguration" : {
+                "LogDestinationConfigs" : asArray(logDestinationConfigs)
+            }
+        }
+        outputs=AWS_NETWORK_FIREWALL_LOGGING_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#function getNetworkFirewallRuleGroupHTTPDomainFiltering action domains protocols ]
+
+    [#-- Used in RulesSource.RulesSourceList  --]
+
+    [#switch action?lower_case ]
+        [#case "allow" ]
+        [#case "allowlist"]
+            [#local action = "ALLOWLIST"]
+            [#break]
+
+        [#case "deny" ]
+        [#case "denylist" ]
+            [#local action = "DENYLIST"]
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Network firewall HTTP domain rule action invalid"
+                context={
+                    "provided" : action,
+                    "supported" : [ "allow", "deny" ]
+                }
+            /]
+    [/#switch]
+
+    [#local targetTypes = []]
+    [#list protocols as protocol ]
+        [#switch protocol?lower_case ]
+            [#case "http" ]
+            [#case "http_host" ]
+                [#local targetTypes += [
+                    "HTTP_HOST"
+                ]]
+                [#break]
+
+            [#case "https"]
+            [#case "tls_sni"]
+                [#local targetTypes += [
+                    "TLS_SNI"
+                ]]
+                [#break]
+            [#default]
+                [@fatal
+                    message="Network firewall HTTP domain protocol invalid"
+                    context={
+                        "provided" : protocol,
+                        "supported" : [ "http", "https" ]
+                    }
+                /]
+        [/#switch]
+    [/#list]
+
+    [#local domainNames = [] ]
+    [#list domains as domain ]
+        [#if domain?starts_with("*")]
+            [#local domainNames += [
+                domain?remove_beginning("*")?ensure_starts_with(".")
+            ]]
+        [#else]
+            [#local domainNames += [
+                domain
+            ]]
+        [/#if]
+    [/#list]
+
+    [#return {
+      "GeneratedRulesType" : action,
+      "Targets" : asFlattenedArray(domainNames),
+      "TargetTypes" : targetTypes
+    }]
+[/#function]
+
+[#function getNetworkFirewallRuleGroupPort port ]
+
+    [#if port?is_string && port == "any" ]
+        [#return "ANY"]
+    [/#if]
+
+    [#if port.PortRange.Configured ]
+        [#return (port.PortRange.From)?c + ":" + (port.PortRange.To)?c ]
+    [/#if]
+    [#return (port.Port)?c ]
+[/#function]
+
+[#function getNetworkFirewallRuleGroupSimpleStatefulRules action destinations destinationPort sources sourcePort direction="any" ruleOptions=[] ]
+    [#local result = []]
+    [#list destinations as destination ]
+        [#list sources as source ]
+
+            [#local result +=
+                [
+                    {
+                        "Action" : action?upper_case,
+                        "RuleOptions" : ruleOptions,
+                        "Header" : {
+                            "Destination" : destination,
+                            "DestinationPort" : getNetworkFirewallRuleGroupPort(destinationPort),
+                            "Source" : source,
+                            "SourcePort" : getNetworkFirewallRuleGroupPort(sourcePort),
+                            "Protocol" : (destinationPort.IPProtocol)?upper_case,
+                            "Direction" : direction?upper_case
+                        }
+                    }
+                ]
+            ]
+
+        [/#list]
+    [/#list]
+
+    [#return result]
+[/#function]
+
+[#function getFirewallRuleGroupStatelessRule priority actions sources=[] sourcePorts=[] destinations=[] destinationPorts=[] tcpFlags=[] ]
+    [#local actionList = []]
+    [#list asArray(actions) as action]
+        [#switch action?lower_case ]
+            [#case "pass"]
+            [#case "aws:pass"]
+                [#local actionList += [ "aws:pass" ]]
+                [#break]
+
+            [#case "drop"]
+            [#case "aws:drop"]
+                [#local actionList += [ "aws:drop"]]
+                [#break]
+
+            [#case "inspect"]
+            [#case "aws:forward_to_sfe"]
+                [#local actionList += [ "aws:forward_to_sfe"]]
+                [#break]
+
+            [#default]
+                [#if action?lower_case?starts_with("custom:")]
+                    [#local actionList += [ action?remove_beginning("custom:")]]
+                [#else]
+                    [@fatal
+                        message="Invalid network firewall stateless rule action"
+                        context={
+                            "provided" : action
+                        }
+                    /]
+                [/#if]
+        [/#switch]
+    [/#list]
+
+    [#return
+        {
+            "Priority" : priority,
+            "RuleDefinition" : {
+                "Actions" : actionList,
+                "MatchAttributes" : {} +
+                attributeIfContent(
+                    "DestinationPorts",
+                    destinationPorts,
+                    asArray(destinationPorts)?map( port -> { "FromPort" : port.PortRange.From, "ToPort" : port.PortRange.To })
+                ) +
+                attributeIfContent(
+                    "Destinations",
+                    asFlattenedArray(destinations)?map( cidr -> { "AddressDefinition" : cidr })
+                ) +
+                attributeIfContent(
+                    "Protocols",
+                    destinationPorts,
+                    getUniqueArrayElements(
+                        asArray(destinationPorts)?map( dstPort -> getIANAIPProtocolNumber(dstPort))
+                    )
+                ) +
+                attributeIfContent(
+                    "SourcePorts",
+                    sourcePorts,
+                    asArray(sourcePorts)?map( port -> { "FromPort" : port.PortRange.From, "ToPort" : port.PortRange.To })
+                ) +
+                attributeIfContent(
+                    "Sources",
+                    asFlattenedArray(sources)?map( cidr -> {"AddressDefinition" : cidr })
+                ) +
+                attributeIfContent(
+                    "TCPFlags",
+                    asArray(tcpFlags)
+                )
+            }
+        }
+    ]
+[/#function]
+
+[#function getNetworkFirewallRuleGroup httpDomainFilter={} statefulComplexRule="" statefulSimpleRules=[] statelessRules=[] variables={} customActions=[]]
+    [#return
+        {
+            "RulesSource" : {} +
+                attributeIfContent(
+                    "RulesSourceList",
+                    httpDomainFilter
+                ) +
+                attributeIfContent(
+                    "RulesString",
+                    statefulComplexRule
+                ) +
+                attributeIfContent(
+                    "StatefulRules",
+                    asArray(statefulSimpleRules)
+                ) +
+                attributeIfTrue(
+                    "StatelessRulesAndCustomActions",
+                    (statelessRules?has_content || customActions?has_content),
+                    {} +
+                    attributeIfContent(
+                        "StatelessRules",
+                        statelessRules,
+                        asArray(statelessRules)
+                    ) +
+                    attributeIfContent(
+                        "CustomActions",
+                        customActions,
+                        asArray(customActions)
+                    )
+
+                )
+        } +
+        attributeIfContent(
+            "RuleVariables",
+            variables
+        )
+    ]
+[/#function]
+
+[#macro createNetworkFirewallRuleGroup id name
+        type
+        capacity
+        ruleGroup={}
+        description=""
+        tags=[]
+        dependencies=[] ]
+
+    [@cfResource
+        id=id
+        type="AWS::NetworkFirewall::RuleGroup"
+        properties={
+            "Capacity" : capacity?number,
+            "RuleGroupName" : name,
+            "Type" : type?upper_case
+        } +
+        attributeIfContent(
+            "Description",
+            description
+        ) +
+        attributeIfContent(
+            "RuleGroup",
+            ruleGroup
+        )
+        outputs=AWS_NETWORK_FIREWALL_RULEGROUP_OUTPUT_MAPPINGS
+        dependencies=dependencies
+        tags=tags
+    /]
+[/#macro]

--- a/aws/services/service.ftl
+++ b/aws/services/service.ftl
@@ -67,6 +67,9 @@
 [#assign AWS_LAMBDA_SERVICE = "lambda"]
 [@addService provider=AWS_PROVIDER service=AWS_LAMBDA_SERVICE /]
 
+[#assign AWS_NETWORK_FIREWALL_SERVICE = "networkfirewall"]
+[@addService provider=AWS_PROVIDER  service=AWS_NETWORK_FIREWALL_SERVICE /]
+
 [#assign AWS_RELATIONAL_DATABASE_SERVICE = "rds"]
 [@addService provider=AWS_PROVIDER service=AWS_RELATIONAL_DATABASE_SERVICE /]
 

--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -67,6 +67,10 @@
                                 "Provider" : "awstest",
                                 "Name" : "filetransfer"
                             },
+                            "firewall" : {
+                                "Provider" : "awstest",
+                                "Name" : "firewall"
+                            },
                             "healthcheck" : {
                                 "Provider" : "awstest",
                                 "Name" : "healthcheck"

--- a/awstest/modules/firewall/module.ftl
+++ b/awstest/modules/firewall/module.ftl
@@ -1,0 +1,277 @@
+[#ftl]
+
+[@addModule
+    name="firewall"
+    description="Testing module for the aws firewall component"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_firewall ]
+
+    [#-- base template generation --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "mgmt" : {
+                    "Components" : {
+                        "firewallbase" : {
+                            "firewall" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-firewall-base"
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Testing" : ["firewallbase"]
+                                },
+                                "Engine" : "network",
+                                "Rules" : {
+                                    "default" : {
+                                        "Action" : "drop",
+                                        "Priority" : "default",
+                                        "Inspection" : "Stateless"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "firewallbase" : {
+                    "OutputSuffix" : "template.json",
+                    "Tools" : {
+                       "CFNLint" : true
+                    },
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "firewall" : {
+                                    "Name" : "networkfirewallXmgmtXfirewallbase",
+                                    "Type" : "AWS::NetworkFirewall::Firewall"
+                                },
+                                "policy" : {
+                                    "Name" : "networkfirewallpolicyXmgmtXfirewallbase",
+                                    "Type" : "AWS::NetworkFirewall::FirewallPolicy"
+                                },
+                                "loggingConfig" : {
+                                    "Name" : "networkfirewallloggingXmgmtXfirewallbase",
+                                    "Type" : "AWS::NetworkFirewall::LoggingConfiguration"
+                                }
+                            },
+                            "Output" : [
+                                "networkfirewallXmgmtXfirewallbaseXinterface",
+                                "networkfirewallXmgmtXfirewallbaseXarn",
+                                "networkfirewallpolicyXmgmtXfirewallbaseXarn"
+                            ]
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "firewallbase" : {
+                    "firewall" : {
+                        "TestCases" : [ "firewallbase" ]
+                    }
+                }
+            }
+        }
+    /]
+
+    [#-- Simple Network rule --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "mgmt" : {
+                    "Components" : {
+                        "firewallsimplenet" : {
+                            "firewall" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-firewall-simplenet"
+                                    }
+                                },
+                                "Engine" : "network",
+                                "Rules" : {
+                                    "tcpinspect" : {
+                                        "Action" : "inspect",
+                                        "Inspection" : "Stateless",
+                                        "Priority" : 50,
+                                        "NetworkTuple" : {
+                                            "Destination" : {
+                                                "Port" : "anytcp",
+                                                "IPAddressGroups" : [ "_global" ]
+                                            }
+                                        }
+                                    },
+                                    "tcpallow" : {
+                                        "Action" : "pass",
+                                        "Inspection" : "Stateful",
+                                        "Priority" : 100,
+                                        "NetworkTuple" : {
+                                            "Destination" : {
+                                                "Port" : "anytcp",
+                                                "IPAddressGroups" : [ "_global" ]
+                                            }
+                                        }
+                                    },
+                                    "default" : {
+                                        "Action" : "drop",
+                                        "Priority" : "default",
+                                        "Inspection" : "Stateless"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "firewallsimplenet" : {
+                    "OutputSuffix" : "template.json",
+                    "Tools" : {
+                       "CFNLint" : true
+                    },
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "firewall" : {
+                                    "Name" : "networkfirewallXmgmtXfirewallsimplenet",
+                                    "Type" : "AWS::NetworkFirewall::Firewall"
+                                },
+                                "policy" : {
+                                    "Name" : "networkfirewallpolicyXmgmtXfirewallsimplenet",
+                                    "Type" : "AWS::NetworkFirewall::FirewallPolicy"
+                                },
+                                "loggingConfig" : {
+                                    "Name" : "networkfirewallloggingXmgmtXfirewallsimplenet",
+                                    "Type" : "AWS::NetworkFirewall::LoggingConfiguration"
+                                },
+                                "tcpStatefulAllow" : {
+                                    "Name" : "networkfirewallrulegroupXmgmtXfirewallsimplenetXtcpallow",
+                                    "Type" : "AWS::NetworkFirewall::RuleGroup"
+                                },
+                                "tcpStatelessInspect" : {
+                                    "Name" : "networkfirewallrulegroupXmgmtXfirewallsimplenetXtcpinspect",
+                                    "Type" : "AWS::NetworkFirewall::RuleGroup"
+                                }
+                            },
+                            "Output" : [
+                                "networkfirewallXmgmtXfirewallsimplenetXinterface",
+                                "networkfirewallXmgmtXfirewallsimplenetXarn",
+                                "networkfirewallpolicyXmgmtXfirewallsimplenetXarn"
+                            ]
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "firewallsimplenet" : {
+                    "firewall" : {
+                        "TestCases" : [ "firewallsimplenet" ]
+                    }
+                }
+            }
+        }
+    /]
+
+    [#-- Domain Filter --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "mgmt" : {
+                    "Components" : {
+                        "firewalldomainfilter" : {
+                            "firewall" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-firewall-domainfilter"
+                                    }
+                                },
+                                "Engine" : "network",
+                                "Rules" : {
+                                    "tcpinspect" : {
+                                        "Action" : "inspect",
+                                        "Inspection" : "Stateless",
+                                        "Priority" : 50,
+                                        "NetworkTuple" : {
+                                            "Destination" : {
+                                                "Port" : "anytcp",
+                                                "IPAddressGroups" : [ "_global" ]
+                                            }
+                                        }
+                                    },
+                                    "hostblock" : {
+                                        "Action" : "drop",
+                                        "Inspection" : "Stateful",
+                                        "Priority" : 100,
+                                        "Type" : "HostFilter",
+                                        "HostFilter" : {
+                                            "Hosts" : [
+                                                "*.baddomain.com",
+                                                "badhost.somewhere.com"
+                                            ]
+                                        }
+                                    },
+                                    "default" : {
+                                        "Action" : "drop",
+                                        "Priority" : "default",
+                                        "Inspection" : "Stateless"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "firewalldomainfilter" : {
+                    "OutputSuffix" : "template.json",
+                    "Tools" : {
+                       "CFNLint" : true
+                    },
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "firewall" : {
+                                    "Name" : "networkfirewallXmgmtXfirewalldomainfilter",
+                                    "Type" : "AWS::NetworkFirewall::Firewall"
+                                },
+                                "policy" : {
+                                    "Name" : "networkfirewallpolicyXmgmtXfirewalldomainfilter",
+                                    "Type" : "AWS::NetworkFirewall::FirewallPolicy"
+                                },
+                                "loggingConfig" : {
+                                    "Name" : "networkfirewallloggingXmgmtXfirewalldomainfilter",
+                                    "Type" : "AWS::NetworkFirewall::LoggingConfiguration"
+                                },
+                                "hostFilterBlock" : {
+                                    "Name" : "networkfirewallrulegroupXmgmtXfirewalldomainfilterXhostblock",
+                                    "Type" : "AWS::NetworkFirewall::RuleGroup"
+                                },
+                                "tcpStatelessInspect" : {
+                                    "Name" : "networkfirewallrulegroupXmgmtXfirewalldomainfilterXtcpinspect",
+                                    "Type" : "AWS::NetworkFirewall::RuleGroup"
+                                }
+                            },
+                            "Output" : [
+                                "networkfirewallXmgmtXfirewalldomainfilterXinterface",
+                                "networkfirewallXmgmtXfirewalldomainfilterXarn",
+                                "networkfirewallpolicyXmgmtXfirewalldomainfilterXarn"
+                            ]
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "firewalldomainfilter" : {
+                    "firewall" : {
+                        "TestCases" : [ "firewalldomainfilter" ]
+                    }
+                }
+            }
+        }
+    /]
+
+[/#macro]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds support for the firewall component within AWS. The initial implementation is based on the AWS NetworkFirewall component. Which supports, stateless, statefule and complex matching rules to filter traffic in and out of a VPC. 

The NetworkFirewall does not support inspecting traffic within the VPC and can only filter outbound NAT traffic after it has been through the NAT gateway.

## Motivation and Context

Provides indepth security monitoring for network traffic entering and leaving the VPC 

## How Has This Been Tested?

Tested locally, on development deployment and with test cases

## Related Changes

### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1752
- https://github.com/hamlet-io/engine/pull/1750
- 

### Dependent PRs:

- None

### Consumer Actions:

- None

