### PR TITLE
fix(firewall): include sid for statefull rules

### DIFF
--- a/aws/components/firewall/setup.ftl
+++ b/aws/components/firewall/setup.ftl
@@ -191,10 +191,11 @@
                             [#local ruleGroupArgs += {
                                 "statefulSimpleRules" : ruleGroupArgs.statefulSimpleRules + getNetworkFirewallRuleGroupSimpleStatefulRules(
                                     subSolution.Action,
-                                    getGroupCIDRs(subSolution.NetworkTuple.Destination.IPAddressGroups),
+                                    getGroupCIDRs(subSolution.NetworkTuple.Destination.IPAddressGroups, true, occurrence),
                                     ports[subSolution.NetworkTuple.Destination.Port],
-                                    getGroupCIDRs(subSolution.NetworkTuple.Source.IPAddressGroups),
+                                    getGroupCIDRs(subSolution.NetworkTuple.Source.IPAddressGroups, true, occurrence),
                                     ports[subSolution.NetworkTuple.Source.Port],
+                                    subSolution.Priority,
                                     "any"
                                 )
                             }]
@@ -299,9 +300,9 @@
                                     "statelessRule" : getFirewallRuleGroupStatelessRule(
                                                         priority,
                                                         statelessAction,
-                                                        getGroupCIDRs(subSolution.NetworkTuple.Source.IPAddressGroups),
+                                                        getGroupCIDRs(subSolution.NetworkTuple.Source.IPAddressGroups, true, occurrence),
                                                         ports[subSolution.NetworkTuple.Source.Port],
-                                                        getGroupCIDRs(subSolution.NetworkTuple.Destination.IPAddressGroups),
+                                                        getGroupCIDRs(subSolution.NetworkTuple.Destination.IPAddressGroups, true, occurrence),
                                                         ports[subSolution.NetworkTuple.Destination.Port]
                                                     )
                                 }]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Adds generation of a unique sid for statefull tuple rules when they are added
- Handle any port ranges for statefull rules

## Motivation and Context

Template generation failing if sid is missing

## How Has This Been Tested?

Tested locally on test deployment

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

