### PR TITLE
fix(lb): allow hostname config on http and https

### DIFF
--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -191,7 +191,9 @@
     [#local certificateId = ""]
     [#local certificateRequired = (sourcePort.Certificate)!false ]
 
-    [#if certificateRequired ]
+    [#local scheme = (sourcePort.Protocol)?lower_case ]
+
+    [#if isPresent(solution.Certificate) ]
 
         [#local certificateObject = getCertificateObject( solution.Certificate ) ]
         [#local hostName = getHostName(certificateObject, occurrence) ]
@@ -199,7 +201,6 @@
         [#local certificateId = formatDomainCertificateId(certificateObject, hostName) ]
 
         [#local fqdn = formatDomainName(hostName, primaryDomainObject) ]
-        [#local scheme = "https" ]
 
         [#-- Redirect any secondary domains --]
         [#list getCertificateSecondaryDomains(certificateObject) as secondaryDomainObject ]
@@ -216,7 +217,6 @@
         [/#list]
     [#else]
         [#local fqdn = internalFqdn ]
-        [#local scheme ="http" ]
     [/#if]
 
     [#local path = ""]

--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -193,7 +193,7 @@
 
     [#local scheme = (sourcePort.Protocol)?lower_case ]
 
-    [#if isPresent(solution.Certificate) ]
+    [#if isPresent(solution.Certificate) || certificateRequired ]
 
         [#local certificateObject = getCertificateObject( solution.Certificate ) ]
         [#local hostName = getHostName(certificateObject, occurrence) ]

--- a/awstest/modules/lb/module.ftl
+++ b/awstest/modules/lb/module.ftl
@@ -48,6 +48,20 @@
                                     },
                                     "httpredirect" : {
                                         "IPAddressGroups" : ["_global"],
+                                        "Certificate" : {
+                                            "IncludeInHost" : {
+                                                "Product" : false,
+                                                "Environment" : true,
+                                                "Segment" : false,
+                                                "Tier" : false,
+                                                "Component" : false,
+                                                "Instance" : true,
+                                                "Version" : false,
+                                                "Host" : true
+                                            },
+                                            "Host" : "test"
+                                        },
+                                        "HostFilter" : true,
                                         "Redirect" : {}
                                     }
                                 }
@@ -87,6 +101,15 @@
                                     "Path"  : "Resources.albXelbXhttpslb.Properties.Name",
                                     "Value" : "mockedup-int-elb-httpslb"
                                 },
+                                "HTTPCondition" : {
+                                    "Path" : "Resources.listenerRuleXelbXhttpslbXhttpX100.Properties.Conditions[1]",
+                                    "Value" : {
+                                        "Field": "host-header",
+                                        "Values": [
+                                            "test-integration.mock.local"
+                                        ]
+                                    }
+                                },
                                 "HTTPAction" : {
                                     "Path" : "Resources.listenerRuleXelbXhttpslbXhttpX100.Properties.Actions[0]",
                                     "Value" : {
@@ -99,6 +122,15 @@
                                             "Query": "#\{query}",
                                             "StatusCode": "HTTP_301"
                                         }
+                                    }
+                                },
+                                "HTTPCondition" : {
+                                    "Path" : "Resources.listenerRuleXelbXhttpslbXhttpsX500.Properties.Conditions[1]",
+                                    "Value" : {
+                                        "Field": "host-header",
+                                        "Values": [
+                                            "test-integration.mock.local"
+                                        ]
                                     }
                                 },
                                 "HTTPSAction" : {


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Updates the portmapping state to handle hostname configuration on any protocol if it has been provided

## Motivation and Context

On the load balancer the Certificate configuration is also used to determine the hostname used on the port mapping. This is used on load balancer rules as a condition to use the rule which means that it supports both http and https usage. This aligns the this expectation with our implementation

## How Has This Been Tested?

tested locally and test cases update

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

