### PR TITLE
feat(firewall): destination route support

### DIFF
--- a/aws/components/firewall/setup.ftl
+++ b/aws/components/firewall/setup.ftl
@@ -171,160 +171,247 @@
             [#local subSolution = subOccurrence.Configuration.Solution ]
             [#local subResources = subOccurrence.State.Resources ]
 
-            [#local ruleGroupId = subResources["rulegroup"].Id ]
-            [#local ruleGroupName = subResources["rulegroup"].Name ]
+            [#if subCore.Type == FIREWALL_RULE_COMPONENT_TYPE ]
+                [#local ruleGroupId = subResources["rulegroup"].Id ]
+                [#local ruleGroupName = subResources["rulegroup"].Name ]
 
-            [#local createRuleGroup = true]
+                [#local createRuleGroup = true]
 
-            [#local ruleGroupArgs = {
-                "httpDomainFilter" : {},
-                "statefulComplexRule" : "",
-                "statefulSimpleRules" : [],
-                "statelessRule" : {},
-                "variables" : {}
-            }]
+                [#local ruleGroupArgs = {
+                    "httpDomainFilter" : {},
+                    "statefulComplexRule" : "",
+                    "statefulSimpleRules" : [],
+                    "statelessRule" : {},
+                    "variables" : {}
+                }]
 
-            [#switch subSolution.Inspection]
-                [#case "Stateful"]
-                    [#local statefulRuleGroupIds = combineEntities(statefulRuleGroupIds, [ruleGroupId], UNIQUE_COMBINE_BEHAVIOUR ) ]
+                [#switch subSolution.Inspection]
+                    [#case "Stateful"]
+                        [#local statefulRuleGroupIds = combineEntities(statefulRuleGroupIds, [ruleGroupId], UNIQUE_COMBINE_BEHAVIOUR ) ]
 
-                    [#switch subSolution.Type ]
-                        [#case "NetworkTuple" ]
-                            [#local ruleGroupArgs += {
-                                "statefulSimpleRules" : ruleGroupArgs.statefulSimpleRules + getNetworkFirewallRuleGroupSimpleStatefulRules(
-                                    subSolution.Action,
-                                    getGroupCIDRs(subSolution.NetworkTuple.Destination.IPAddressGroups, true, occurrence),
-                                    ports[subSolution.NetworkTuple.Destination.Port],
-                                    getGroupCIDRs(subSolution.NetworkTuple.Source.IPAddressGroups, true, occurrence),
-                                    ports[subSolution.NetworkTuple.Source.Port],
-                                    subSolution.Priority,
-                                    "any"
-                                )
-                            }]
-                            [#break]
+                        [#switch subSolution.Type ]
+                            [#case "NetworkTuple" ]
+                                [#local ruleGroupArgs += {
+                                    "statefulSimpleRules" : ruleGroupArgs.statefulSimpleRules + getNetworkFirewallRuleGroupSimpleStatefulRules(
+                                        subSolution.Action,
+                                        getGroupCIDRs(subSolution.NetworkTuple.Destination.IPAddressGroups, true, occurrence),
+                                        ports[subSolution.NetworkTuple.Destination.Port],
+                                        getGroupCIDRs(subSolution.NetworkTuple.Source.IPAddressGroups, true, occurrence),
+                                        ports[subSolution.NetworkTuple.Source.Port],
+                                        subSolution.Priority,
+                                        "any"
+                                    )
+                                }]
+                                [#break]
 
-                        [#case "HostFilter"]
-                            [#local domains = subSolution.HostFilter.Hosts ]
-                            [#list (subSolution.HostFilter.LinkEndpoints)?values as linkEndpoint ]
-                                [#local linkTarget = getLinkTarget(linkEndpoint.Link)]
-                                [#if linkTarget?has_content
-                                        && ((linkTarget.State.Attributes[linkEndpoint.Attribute])!"")?has_content]
-                                    [#local domains = combineEntities(
-                                                        domains,
-                                                        [ linkTarget.State.Attributes[linkEndpoint.Attribute] ],
-                                                        MERGE_COMBINE_BEHAVIOUR) ]
-                                [/#if]
-                            [/#list]
+                            [#case "HostFilter"]
+                                [#local domains = subSolution.HostFilter.Hosts ]
+                                [#list (subSolution.HostFilter.LinkEndpoints)?values as linkEndpoint ]
+                                    [#local linkTarget = getLinkTarget(linkEndpoint.Link)]
+                                    [#if linkTarget?has_content
+                                            && ((linkTarget.State.Attributes[linkEndpoint.Attribute])!"")?has_content]
+                                        [#local domains = combineEntities(
+                                                            domains,
+                                                            [ linkTarget.State.Attributes[linkEndpoint.Attribute] ],
+                                                            MERGE_COMBINE_BEHAVIOUR) ]
+                                    [/#if]
+                                [/#list]
 
-                            [#local hostfilterAction = ""]
-                            [#switch subSolution.Action ]
-                                [#case "pass"]
-                                    [#local hostfilterAction = "allow"]
-                                    [#break]
-
-                                [#case "drop"]
-                                    [#local hostfilterAction = "deny"]
-                                    [#break]
-
-                                [#default]
-                                    [@fatal
-                                        message="Invalid action for HostFilter network Rule"
-                                        context={
-                                            "FirewallId" : core.RawId,
-                                            "RuleId" : subCore.RawId,
-                                            "Action" : subSolution.Action,
-                                            "PermittedActions" : [ "pass", "drop" ]
-                                        }
-                                    /]
-                            [/#switch]
-
-                            [#local ruleGroupArgs += {
-                                "httpDomainFilter" : getNetworkFirewallRuleGroupHTTPDomainFiltering(
-                                    hostfilterAction,
-                                    domains,
-                                    subSolution.HostFilter.Protocols
-                                )
-                            }]
-                            [#break]
-
-                        [#default]
-                            [@fatal
-                                message="Stateful rule inspection does not support rule type"
-                                context={
-                                    "FirewallId" : core.RawId,
-                                    "RuleId" : subCore.RawId,
-                                    "Type" : subSolution.Type
-                                }
-                            /]
-                    [/#switch]
-                    [#break]
-
-                [#case "Stateless"]
-                    [#switch subSolution.Type]
-                        [#case "NetworkTuple"]
-
-                            [#local statelessAction = ""]
-                            [#if subSolution.Priority?is_string && (subSolution.Priority)?lower_case == "default" ]
-                                [#local priority = 1 ]
-                                [#local statelessAction = subSolution.Action ]
-
+                                [#local hostfilterAction = ""]
                                 [#switch subSolution.Action ]
-                                    [#case "drop"]
-                                        [#local statelessDefaultActions += ["aws:drop"]]
-                                        [#break]
                                     [#case "pass"]
-                                        [#local statelessDefaultActions += ["aws:pass"]]
+                                        [#local hostfilterAction = "allow"]
                                         [#break]
-                                    [#case "inspect"]
-                                        [#local statelessDefaultActions += ["aws:forward_to_sfe"]]
+
+                                    [#case "drop"]
+                                        [#local hostfilterAction = "deny"]
                                         [#break]
 
                                     [#default]
                                         [@fatal
-                                            message="Invalid network friewall stateless default action"
+                                            message="Invalid action for HostFilter network Rule"
                                             context={
                                                 "FirewallId" : core.RawId,
                                                 "RuleId" : subCore.RawId,
                                                 "Action" : subSolution.Action,
-                                                "PossibleActions" : [ "drop", "pass", "inspect"]
+                                                "PermittedActions" : [ "pass", "drop" ]
                                             }
                                         /]
                                 [/#switch]
 
-                                [#local createRuleGroup = false ]
-
-                            [#else]
-                                [#local priority = subSolution.Priority]
-                                [#local statelessRuleGroupRefs += [ getNetworkFirewallPolicyStatelessRuleReference(ruleGroupId, subSolution.Priority)] ]
-                                [#local statelessAction = subSolution.Action]
-
                                 [#local ruleGroupArgs += {
-                                    "statelessRule" : getFirewallRuleGroupStatelessRule(
-                                                        priority,
-                                                        statelessAction,
-                                                        getGroupCIDRs(subSolution.NetworkTuple.Source.IPAddressGroups, true, occurrence),
-                                                        ports[subSolution.NetworkTuple.Source.Port],
-                                                        getGroupCIDRs(subSolution.NetworkTuple.Destination.IPAddressGroups, true, occurrence),
-                                                        ports[subSolution.NetworkTuple.Destination.Port]
-                                                    )
+                                    "httpDomainFilter" : getNetworkFirewallRuleGroupHTTPDomainFiltering(
+                                        hostfilterAction,
+                                        domains,
+                                        subSolution.HostFilter.Protocols
+                                    )
                                 }]
-                            [/#if]
-                            [#break]
-                    [/#switch]
-                    [#break]
-            [/#switch]
+                                [#break]
 
-            [#if createRuleGroup ]
-                [@createNetworkFirewallRuleGroup
-                    id=ruleGroupId
-                    name=ruleGroupName
-                    type=subSolution.Inspection
-                    capacity=100
-                    ruleGroup=getNetworkFirewallRuleGroup?with_args(ruleGroupArgs?values)()
-                    tags=getOccurrenceCoreTags(subOccurrence, subCore.FullName)
-                /]
+                            [#default]
+                                [@fatal
+                                    message="Stateful rule inspection does not support rule type"
+                                    context={
+                                        "FirewallId" : core.RawId,
+                                        "RuleId" : subCore.RawId,
+                                        "Type" : subSolution.Type
+                                    }
+                                /]
+                        [/#switch]
+                        [#break]
+
+                    [#case "Stateless"]
+                        [#switch subSolution.Type]
+                            [#case "NetworkTuple"]
+
+                                [#local statelessAction = ""]
+                                [#if subSolution.Priority?is_string && (subSolution.Priority)?lower_case == "default" ]
+                                    [#local priority = 1 ]
+                                    [#local statelessAction = subSolution.Action ]
+
+                                    [#switch subSolution.Action ]
+                                        [#case "drop"]
+                                            [#local statelessDefaultActions += ["aws:drop"]]
+                                            [#break]
+                                        [#case "pass"]
+                                            [#local statelessDefaultActions += ["aws:pass"]]
+                                            [#break]
+                                        [#case "inspect"]
+                                            [#local statelessDefaultActions += ["aws:forward_to_sfe"]]
+                                            [#break]
+
+                                        [#default]
+                                            [@fatal
+                                                message="Invalid network friewall stateless default action"
+                                                context={
+                                                    "FirewallId" : core.RawId,
+                                                    "RuleId" : subCore.RawId,
+                                                    "Action" : subSolution.Action,
+                                                    "PossibleActions" : [ "drop", "pass", "inspect"]
+                                                }
+                                            /]
+                                    [/#switch]
+
+                                    [#local createRuleGroup = false ]
+
+                                [#else]
+                                    [#local priority = subSolution.Priority]
+                                    [#local statelessRuleGroupRefs += [ getNetworkFirewallPolicyStatelessRuleReference(ruleGroupId, subSolution.Priority)] ]
+                                    [#local statelessAction = subSolution.Action]
+
+                                    [#local ruleGroupArgs += {
+                                        "statelessRule" : getFirewallRuleGroupStatelessRule(
+                                                            priority,
+                                                            statelessAction,
+                                                            getGroupCIDRs(subSolution.NetworkTuple.Source.IPAddressGroups, true, occurrence),
+                                                            ports[subSolution.NetworkTuple.Source.Port],
+                                                            getGroupCIDRs(subSolution.NetworkTuple.Destination.IPAddressGroups, true, occurrence),
+                                                            ports[subSolution.NetworkTuple.Destination.Port]
+                                                        )
+                                    }]
+                                [/#if]
+                                [#break]
+                        [/#switch]
+                        [#break]
+                [/#switch]
+
+                [#if createRuleGroup ]
+                    [@createNetworkFirewallRuleGroup
+                        id=ruleGroupId
+                        name=ruleGroupName
+                        type=subSolution.Inspection
+                        capacity=100
+                        ruleGroup=getNetworkFirewallRuleGroup?with_args(ruleGroupArgs?values)()
+                        tags=getOccurrenceCoreTags(subOccurrence, subCore.FullName)
+                    /]
+                [/#if]
             [/#if]
 
+            [#if subCore.Type == FIREWALL_DESTINATION_COMPONENT_TYPE ]
+
+                [#if ! getExistingReference(firewallId, INTERFACE_ATTRIBUTE_TYPE)?has_content ]
+                    [@warn
+                        message="Firewall must be deployed before destination routes can be added"
+                        detail="Rerun this deployment to complete the setup"
+                        context={
+                            "Firewall" : core.RawId,
+                            "Destination" : subCore.RawId
+                        }
+                    /]
+                    [#continue]
+                [/#if]
+
+                [#local firewallVPCEndpoints = getExistingReference(firewallId, INTERFACE_ATTRIBUTE_TYPE)?split(',') ]
+                [#local firewallZones = firewallVPCEndpoints?map( x -> x?split(":")[0] )]
+
+                [#local zoneIPAddressGroups = {}]
+                [#list subSolution.IPAddressGroups as IPAddressGroup ]
+                    [#if IPAddressGroup?starts_with("_tier") ]
+                        [#list zones as zone ]
+                            [#local zoneIPAddressGroups += {
+                                zone.AWSZone : combineEntities((zoneIPAddressGroups[zone.AWSZone])![], [ getIPAddressGroup("${IPAddressGroup}:${zone.Id}", subOccurrence)], APPEND_COMBINE_BEHAVIOUR )
+                            }]
+                        [/#list]
+                    [#else]
+                        [#local zoneIPAddressGroups += {
+                            "global" : combineEntities((zoneIPAddressGroups["global"])![], [ getIPAddressGroup(IPAddressGroup, subOccurrence)], APPEND_COMBINE_BEHAVIOUR )
+                        }]
+                    [/#if]
+                [/#list]
+
+                [#list solution.Links?values as link]
+                    [#if link?is_hash]
+
+                        [#local linkTarget = getLinkTarget(occurrence, link) ]
+
+                        [@debug message="Link Target" context=linkTarget enabled=false /]
+
+                        [#if !linkTarget?has_content]
+                            [#continue]
+                        [/#if]
+
+                        [#local linkTargetCore = linkTarget.Core ]
+                        [#local linkTargetConfiguration = linkTarget.Configuration ]
+                        [#local linkTargetResources = linkTarget.State.Resources ]
+                        [#local linkTargetAttributes = linkTarget.State.Attributes ]
+
+                        [#switch linkTargetCore.Type]
+                            [#case NETWORK_ROUTE_TABLE_COMPONENT_TYPE]
+
+                                [#list linkTargetResources["routeTables"] as routeZone, zoneRouteTableResources ]
+
+                                    [#local zoneRouteTableId = zoneRouteTableResources["routeTable"].Id]
+                                    [#list zoneIPAddressGroups as zone,groups ]
+
+                                        [#local defaultFirewallEndpoint = firewallVPCEndpoints[0]?split(":")[1] ]
+
+                                        [#if deploymentSubsetRequired(FIREWALL_COMPONENT_TYPE, true)]
+
+                                            [#if zone == "global" ]
+                                                [#local zoneEndpoint = defaultFirewallEndpoint]
+                                            [#else]
+                                                [#local zoneEndpoint = ((firewallVPCEndpoints?filter(x -> x?starts_with("${zone}:"))[0])?split(":")[1])!defaultFirewallEndpoint ]
+                                            [/#if]
+
+                                            [#list groups as group ]
+                                                [#list getGroupCIDRs(group) as cidr ]
+                                                    [@createRoute
+                                                        id=subResources["routes"][routeZone][replaceAlphaNumericOnly(cidr)].Id
+                                                        routeTableId=zoneRouteTableId
+                                                        destinationType="vpcendpoint"
+                                                        destinationAttribute=zoneEndpoint
+                                                        destinationCidr=cidr
+                                                    /]
+                                                [/#list]
+                                            [/#list]
+                                        [/#if]
+                                    [/#list]
+                                [/#list]
+                                [#break]
+                        [/#switch]
+                    [/#if]
+                [/#list]
+            [/#if]
         [/#list]
 
         [#if ! statelessDefaultActions?has_content ]

--- a/aws/components/firewall/state.ftl
+++ b/aws/components/firewall/state.ftl
@@ -130,3 +130,38 @@
         }
     ]
 [/#macro]
+
+[#macro aws_firewalldestination_cf_state occurrence parent={}]
+    [#local core = occurrence.Core ]
+    [#local solution = occurrence.Configuration.Solution ]
+
+    [#local resources = {}]
+
+    [#list zones as zone ]
+        [#list getGroupCIDRs(solution.IPAddressGroups) as cidr ]
+            [#local resources = mergeObjects(
+                resources,
+                {
+                    "routes" : {
+                        zone.Id : {
+                            replaceAlphaNumericOnly(cidr) : {
+                                "Id" : formatResourceId(AWS_VPC_ROUTE_RESOURCE_TYPE, core.Id, zone.Id, replaceAlphaNumericOnly(cidr)),
+                                "Type" : AWS_VPC_ROUTE_RESOURCE_TYPE
+                            }
+                        }
+                    }
+                })]
+        [/#list]
+    [/#list]
+
+    [#assign componentState =
+        {
+            "Resources" : resources,
+            "Attributes" : {},
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds state for the firewalldestination subcomponent
- Adds setup implementation of firewall destination based on the vpc endpoints offered by the firewall

## Motivation and Context

Implementation of https://github.com/hamlet-io/engine/pull/1803 which defines routing for firewalls in a similar way to gateways 

## How Has This Been Tested?

tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

