### PR TITLE
feat: add support for http backends on cdn

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -292,9 +292,6 @@
                 [#local routeBehaviours += configCacheBehaviour ]
                 [#break]
 
-
-
-
             [#case LB_COMPONENT_TYPE ]
             [#case LB_PORT_COMPONENT_TYPE ]
 
@@ -302,11 +299,15 @@
                     [#case LB_COMPONENT_TYPE ]
                         [#local originHostName = originLinkTargetAttributes["INTERNAL_FQDN"] ]
                         [#local originPath = formatAbsolutePath( "", subSolution.Origin.BasePath ) ]
+                        [#local originProtocol = "HTTPS" ]
+                        [#local originPort = 443 ]
                         [#break]
 
                     [#case LB_PORT_COMPONENT_TYPE ]
                         [#local originHostName = originLinkTargetAttributes["FQDN"] ]
                         [#local originPath = formatAbsolutePath( originLinkTargetAttributes["PATH"], subSolution.Origin.BasePath ) ]
+                        [#local originProtocol = originLinkTargetAttributes["PROTOCOL"]]
+                        [#local originPort = originLinkTargetAttributes["PORT"]]
                         [#break]
                 [/#switch]
 
@@ -315,7 +316,9 @@
                                 originId,
                                 originHostName,
                                 _context.CustomOriginHeaders,
-                                originPath
+                                originPath,
+                                originProtocol,
+                                originPort
                             )]
                 [#local origins += origin ]
 
@@ -357,13 +360,17 @@
 
                 [#local path = originLinkTargetAttributes["PATH"]!"HamletFatal: Could not find PATH Attribute on external service" ]
                 [#local originPath = formatAbsolutePath( path, subSolution.Origin.BasePath ) ]
+                [#local protocol = (originLinkTargetAttributes["PROTOCOL"])!"https" ]
+                [#local port = (originLinkTargetAttributes["PROTOCOL"])!443 ]
 
                 [#local origin =
                             getCFHTTPOrigin(
                                 originId,
                                 originHostName,
                                 _context.CustomOriginHeaders,
-                                originPath
+                                originPath,
+                                protocol,
+                                port
                             )]
                 [#local origins += origin ]
 

--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -299,6 +299,7 @@
                 "INTERNAL_FQDN" : internalFqdn,
                 "INTERNAL_URL" : internalUrl + path,
                 "PATH" : path,
+                "PROTOCOL" : sourcePort.Protocol,
                 "PORT" : sourcePort.Port,
                 "SOURCE_PORT" : sourcePort.Port,
                 "DESTINATION_PORT" : destinationPort.Port,


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- includes protocol information on lb components
- updates the HTTP origin for cloudfront to support http or https origins
- updates the cdn component to support the protocol changes in the resource

## Motivation and Context

Allows for creating CDN frontends for http backends. This is useful when you want to create https endpoints without having to manage certificate generation and creation 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

