### PR TITLE
Feat aws pinpoint

### DIFF
--- a/aws/components/correspondent/id.ftl
+++ b/aws/components/correspondent/id.ftl
@@ -1,0 +1,12 @@
+[#ftl]
+
+[@addResourceGroupInformation
+    type=CORRESPONDENT_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_PINPOINT_SERVICE
+        ]
+/]

--- a/aws/components/correspondent/setup.ftl
+++ b/aws/components/correspondent/setup.ftl
@@ -1,0 +1,22 @@
+[#ftl]
+
+[#macro aws_correspondent_cf_deployment_generationcontract occurrence ]
+    [@addDefaultGenerationContract subsets=["template"] /]
+[/#macro]
+
+[#macro aws_correspondent_cf_deployment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core ]
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local resources = occurrence.State.Resources ]
+
+    [#local correspondentId = resources["correspondent"].Id ]
+    [#local correspondentName = resources["correspondent"].Name ]
+
+    [@createPinpointApp
+        id=correspondentId
+        name=correspondentName
+        tags=getOccurrenceCoreTags(occurrence, core.FullName, "", false, true)
+    /]
+[/#macro]

--- a/aws/components/correspondent/state.ftl
+++ b/aws/components/correspondent/state.ftl
@@ -1,0 +1,32 @@
+[#ftl]
+
+[#macro aws_correspondent_cf_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local resources = {}]
+    [#local attributes = {}]
+
+    [#local correspondentId = formatResourceId(AWS_PINPOINT_RESOURCE_TYPE, core.Id)]
+
+    [#local resources += {
+        "correspondent" : {
+            "Id" : correspondentId,
+            "Name" : core.FullName,
+            "Type" : AWS_PINPOINT_RESOURCE_TYPE
+        }
+    }]
+
+     [#local attributes += {
+        "ARN" : getExistingReference(correspondentId, ARN_ATTRIBUTE_TYPE),
+        "APP" : getExistingReference(correspondentId)
+    }]
+
+    [#assign componentState =
+        {
+            "Resources" : resources,
+            "Attributes" : attributes
+        }
+    ]
+
+[/#macro]

--- a/aws/components/firewall/setup.ftl
+++ b/aws/components/firewall/setup.ftl
@@ -49,13 +49,6 @@
         tags=getOccurrenceCoreTags(occurrence, core.FullName)
     /]
 
-                            {
-                                "Fn::Join": [
-                                    ",",
-                                    tierSubnetIdRefs
-                                ]
-                            },
-
     [@cfOutput
         formatId(firewallId, INTERFACE_ATTRIBUTE_TYPE),
         {

--- a/aws/services/pinpoint/id.ftl
+++ b/aws/services/pinpoint/id.ftl
@@ -1,0 +1,9 @@
+[#ftl]
+
+[#-- Resources --]
+[#assign AWS_PINPOINT_RESOURCE_TYPE = "pinpoint"]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_PINPOINT_SERVICE
+    resource=AWS_PINPOINT_RESOURCE_TYPE
+/]

--- a/aws/services/pinpoint/policy.ftl
+++ b/aws/services/pinpoint/policy.ftl
@@ -1,0 +1,39 @@
+[#ftl]
+
+[#-- https://docs.aws.amazon.com/pinpoint/latest/developerguide/security_iam_id-based-policy-examples.html#security_iam_id-based-policy-examples-access-one-project --]
+[#function pinpointWriteProjectStatement projectId principals="" conditions={}]
+    [#return
+        [
+            getPolicyStatement(
+                "mobiletargeting:GetApps",
+                formatRegionalArn("mobiletargeting", "*"),
+                principals,
+                conditions),
+            getPolicyStatement(
+                [
+                    "mobiletargeting:Get*",
+                    "mobiletargeting:List*",
+                    "mobiletargeting:Create*",
+                    "mobiletargeting:Update*",
+                    "mobiletargeting:Put*"
+                ],
+                [
+                    formatRegionalArn(
+                        "mobiletargeting",
+                        "apps/"+projectId
+                    ),
+                    formatRegionalArn(
+                        "mobiletargeting",
+                        "apps/"+projectId + "/*"
+                    ),
+                    formatRegionalArn(
+                        "mobiletargeting",
+                        "reports"
+                    )
+                ],
+                principals,
+                conditions)
+        ]
+    ]
+[/#function]
+

--- a/aws/services/pinpoint/resource.ftl
+++ b/aws/services/pinpoint/resource.ftl
@@ -1,0 +1,39 @@
+[#ftl]
+
+[#assign AWS_PINPOINT_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : {
+            "Attribute" : "Arn"
+        }
+    }
+]
+
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_PINPOINT_RESOURCE_TYPE
+    mappings=AWS_PINPOINT_OUTPUT_MAPPINGS
+/]
+
+[#macro createPinpointApp id name
+        tags={}
+        description=""
+        dependencies="" ]
+    [@cfResource
+        id=id
+        type="AWS::Pinpoint::App"
+        properties=
+        {
+            "Name" : name
+        } +
+        attributeIfContent(
+            "Description",
+            description
+        )
+        tags=tags
+        outputs=AWS_PINPOINT_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]

--- a/aws/services/service.ftl
+++ b/aws/services/service.ftl
@@ -70,6 +70,9 @@
 [#assign AWS_NETWORK_FIREWALL_SERVICE = "networkfirewall"]
 [@addService provider=AWS_PROVIDER  service=AWS_NETWORK_FIREWALL_SERVICE /]
 
+[#assign AWS_PINPOINT_SERVICE = "pinpoint"]
+[@addService provider=AWS_PROVIDER  service=AWS_PINPOINT_SERVICE /]
+
 [#assign AWS_RELATIONAL_DATABASE_SERVICE = "rds"]
 [@addService provider=AWS_PROVIDER service=AWS_RELATIONAL_DATABASE_SERVICE /]
 

--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -93,6 +93,10 @@
                                 "Provider" : "awstest",
                                 "Name" : "contentnode"
                             },
+                            "correspondent" : {
+                                "Provider" : "awstest",
+                                "Name" : "correspondent"
+                            },
                             "datapipeline" : {
                                 "Provider" : "awstest",
                                 "Name" : "datapipeline"

--- a/awstest/modules/correspondent/module.ftl
+++ b/awstest/modules/correspondent/module.ftl
@@ -1,0 +1,66 @@
+[#ftl]
+
+[@addModule
+    name="correspondent"
+    description="Testing module for the aws correspondent component"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_correspondent ]
+
+    [#-- base template generation --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "mgmt" : {
+                    "Components" : {
+                        "correspondentbase" : {
+                            "correspondent" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "deployment:Unit" : "aws-correspondent-base"
+                                    }
+                                },
+                                "Profiles" : {
+                                    "Testing" : ["correspondentbase"]
+                                },
+                                "Name" : "pinpoint"
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "correspondentbase" : {
+                    "OutputSuffix" : "template.json",
+                    "Tools" : {
+                       "CFNLint" : true
+                    },
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "correspondent" : {
+                                    "Name" : "pinpointXmgmtXcorrespondentbase",
+                                    "Type" : "AWS::Pinpoint::App"
+                                }
+                            },
+                            "Output" : [
+                                "pinpointXmgmtXcorrespondentbase",
+                                "pinpointXmgmtXcorrespondentbaseXarn"
+                            ]
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "correspondentbase" : {
+                    "correspondent" : {
+                        "TestCases" : [ "correspondent" ]
+                    }
+                }
+            }
+        }
+    /]
+
+[/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
This PR adds an initial support for AWS Pinpoint component creation as a service for the shared correspondent component.
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
To support push notifications for mobile applications AWS Pinpoint project needs to be created and its projectID shared with mobile apps and notifications services providers. Also, Amplify requires Cognito setup with identity roles providing the access to AWS Pinpoint project.
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally, on development deployment and with test cases
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- hamlet-io/engine#1793

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

