### PR TITLE
feat: add support for resource type mocks

### DIFF
--- a/aws/inputseeders/aws/id.ftl
+++ b/aws/inputseeders/aws/id.ftl
@@ -158,6 +158,23 @@
             [#local value = formatId( "##MockOutput", id, "##") ]
     [/#switch]
 
+    [#-- Resource specific values to align with linting --]
+    [@includeServicesConfiguration
+        provider=AWS_PROVIDER
+        services=[
+            AWS_VIRTUAL_PRIVATE_CLOUD_SERVICE
+        ]
+        deploymentFramework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
+    /]
+
+    [#switch id?split("X")?first ]
+        [#case AWS_VPC_RESOURCE_TYPE ]
+            [#-- this will return the value for all attribute lookups --]
+            [#-- VPC only has ref so that is ok --]
+            [#local value = "vpc-123456789abcdef12" ]
+            [#break]
+    [/#switch]
+
     [#return
         mergeObjects(
             state,


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds the ability to override the mock response using the resource type of a provided reference id

## Motivation and Context

Allows for mocking templates which have linting filters based on the value aligning with the Id attributes of components

## How Has This Been Tested?

Tested as part of https://github.com/hamlet-io/engine-plugin-aws/pull/378

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

