### PR TITLE
fix(network): handling missing network on segments

### DIFF
--- a/aws/components/network/setup.ftl
+++ b/aws/components/network/setup.ftl
@@ -255,9 +255,35 @@
             [#else]
 
                 [#local routeTable = getLinkTarget(occurrence, networkLink + { "RouteTable" : routeTableId }, false )]
+                [#if ! routeTable?has_content ]
+                    [@fatal
+                        message="RouteTable not found for subnet"
+                        detail="Make sure your subnet is configured with a RouteTable from your network component"
+                        context={
+                            "SubnetTier" : tierId,
+                            "RouteTable" : routeTableId,
+                            "Network" : networkLink
+                        }
+                    /]
+                    [#continue]
+                [/#if]
+
                 [#local routeTableZones = routeTable.State.Resources["routeTables"] ]
 
                 [#local networkACL = getLinkTarget(occurrence, networkLink + { "NetworkACL" : networkACLId }, false )]
+                [#if ! networkACL?has_content ]
+                    [@fatal
+                        message="NetworkACL not found for subnet"
+                        detail="Make sure your subnet is configured with a NetworkACL from your network component"
+                        context={
+                            "SubnetTier" : tierId,
+                            "NetworkACL" : networkACLId,
+                            "Network" : networkLink
+                        }
+                    /]
+                    [#continue]
+                [/#if]
+
                 [#local networkACLId = networkACL.State.Resources["networkACL"].Id ]
 
                 [#local tierSubnetIdRefs = []]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Handles missing network for firewalls when deployment segment resource sets
- Handle missing routetable or networkacls on subnets

## Motivation and Context

Some minor updates around segment level component handling

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

