### PR TITLE
fix(firewall): align routes to AZ endpoints

### DIFF
--- a/aws/components/firewall/state.ftl
+++ b/aws/components/firewall/state.ftl
@@ -137,20 +137,43 @@
 
     [#local resources = {}]
 
-    [#list zones as zone ]
-        [#list getGroupCIDRs(solution.IPAddressGroups, true, occurrence) as cidr ]
-            [#local resources = mergeObjects(
-                resources,
-                {
-                    "routes" : {
-                        zone.Id : {
-                            replaceAlphaNumericOnly(cidr) : {
-                                "Id" : formatResourceId(AWS_VPC_ROUTE_RESOURCE_TYPE, core.Id, zone.Id, replaceAlphaNumericOnly(cidr)),
-                                "Type" : AWS_VPC_ROUTE_RESOURCE_TYPE
-                            }
-                        }
-                    }
-                })]
+    [#list (solution.Links)?keys as link]
+        [#list zones as zone ]
+            [#list solution.IPAddressGroups as IPAddressGroup ]
+                [#if IPAddressGroup?starts_with("_tier")]
+                    [#list getGroupCIDRs("${IPAddressGroup}:${zone.Id}", true, occurrence) as cidr ]
+                        [#local resources = mergeObjects(
+                            resources,
+                            {
+                                "routes" : {
+                                    zone.Id : {
+                                        formatName(link, replaceAlphaNumericOnly(cidr)) : {
+                                            "Id" : formatResourceId(AWS_VPC_ROUTE_RESOURCE_TYPE, core.Id, zone.Id, link, replaceAlphaNumericOnly(cidr)),
+                                            "CIDR" : cidr,
+                                            "Type" : AWS_VPC_ROUTE_RESOURCE_TYPE
+                                        }
+                                    }
+                                }
+                            })]
+                    [/#list]
+                [#else]
+                    [#list getGroupCIDRs(solution.IPAddressGroups, true, occurrence) as cidr ]
+                        [#local resources = mergeObjects(
+                            resources,
+                            {
+                                "routes" : {
+                                    zone.Id : {
+                                        formatName(link, replaceAlphaNumericOnly(cidr)) : {
+                                            "Id" : formatResourceId(AWS_VPC_ROUTE_RESOURCE_TYPE, core.Id, zone.Id, link, replaceAlphaNumericOnly(cidr)),
+                                            "CIDR" : cidr,
+                                            "Type" : AWS_VPC_ROUTE_RESOURCE_TYPE
+                                        }
+                                    }
+                                }
+                            })]
+                    [/#list]
+                [/#if]
+            [/#list]
         [/#list]
     [/#list]
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- fixes an issue where firewall routes were routing asymmetrically and overriding each other.
- Raises an exception if a route for zone endpoint can not be found for the firewall

## Motivation and Context

Routing for firewall traffic not working as expected 

## How Has This Been Tested?

Tested locally and with active deployment with instance connectivity now confirmed

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

