### PR TITLE
fix(baseline): handle aws required ssh key format

### DIFF
--- a/aws/components/baseline/state.ftl
+++ b/aws/components/baseline/state.ftl
@@ -226,7 +226,7 @@
 
         [#case "ssh"]
             [#local legacyKey = false]
-            [#if core.SubComponent.Id == "ssh" &&
+            [#if core.SubComponent.RawId == "ssh" &&
                     getExistingReference(formatEC2KeyPairId(), NAME_ATTRIBUTE_TYPE)?has_content ]
                 [#local keyPairId = formatEC2KeyPairId()]
                 [#local keyPairName = formatSegmentFullName() ]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- Updates the ssh key handling to support the ssh-key format for public certs
- refactors the script formatting to remove escaping requirements
- Adds handling for new ssh keys added to the baseline component

## Motivation and Context

AWS don't appear to support providing PEM files for ec2 key pairs anymore 
formatting updates make it easier to follow what is happening in the script 

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- https://github.com/hamlet-io/executor-bash/pull/276

### Dependent PRs:

- None

### Consumer Actions:

- None

