### PR TITLE
fix(bastion): fix eip allocation

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -109,7 +109,7 @@
             "BootstrapProfile" : bootstrapProfile,
             "InstanceLogGroup" : bastionLgName,
             "InstanceOSPatching" : osPatching,
-            "ElasticIPs" : asArray(bastionEIPId)
+            "ElasticIPs" : asArray(bastionEIPId)?filter(x -> x?has_content)
         }
     ]
 


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Fixes an issue where an EIP script was being run if the EIP wasn't required

## Motivation and Context

Autoscaling group for bastion host was failing to complete its lifecylce activity when the bastion is deployed to a private subnet

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

