### PR TITLE
feat: new components

### DIFF
--- a/aws/components/cdn/id.ftl
+++ b/aws/components/cdn/id.ftl
@@ -15,4 +15,34 @@
             AWS_CLOUDWATCH_SERVICE,
             AWS_IDENTITY_SERVICE
         ]
+[#--
+
+Comment out for now to avoid errors when no locations are configured.
+
+    locations={
+        DEFAULT_RESOURCE_GROUP : {
+            "TargetComponentTypes" : [
+                HOSTING_PLATFORM_COMPONENT_TYPE
+            ]
+        }
+    }
+--]
 /]
+
+[#-- @addResourceGroupInformation
+    type=CDN_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DNS_RESOURCE_GROUP
+    services=
+        [
+            AWS_ROUTE53_SERVICE
+        ]
+    locations={
+        DNS_RESOURCE_GROUP : {
+            "TargetComponentTypes" : [
+                DNS_ZONE_COMPONENT_TYPE
+            ]
+        }
+    }
+/--]

--- a/aws/components/dnszone/id.ftl
+++ b/aws/components/dnszone/id.ftl
@@ -1,0 +1,18 @@
+[#ftl]
+
+[@addResourceGroupInformation
+    type=DNS_ZONE_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=[
+        AWS_ROUTE53_SERVICE
+    ]
+    locations={
+        DEFAULT_RESOURCE_GROUP : {
+            "TargetComponentTypes" : [
+                SUBSCRIPTION_COMPONENT_TYPE
+            ]
+        }
+    }
+/]

--- a/aws/components/dnszone/state.ftl
+++ b/aws/components/dnszone/state.ftl
@@ -1,0 +1,40 @@
+[#ftl]
+
+[#macro aws_dnszone_cf_state occurrence parent={} ]
+    [#local core = getOccurrenceCore(occurrence) ]
+    [#local solution = getOccurrenceSolution(occurrence) ]
+    [#local locations = getOccurrenceLocations(occurrence) ]
+
+    [#-- Combine any placement attributes with explicitly provided values --]
+    [#local attributes =
+        {
+            "REGION" : "us-east-1"
+        } +
+        ((locations[DEFAULT_RESOURCE_GROUP].Attributes)!{}) +
+        attributeIfContent(
+            "ZONE",
+            solution["external:ProviderId"]!""
+        )
+    ]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "external" : {
+                    "Id" : formatResourceId(AWS_ROUTE53_DNS_ZONE_RESOURCE_TYPE, core.Id),
+                    "Type" : AWS_ROUTE53_DNS_ZONE_RESOURCE_TYPE,
+                    "Deployed" :
+                        attributes["PROVIDER"]?has_content &&
+                        attributes["ACCOUNT"]?has_content &&
+                        attributes["ZONE"]?has_content
+                }
+            },
+            "Attributes" : attributes,
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+
+[/#macro]

--- a/aws/components/hostingplatform/id.ftl
+++ b/aws/components/hostingplatform/id.ftl
@@ -1,0 +1,16 @@
+[#ftl]
+
+[@addResourceGroupInformation
+    type=HOSTING_PLATFORM_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=[]
+    locations={
+        DEFAULT_RESOURCE_GROUP : {
+            "TargetComponentTypes" : [
+                SUBSCRIPTION_COMPONENT_TYPE
+            ]
+        }
+    }
+/]

--- a/aws/components/hostingplatform/state.ftl
+++ b/aws/components/hostingplatform/state.ftl
@@ -1,0 +1,36 @@
+[#ftl]
+
+[#macro aws_hostingplatform_cf_state occurrence parent={} ]
+    [#local core = getOccurrenceCore(occurrence) ]
+    [#local solution = getOccurrenceSolution(occurrence) ]
+    [#local locations = getOccurrenceLocations(occurrence) ]
+
+    [#-- Combine any placement attributes with explicitly provided values --]
+    [#local attributes =
+        ((locations[DEFAULT_RESOURCE_GROUP].Attributes)!{}) +
+        attributeIfContent(
+            "REGION",
+            (solution["Engine:region"].Region)!""
+        )
+    ]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "external" : {
+                    "Id" : formatResourceId("external", core.Id),
+                    "Type" : "external",
+                    "Deployed" :
+                        attributes["PROVIDER"]?has_content &&
+                        attributes["ACCOUNT"]?has_content &&
+                        attributes["REGION"]?has_content
+                }
+            },
+            "Attributes" : attributes,
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]

--- a/aws/components/subscription/id.ftl
+++ b/aws/components/subscription/id.ftl
@@ -1,0 +1,20 @@
+[#ftl]
+
+[@addResourceGroupInformation
+    type=SUBSCRIPTION_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=[
+        AWS_ORGANIZATIONS_SERVICE
+    ]
+    locations={
+        [#-- A link to a subscription is required if not importing the provider --]
+        DEFAULT_RESOURCE_GROUP : {
+            "Mandatory" : false,
+            "TargetComponentTypes" : [
+                SUBSCRIPTION_COMPONENT_TYPE
+            ]
+        }
+    }
+/]

--- a/aws/components/subscription/state.ftl
+++ b/aws/components/subscription/state.ftl
@@ -1,0 +1,42 @@
+[#ftl]
+
+[#macro aws_subscription_cf_state occurrence parent={} ]
+    [#local core = getOccurrenceCore(occurrence) ]
+    [#local solution = getOccurrenceSolution(occurrence) ]
+    [#local locations = getOccurrenceLocations(occurrence) ]
+
+    [#-- Combine any placement attributes with explicitly provided values --]
+    [#local attributes =
+        ((locations[DEFAULT_RESOURCE_GROUP].Attributes)!{}) +
+        attributeIfContent(
+            "PROVIDER",
+            solution["external:Provider"]!""
+        ) +
+        attributeIfContent(
+            "ACCOUNT",
+            solution["external:ProviderId"]!""
+        ) +
+        attributeIfContent(
+            "DEPLOYMENT_FRAMEWORK",
+            solution["external:DeploymentFramework"]!""
+        )
+    ]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "external" : {
+                    "Id" : formatResourceId(AWS_ORGANIZATIONS_ACCOUNT_RESOURCE_TYPE, core.Id),
+                    "Type" : AWS_ORGANIZATIONS_ACCOUNT_RESOURCE_TYPE,
+                    "Deployed" : attributes["PROVIDER"]?has_content
+                }
+            },
+            "Attributes" : attributes,
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+
+[/#macro]

--- a/aws/services/organizations/id.ftl
+++ b/aws/services/organizations/id.ftl
@@ -1,0 +1,10 @@
+[#ftl]
+
+[#-- Resources --]
+
+[#assign AWS_ORGANIZATIONS_ACCOUNT_RESOURCE_TYPE = "account" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_ORGANIZATIONS_SERVICE
+    resource=AWS_ORGANIZATIONS_ACCOUNT_RESOURCE_TYPE
+/]

--- a/aws/services/route53/id.ftl
+++ b/aws/services/route53/id.ftl
@@ -20,3 +20,10 @@
     service=AWS_ROUTE53_SERVICE
     resource=AWS_ROUTE53_HEALTHCHECK_RESOURCE_TYPE
 /]
+
+[#assign AWS_ROUTE53_DNS_ZONE_RESOURCE_TYPE = "route53dnszone" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_ROUTE53_SERVICE
+    resource=AWS_ROUTE53_DNS_ZONE_RESOURCE_TYPE
+/]

--- a/aws/services/service.ftl
+++ b/aws/services/service.ftl
@@ -73,6 +73,9 @@
 [#assign AWS_NETWORK_FIREWALL_SERVICE = "networkfirewall"]
 [@addService provider=AWS_PROVIDER  service=AWS_NETWORK_FIREWALL_SERVICE /]
 
+[#assign AWS_ORGANIZATIONS_SERVICE = "organizations"]
+[@addService provider=AWS_PROVIDER  service=AWS_ORGANIZATIONS_SERVICE /]
+
 [#assign AWS_PINPOINT_SERVICE = "pinpoint"]
 [@addService provider=AWS_PROVIDER  service=AWS_PINPOINT_SERVICE /]
 


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add minimal implementations of `subscription`, `hostingplatform` and `dnszone` components. They support the importing of externally created resources.

While commented out, there is also the start of support for dns entry creation for the CDN component for testing of additional resource groups on components.

Minimal support for associated resource types/services has also been added.

## Motivation and Context
Part of [ADR0007](https://github.com/hamlet-io/architectural-decision-log/blob/main/adr/0007-placement-support.md) implementation.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- https://github.com/hamlet-io/engine/pull/1810

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

