### PR TITLE
feat(av): Windows Defender logging to CloudWatch and definition updates

### DIFF
--- a/aws/extensions/computetask_awswin_cwlog/extension.ftl
+++ b/aws/extensions/computetask_awswin_cwlog/extension.ftl
@@ -99,6 +99,18 @@
                 "ERROR",
                 "CRITICAL"
             ],
+            "event_name" : "Microsoft-Windows-Windows Defender/Operational",
+            "log_group_name" : logGroupName,
+            "log_stream_name" : "{instance_id}/AntiVirus"
+        },
+        {
+            "event_format" : "xml",
+            "event_levels" : [
+                "INFORMATION",
+                "WARNING",
+                "ERROR",
+                "CRITICAL"
+            ],
             "event_name" : "Security",
             "log_group_name" : logGroupName,
             "log_stream_name" : "{instance_id}/Security"

--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -1130,9 +1130,6 @@
                                     "Name" : "/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-ECS_Optimized/image_id"
                                 }
                             },
-                            "OSPatching": {
-                                "Enabled":false
-                            },
                             "ComputeTasks": {
                                 "Extensions" : [
                                     "_computetask_awscli",
@@ -1171,9 +1168,6 @@
                                 "aws:Source:SSMParam" : {
                                     "Name" : "/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base"
                                 }
-                            },
-                            "OSPatching": {
-                                "Enabled":false
                             },
                             "ComputeTasks": {
                                 "Extensions" : [
@@ -1214,9 +1208,6 @@
                                     "Name" : "/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base"
                                 }
                             },
-                            "OSPatching": {
-                                "Enabled":false
-                            },
                             "ComputeTasks": {
                                 "Extensions" : [
                                     "_computetask_awscli",
@@ -1254,9 +1245,6 @@
                                 "aws:Source:SSMParam" : {
                                     "Name" : "/aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base"
                                 }
-                            },
-                            "OSPatching": {
-                                "Enabled":false
                             },
                             "ComputeTasks": {
                                 "Extensions" : [


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
Log Windows Defender events to CloudWatch {instance}/AntiVirus
Include Windows Defender definition updates as OSpatching

## Motivation and Context
Incremental step for https://github.com/gs-gs/ha-ema-arcgis/issues/10 AV configuration

## How Has This Been Tested?
Locally generated and deployed to AWS

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

