### PR TITLE
feat: initial support for ssm patching

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -24,6 +24,13 @@
     [#local bastionLgName = resources["lg"].Name]
     [#local bastionOS = (solution.ComputeInstance.OperatingSystem.Family)!"linux"]
 
+    [#local bastionASGTags = getOccurrenceCoreTags(
+                        occurrence,
+                        bastionAutoScaleGroupName
+                        "",
+                        true
+                    )]
+
     [#local bastionType = occurrence.Core.Type]
     [#local configSetName = bastionType]
 
@@ -192,6 +199,102 @@
         /]
 
         [#if deploymentSubsetRequired("bastion", true)]
+
+            [#-- Create SSM Maintenance window --]
+            [#local computeMaintenanceWindow = solution.ComputeInstance.MaintenanceWindow ]
+
+            [#local windowId = resources["maintenanceWindow"].Id ]
+            [#local windowName = resources["maintenanceWindow"].Name ]
+
+            [#local windowTargetId = resources["maintenanceWindowTarget"].Id ]
+            [#local windowTargetName = resources["maintenanceWindowTarget"].Name ]
+
+            [#local patchingTaskId = resources["patchingMaintenanceTask"].Id ]
+            [#local patchingTaskName = resources["patchingMaintenanceTask"].Name ]
+
+            [#local maintenanceRoleId = resources["maintenanceRole"].Id ]
+
+            [#local targetTags = bastionASGTags?filter( x-> ["Name", "cot:account", "cot:environment", "cot:product", "cot:segment" ]?seq_contains(x.Key))]
+
+            [#-- Setup SSM Maintenance Window --]
+            [@createSSMMaintenanceWindow
+                id=windowId
+                name=windowName
+                schedule=getCronScheduleFromMaintenanceWindow(computeMaintenanceWindow)
+                durationHours=1
+                cutoffHours=0
+                tags=getOccurrenceCoreTags(ocurrrence, windowName)
+                scheduleTimezone=computeMaintenanceWindow.TimeZone
+            /]
+
+            [@createSSMMaintenanceWindowTarget
+                id=windowTargetId
+                name=windowTargetName
+                windowId=windowId
+                targets=getSSMWindowTargets(targetTags)
+            /]
+
+            [#-- Setup Patching --]
+            [@createSSMMaintenanceWindowTask
+                id=patchingTaskId
+                name=patchingTaskName
+                targets=[ {
+                    "Key" : "WindowTargetIds",
+                    "Values" : [ getReference(windowTargetId)]
+                } ]
+                windowId=windowId
+                serviceRoleId=maintenanceRoleId
+                taskId="AWS-RunPatchBaseline"
+                taskType="RUN_COMMAND"
+                taskParameters=getSSMWindowRunCommandTaskParameters(
+                    "Install Security patch baseline",
+                    {
+                        "Operation" : [ "Install" ],
+                        "RebootOption" : [ "RebootIfNeeded" ]
+                    }
+                )
+            /]
+
+            [@createRole
+                id=maintenanceRoleId
+                trustedServices=[
+                    "ssm.amazonaws.com"
+                ]
+                policies=
+                    [
+                        getPolicyDocument(
+                            [
+                                getPolicyStatement(
+                                    [
+                                        "ssm:CancelCommand",
+                                        "ssm:GetCommandInvocation",
+                                        "ssm:ListCommandInvocations",
+                                        "ssm:ListCommands",
+                                        "ssm:SendCommand",
+                                        "ssm:GetAutomationExecution",
+                                        "ssm:GetParameters",
+                                        "ssm:StartAutomationExecution",
+                                        "ssm:ListTagsForResource",
+                                        "ssm:GetCalendarState"
+                                    ]
+                                ),
+                                getPolicyStatement(
+                                    [
+                                        "ssm:UpdateServiceSetting",
+                                        "ssm:GetServiceSetting"
+                                    ],
+                                    [
+                                        "arn:aws:ssm:*:*:servicesetting/ssm/opsitem/*",
+                                        "arn:aws:ssm:*:*:servicesetting/ssm/opsdata/*"
+                                    ]
+                                )
+                            ],
+                            "basic"
+                        )
+                    ]
+                tags=getOccurrenceCoreTags(occurrence)
+            /]
+
             [@createSecurityGroup
                 id=bastionSecurityGroupToId
                 name=bastionSecurityGroupToName
@@ -246,12 +349,7 @@
                 processorProfile=processorProfile
                 autoScalingConfig=solution.AutoScaling
                 multiAZ=multiAZ
-                tags=getOccurrenceCoreTags(
-                        occurrence,
-                        bastionAutoScaleGroupName
-                        "",
-                        true
-                    )
+                tags=bastionASGTags
                 networkResources=networkResources
             /]
 

--- a/aws/components/bastion/state.ftl
+++ b/aws/components/bastion/state.ftl
@@ -60,6 +60,26 @@
                                 formatResourceId(AWS_EC2_LAUNCH_CONFIG_RESOURCE_TYPE, core.Id)
                     ),
                     "Type" : AWS_EC2_LAUNCH_CONFIG_RESOURCE_TYPE
+                },
+                "maintenanceWindow" : {
+                    "Id" : formatResourceId(AWS_SSM_MAINTENANCE_WINDOW_RESOURCE_TYPE, core.Id),
+                    "Name" : core.FullName,
+                    "Type" : AWS_SSM_MAINTENANCE_WINDOW_RESOURCE_TYPE
+                },
+                "maintenanceWindowTarget" : {
+                    "Id" : formatResourceId(AWS_SSM_MAINTENANCE_WINDOW_TARGET_RESOURCE_TYPE, core.Id),
+                    "Name" : core.FullName,
+                    "Type" : AWS_SSM_MAINTENANCE_WINDOW_TARGET_RESOURCE_TYPE
+                },
+                "patchingMaintenanceTask" : {
+                    "Id" : formatResourceId(AWS_SSM_MAINTENANCE_WINDOW_TASK_RESOURCE_TYPE, core.Id, "patching"),
+                    "Name" : formatName(core.FullName, "patching"),
+                    "Type" : AWS_SSM_MAINTENANCE_WINDOW_TASK_RESOURCE_TYPE
+                },
+                "maintenanceRole" : {
+                    "Id" : formatResourceId(AWS_IAM_ROLE_RESOURCE_TYPE, core.Id, "maintenance"),
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             },
             "Attributes" : {

--- a/aws/services/ssm/id.ftl
+++ b/aws/services/ssm/id.ftl
@@ -7,23 +7,33 @@
     service=AWS_SYSTEMS_MANAGER_SERVICE
     resource=AWS_SSM_DOCUMENT_RESOURCE_TYPE
 /]
+
 [#assign AWS_SSM_MAINTENANCE_WINDOW_RESOURCE_TYPE = "ssmMaintenanceWindow" ]
 [@addServiceResource
     provider=AWS_PROVIDER
     service=AWS_SYSTEMS_MANAGER_SERVICE
     resource=AWS_SSM_MAINTENANCE_WINDOW_RESOURCE_TYPE
 /]
+
 [#assign AWS_SSM_MAINTENANCE_WINDOW_TARGET_RESOURCE_TYPE = "ssmWindowTarget" ]
 [@addServiceResource
     provider=AWS_PROVIDER
     service=AWS_SYSTEMS_MANAGER_SERVICE
     resource=AWS_SSM_MAINTENANCE_WINDOW_TARGET_RESOURCE_TYPE
 /]
+
 [#assign AWS_SSM_MAINTENANCE_WINDOW_TASK_RESOURCE_TYPE = "ssmWindowTask" ]
 [@addServiceResource
     provider=AWS_PROVIDER
     service=AWS_SYSTEMS_MANAGER_SERVICE
     resource=AWS_SSM_MAINTENANCE_WINDOW_TASK_RESOURCE_TYPE
+/]
+
+[#assign AWS_SSM_PATCH_BASELINE_RESOURCE_TYPE = "ssmPatchBaseline"]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_SYSTEMS_MANAGER_SERVICE
+    resource=AWS_SSM_PATCH_BASELINE_RESOURCE_TYPE
 /]
 
 


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds an initial implementation of applying patches to ec2 instances through SSM With maintenance windows and patch manger

## Motivation and Context

Allows for more finegrained control of when and what patches are installed 
Provided reporting and alerting tools to track patching compliance 

## How Has This Been Tested?

Ongoing 

## Related Changes


### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1797

### Dependent PRs:

- None

### Consumer Actions:

- None

