### PR TITLE
refactor(lb): support for default rule control

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -280,6 +280,24 @@
                         [#local path = solution.Path ]
                     [/#if]
                 [/#if]
+
+
+                [#if listenerRulePriority?is_string &&
+                            listenerRulePriority == "default" ]
+                    [#if solution.HostFilter || solution.Path != "default" ]
+                        [@fatal
+                            message="Request conditions can not be used for default rules"
+                            context={
+                                "Lb" : lbId,
+                                "PortMapping" : core.RawId,
+                                "Conditions" : {
+                                    "HostFilter" : solution.HostFilter,
+                                    "Path" : solution.Path
+                                }
+                            }
+                        /]
+                    [/#if]
+                [/#if]
                 [#break]
 
             [#default]
@@ -333,6 +351,7 @@
 
                     [#if listenerRulePriority?is_string &&
                             listenerRulePriority == "default" ]
+
                         [#if ! ((defaultActions[lbListener.Source])!{})?has_content ]
                             [#local defaultActions += {
                                 source : redirectAction

--- a/aws/services/lb/resource.ftl
+++ b/aws/services/lb/resource.ftl
@@ -206,7 +206,7 @@
     /]
 [/#macro]
 
-[#macro createALBListener id port albId defaultTargetGroupId certificateId="" sslPolicy="" ]
+[#macro createALBListener id port albId defaultActions certificateId="" sslPolicy="" ]
 
     [#if port.Protocol == "SSL" ]
         [#local protocol = "TLS" ]
@@ -231,12 +231,7 @@
         type="AWS::ElasticLoadBalancingV2::Listener"
         properties=
             {
-                "DefaultActions" : [
-                    {
-                      "TargetGroupArn" : getReference(defaultTargetGroupId),
-                      "Type" : "forward"
-                    }
-                ],
+                "DefaultActions" : asArray(defaultActions),
                 "LoadBalancerArn" : getReference(albId),
                 "Port" : port.Port,
                 "Protocol" : protocol
@@ -390,7 +385,10 @@
                 "FixedResponseConfig": {
                     "MessageBody": message,
                     "ContentType": contentType,
-                    "StatusCode": statusCode
+                    "StatusCode": statusCode?is_number?then(
+                        statusCode?c,
+                        statusCode
+                    )
                 }
             } +
             attributeIfContent("Order", order)

--- a/awstest/modules/lb/module.ftl
+++ b/awstest/modules/lb/module.ftl
@@ -25,14 +25,14 @@
                                 "Engine" : "application",
                                 "Logs" : true,
                                 "Profiles" : {
-                                    "Testing" : [ "Component" ]
+                                    "Testing" : [ "httpslb" ]
                                 },
                                 "PortMappings" : {
                                     "https" : {
                                         "IPAddressGroups" : ["_global"],
                                         "Priority" : 500,
                                         "HostFilter" : true,
-                                        "Certificate" : {
+                                        "Hostname" : {
                                             "IncludeInHost" : {
                                                 "Product" : false,
                                                 "Environment" : true,
@@ -48,7 +48,7 @@
                                     },
                                     "httpredirect" : {
                                         "IPAddressGroups" : ["_global"],
-                                        "Certificate" : {
+                                        "Hostname" : {
                                             "IncludeInHost" : {
                                                 "Product" : false,
                                                 "Environment" : true,
@@ -92,7 +92,7 @@
                             "Output" : [
                                 "securityGroupXlistenerXelbXhttpslbXhttps",
                                 "listenerRuleXelbXhttpslbXhttpsX500",
-                                "tgXdefaultXelbXhttpslbXhttps"
+                                "tgXelbXhttpslbXhttpsXname"
                             ]
                         },
                         "JSON" : {
@@ -159,9 +159,183 @@
                 }
             },
             "TestProfiles" : {
-                "Component" : {
+                "httpslb" : {
                     "lb" : {
                         "TestCases" : [ "httpslb", "validation" ]
+                    }
+                }
+            }
+        }
+    /]
+
+    [#-- HTTP Load Balancer --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "elb" : {
+                    "Components" : {
+                        "httplb" : {
+                            "LB" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : ["aws-lb-app-http"]
+                                    }
+                                },
+                                "Engine" : "application",
+                                "Logs" : true,
+                                "Profiles" : {
+                                    "Testing" : [ "httplb" ]
+                                },
+                                "PortMappings" : {
+                                    "http" : {
+                                        "IPAddressGroups" : ["_global"],
+                                        "Hostname" : {
+                                            "IncludeInHost" : {
+                                                "Product" : false,
+                                                "Environment" : true,
+                                                "Segment" : false,
+                                                "Tier" : false,
+                                                "Component" : false,
+                                                "Instance" : true,
+                                                "Version" : false,
+                                                "Host" : true
+                                            },
+                                            "Host" : "test"
+                                        },
+                                        "Priority" : 100,
+                                        "HostFilter" : true,
+                                        "Forward" : {}
+                                    },
+                                    "httpfixeddefault": {
+                                        "IPAddressGroups" : ["_global"],
+                                        "Mapping" : "http",
+                                        "Priority" : "default",
+                                        "Fixed" : {
+                                            "Message" : "Fixed Response",
+                                            "StatusCode" : "200",
+                                            "ContentType" : "text/plain"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "httplb" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "httpListenerRule" : {
+                                    "Name" : "listenerRuleXelbXhttplbXhttpX100",
+                                    "Type" : "AWS::ElasticLoadBalancingV2::ListenerRule"
+                                },
+                                "httpListener" : {
+                                    "Name" : "listenerXelbXhttplbXhttp",
+                                    "Type" : "AWS::ElasticLoadBalancingV2::Listener"
+                                },
+                                "loadBalancer" : {
+                                    "Name" : "albXelbXhttplb",
+                                    "Type" : "AWS::ElasticLoadBalancingV2::LoadBalancer"
+                                }
+                            },
+                            "Output" : [
+                                "securityGroupXlistenerXelbXhttplbXhttp",
+                                "listenerRuleXelbXhttplbXhttpX100",
+                                "tgXelbXhttplbXhttpXname"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "LBName" : {
+                                    "Path"  : "Resources.albXelbXhttplb.Properties.Name",
+                                    "Value" : "mockedup-int-elb-httplb"
+                                },
+                                "HTTPCondition" : {
+                                    "Path" : "Resources.listenerRuleXelbXhttplbXhttpX100.Properties.Conditions[1]",
+                                    "Value" : {
+                                        "Field": "host-header",
+                                        "Values": [
+                                            "test-integration.mock.local"
+                                        ]
+                                    }
+                                },
+                                "HTTPAction" : {
+                                    "Path" : "Resources.listenerRuleXelbXhttplbXhttpX100.Properties.Actions[0]",
+                                    "Value" : {
+                                        "Type": "forward",
+                                        "TargetGroupArn": "arn:aws:iam::123456789012:mock/tgXelbXhttplbXhttpXarn"
+                                    }
+                                }
+                            },
+                            "Length" : {
+                                "listenerActions" : {
+                                    "Path" : "Resources.listenerRuleXelbXhttplbXhttpX100.Properties.Actions",
+                                    "Count" : 1
+                                }
+                            },
+                            "NotEmpty" : [
+                                "Resources.listenerRuleXelbXhttplbXhttpX100.Properties.Priority"
+                            ]
+                        }
+                    }
+                },
+                "httplbfixeddefault" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "httpListener" : {
+                                    "Name" : "listenerXelbXhttplbXhttp",
+                                    "Type" : "AWS::ElasticLoadBalancingV2::Listener"
+                                },
+                                "loadBalancer" : {
+                                    "Name" : "albXelbXhttplb",
+                                    "Type" : "AWS::ElasticLoadBalancingV2::LoadBalancer"
+                                }
+                            }
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "HTTPFixedResponseAction" : {
+                                    "Path" : "Resources.listenerXelbXhttplbXhttp.Properties.DefaultActions[0]",
+                                    "Value" : {
+                                        "Type": "fixed-response",
+                                        "FixedResponseConfig": {
+                                            "ContentType": "text/plain",
+                                            "StatusCode": "200",
+                                            "MessageBody": "Fixed Response"
+                                        }
+                                    }
+                                },
+                                "LoadBalancerLink" : {
+                                    "Path" : "Resources.listenerXelbXhttplbXhttp.Properties.LoadBalancerArn",
+                                    "Value" : "##MockOutputXalbXelbXhttplbX##"
+                                }
+                            },
+                            "Length" : {
+                                "listenerActions" : {
+                                    "Path" : "Resources.listenerXelbXhttplbXhttp.Properties.DefaultActions",
+                                    "Count" : 1
+                                }
+                            }
+                        }
+                    }
+                },
+                "validation" : {
+                    "OutputSuffix" : "template.json",
+                    "Tools" : {
+                        "CFNLint" : true,
+                        "CFNNag" : false
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "httplb" : {
+                    "lb" : {
+                        "TestCases" : [ "httplb", "httplbfixeddefault", "validation" ]
                     }
                 }
             }


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)


## Description

- Adds support for configuring the default action on a listener - this aligns with any of the standard rules actions available for the listener rules ( forward, fixed, redirect etc ) 
- Removes the default target group that was included to act as a dummy endpoint and instead sends a fixed response by default 

## Motivation and Context

- Removes the creation of a target group that will never be used within hamlet 
- Allows for integration with template deployments which create their own listener rules and rely on the default for the base actions 

## How Has This Been Tested?

Tested locally and on a development deployment 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

