### PR TITLE
feat(cdn): include internal fqdn in state

### DIFF
--- a/aws/components/cdn/state.ftl
+++ b/aws/components/cdn/state.ftl
@@ -7,6 +7,8 @@
     [#local cfId  = formatResourceId(AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE, core.Id)]
     [#local cfName = core.FullName]
 
+    [#local internalFqdn = getExistingReference(cfId,DNS_ATTRIBUTE_TYPE)]
+
     [#if isPresent(solution.Certificate) ]
         [#local certificateObject = getCertificateObject(solution.Certificate!"") ]
         [#local hostName = getHostName(certificateObject, occurrence) ]
@@ -14,7 +16,7 @@
         [#local fqdn = formatDomainName(hostName, primaryDomainObject)]
 
     [#else]
-            [#local fqdn = getExistingReference(cfId,DNS_ATTRIBUTE_TYPE)]
+            [#local fqdn = internalFqdn ]
     [/#if]
 
     [#local wafPresent = isPresent(solution.WAF)]
@@ -49,6 +51,7 @@
             attributeIfContent("wafLogStreaming", wafLogStreamResources),
             "Attributes" : {
                 "FQDN" : fqdn,
+                "INTERNAL_FQDN" : internalFqdn,
                 "URL" : "https://" + fqdn,
                 "DISTRIBUTION_ID" : getExistingReference(cfId)
             },


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)


## Description

include the internal fqdn as part of the cdn attributes. This allows for it to be easily found by users from the hamlet cli

## Motivation and Context

When creating DNS records you need both the internal cloudfront provided DNS name along with the primary alias. This allows for you to query these values through the hamlet cli

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

