### PR TITLE
fix: API Gateway deployment tags

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -481,10 +481,6 @@
                 }
             outputs={}
             dependencies=apiId
-            tags=
-                getOccurrenceCoreTags(
-                    occurrence,
-                    deployName)
         /]
 
         [#-- Throttling Configuration --]

--- a/awstest/modules/apigateway/module.ftl
+++ b/awstest/modules/apigateway/module.ftl
@@ -128,10 +128,6 @@
                         },
                         "JSON" : {
                             "Match" : {
-                                "DeployTagName" : {
-                                    "Path"  : "Resources.apiDeployXappXapigatewaybaseXrunId098.Properties.Tags[10].Value",
-                                    "Value" : "mockedup-integration-application-apigatewaybase"
-                                },
                                 "RestAPITagName" : {
                                     "Path"  : "Resources.apiXappXapigatewaybase.Properties.Tags[10].Value",
                                     "Value" : "mockedup-integration-application-apigatewaybase"


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Remove the addition of a `Tags` property on API Gateway deployment resources.

## Motivation and Context
API gateway deployments report errors due to the presence of the Tags attribute.

Fixes https://github.com/hamlet-io/engine/issues/1800

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

