### PR TITLE
fix(firewall): missing reference for stateful rule

### DIFF
--- a/aws/components/firewall/setup.ftl
+++ b/aws/components/firewall/setup.ftl
@@ -186,6 +186,8 @@
 
             [#switch subSolution.Inspection]
                 [#case "Stateful"]
+                    [#local statefulRuleGroupIds = combineEntities(statefulRuleGroupIds, [ruleGroupId], UNIQUE_COMBINE_BEHAVIOUR ) ]
+
                     [#switch subSolution.Type ]
                         [#case "NetworkTuple" ]
                             [#local ruleGroupArgs += {


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)


## Description

- fixes an issue where stateful firewall rules were not being applied to the firewall policy

## Motivation and Context

firewall policy not being applied as expected 

## How Has This Been Tested?


## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

