### PR TITLE
fix: handle empty domain names on api gateway

### DIFF
--- a/aws/components/apigateway/state.ftl
+++ b/aws/components/apigateway/state.ftl
@@ -218,7 +218,7 @@ created in either case.
 
     [#-- Determine the list of hostname alternatives --]
     [#local fqdns = [] ]
-    [#list hostDomains as domain]
+    [#list hostDomains?filter( x -> x?has_content ) as domain]
         [#local fqdns += [ formatDomainName(hostName, domain.Name) ] ]
     [/#list]
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

adds handling for domain processing which returns an empty value when looking up the domain

## Motivation and Context

Handles deployments when API domains aren't provided or cannot be found

## How Has This Been Tested?


## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

