### PR TITLE
fix(queuehost): reference to wrong sec group id

### DIFF
--- a/aws/components/queuehost/setup.ftl
+++ b/aws/components/queuehost/setup.ftl
@@ -61,7 +61,7 @@
             [#if deploymentSubsetRequired(QUEUEHOST_COMPONENT_TYPE, true)]
                 [@createSecurityGroupRulesFromLink
                     occurrence=occurrence
-                    groupId=cacheSecurityGroupId
+                    groupId=securityGroupId
                     linkTarget=linkTarget
                     inboundPorts=[ port ]
                 /]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

fixes an invalid reference to a security group id

## Motivation and Context

Template generation would have failed if this routine was called

## How Has This Been Tested?

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

