### PR TITLE
fix(cache): zone lookup configuration and version handling

### DIFF
--- a/aws/components/cache/setup.ftl
+++ b/aws/components/cache/setup.ftl
@@ -201,12 +201,12 @@
                     multiAZ?then(
                         {
                             "AZMode": "cross-az",
-                            "PreferredAvailabilityZones" : getCFAWSAzReferences(awsZones),
+                            "PreferredAvailabilityZones" : getCFAWSAzReferences(zones?map( x -> x.Id)),
                             "NumCacheNodes" : processorProfile.CountPerZone * zones?size
                         },
                         {
                             "AZMode": "single-az",
-                            "PreferredAvailabilityZone" : getCFAWSAzReference(awsZones[0]),
+                            "PreferredAvailabilityZone" : getCFAWSAzReference(zones[0].Id),
                             "NumCacheNodes" : processorProfile.CountPerZone
                         }
                     ) +

--- a/aws/components/cache/state.ftl
+++ b/aws/components/cache/state.ftl
@@ -7,31 +7,23 @@
     [#local securityGroupId = formatDependentSecurityGroupId(id)]
 
     [#local engine = solution.Engine ]
+    [#local engineVersion = solution.EngineVersion ]
 
     [#switch engine]
         [#case "memcached"]
-            [#local engineVersion =
-                valueIfContent(
-                    solution.EngineVersion!"",
-                    solution.EngineVersion!"",
-                    "1.4.24"
-                )
-            ]
             [#local familyVersionIndex = engineVersion?last_index_of(".") - 1]
             [#local family = "memcached" + engineVersion[0..familyVersionIndex]]
             [#local port = solution.Port!"memcached" ]
             [#break]
 
         [#case "redis"]
-            [#local engineVersion =
-                valueIfContent(
-                    solution.EngineVersion!"",
-                    solution.EngineVersion!"",
-                    "2.8.24"
-                )
-            ]
-            [#local familyVersionIndex = engineVersion?last_index_of(".") - 1]
-            [#local family = "redis" + engineVersion[0..familyVersionIndex]]
+            [#if engineVersion?lower_case?ends_with(".x")]
+                [#local family = "redis" + engineVersion?lower_case ]
+            [#else]
+                [#local familyVersionIndex = engineVersion?last_index_of(".") - 1]
+                [#local family = "redis" + engineVersion[0..familyVersionIndex]]
+            [/#if]
+
             [#local port = solution.Port!"redis" ]
             [#break]
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- fixes the lookup of the zone configuration parameters to align with the use of Parameters for regions
- Adds support for the new .x versions of redis elasticache versions
- Removes defaulting engine versions inside of setup macro and instead relies on the configuration for version being mandatory

## Motivation and Context

Fixes a bug where the zone parameter lookup was looking at the wrong value.
Removing the version defaulting in the setup macro and make it mandatory removes reliance on hamlet maintaining the version

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

