### PR TITLE
feat(districts): Refactoring to support feat(districts)

### DIFF
--- a/aws/components/baseline/state.ftl
+++ b/aws/components/baseline/state.ftl
@@ -16,8 +16,8 @@
 
     [#local segmentSeedId = formatSegmentSeedId() ]
     [#if !(getExistingReference(segmentSeedId)?has_content) ]
-        [#if legacyVpc ]
-            [#local segmentSeedValue = vpc?remove_beginning("vpc-")]
+        [#if legacyVpc() ]
+            [#local segmentSeedValue = vpc()?remove_beginning("vpc-")]
         [#else]
             [#local segmentSeedValue = ( getCLORunId() + accountObject.Seed)[0..(solution.Seed.Length - 1)]  ]
         [/#if]

--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -156,12 +156,12 @@
                             ec2AutoScaleGroupLifecyclePermission(bastionAutoScaleGroupName) +
                             ec2IPAddressUpdatePermission() +
                             ec2ReadTagsPermission() +
-                            s3ListPermission(codeBucket) +
-                            s3ReadPermission(codeBucket) +
+                            s3ListPermission(codeBucket()) +
+                            s3ReadPermission(codeBucket()) +
                             s3AccountEncryptionReadPermission(
-                                codeBucket,
+                                codeBucket(),
                                 "*",
-                                codeBucketRegion
+                                codeBucketRegion()
                             ) +
                             cwMetricsProducePermission("CWAgent") +
                             cwLogsProducePermission(bastionLgName),

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -195,16 +195,16 @@
                             )
                         ) +
                         s3AccountEncryptionReadPermission(
-                            registryBucket,
+                            registryBucket(),
                             getRegistryPrefix("scripts", occurrence),
-                            registryBucketRegion
+                            registryBucketRegion()
                         ) +
-                        s3ListPermission(codeBucket) +
-                        s3ReadPermission(codeBucket) +
+                        s3ListPermission(codeBucket()) +
+                        s3ReadPermission(codeBucket()) +
                         s3AccountEncryptionReadPermission(
-                            codeBucket,
+                            codeBucket(),
                             "*",
-                            codeBucketRegion
+                            codeBucketRegion()
                         ) +
                         s3ListPermission(operationsBucket) +
                         s3WritePermission(operationsBucket, "DOCKERLogs") +

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -247,12 +247,12 @@
                 [
                     getPolicyDocument(
                         ec2ReadTagsPermission() +
-                        s3ListPermission(codeBucket) +
-                        s3ReadPermission(codeBucket) +
+                        s3ListPermission(codeBucket()) +
+                        s3ReadPermission(codeBucket()) +
                         s3AccountEncryptionReadPermission(
-                            codeBucket,
+                            codeBucket(),
                             "*",
-                            codeBucketRegion
+                            codeBucketRegion()
                         ) +
                         s3ListPermission(operationsBucket) +
                         s3WritePermission(operationsBucket, "DOCKERLogs") +
@@ -404,8 +404,8 @@
                                 "SourceDestCheck" : true,
                                 "GroupSet" :
                                     [getReference(ec2SecurityGroupId)] +
-                                    sshFromProxySecurityGroup?has_content?then(
-                                        [sshFromProxySecurityGroup],
+                                    sshFromProxySecurityGroup()?has_content?then(
+                                        [sshFromProxySecurityGroup()],
                                         []
                                     )
                             }

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -141,22 +141,22 @@
                     getPolicyDocument(
                             ec2AutoScaleGroupLifecyclePermission(ecsAutoScaleGroupName) +
                             ec2ReadTagsPermission() +
-                            s3ListPermission(codeBucket) +
-                            s3ReadPermission(credentialsBucket, accountId + "/alm/docker") +
+                            s3ListPermission(codeBucket()) +
+                            s3ReadPermission(credentialsBucket(), accountId + "/alm/docker") +
                             s3AccountEncryptionReadPermission(
-                                credentialsBucket,
+                                credentialsBucket(),
                                 "*",
-                                credentialsBucketRegion
+                                credentialsBucketRegion()
                             ) +
                             fixedIP?then(
                                 ec2IPAddressUpdatePermission(),
                                 []
                             ) +
-                            s3ReadPermission(codeBucket) +
+                            s3ReadPermission(codeBucket()) +
                             s3AccountEncryptionReadPermission(
-                                codeBucket,
+                                codeBucket(),
                                 "*",
-                                codeBucketRegion
+                                codeBucketRegion()
                             ) +
                             s3ListPermission(operationsBucket) +
                             s3WritePermission(operationsBucket, getSegmentBackupsFilePrefix()) +

--- a/aws/components/gateway/state.ftl
+++ b/aws/components/gateway/state.ftl
@@ -18,7 +18,7 @@
 
     [#local occurrenceNetwork = getOccurrenceNetwork(occurrence)]
 
-    [#local legacyVpc = legacyVpc
+    [#local legacyVpc = legacyVpc()
                 && occurrenceNetwork.Link.Tier == "mgmt" && occurrenceNetwork.Link.Component == "vpc"
                 && occurrenceNetwork.Link.Instance == "" && occurrenceNetwork.Link.Version == "" ]
 

--- a/aws/components/network/state.ftl
+++ b/aws/components/network/state.ftl
@@ -5,7 +5,7 @@
     [#local solution = occurrence.Configuration.Solution]
 
     [#-- Only apply legacy controls to the default master data vpc --]
-    [#local legacyVpc = legacyVpc
+    [#local legacyVpc = legacyVpc()
                             && core.Tier.Id == "mgmt" && core.Component.RawId == "vpc"
                             && core.Instance.Id == "" && core.Version.Id = ""]
 

--- a/aws/extensions/computetask_awswin_hamletenv/extension.ftl
+++ b/aws/extensions/computetask_awswin_hamletenv/extension.ftl
@@ -45,8 +45,8 @@
         "hamlet_environment" : environmentId,
         "hamlet_tier" : occurrence.Core.Tier.Id ,
         "hamlet_component" : occurrence.Core.Component.Id,
-        "hamlet_credentials" : credentialsBucket,
-        "hamlet_code" : codeBucket,
+        "hamlet_credentials" : credentialsBucket(),
+        "hamlet_code" : codeBucket(),
         "hamlet_logs" : operationsBucket,
         "hamlet_backups" : dataBucket
     }

--- a/aws/extensions/computetask_awswin_userbootstrap/extension.ftl
+++ b/aws/extensions/computetask_awswin_userbootstrap/extension.ftl
@@ -85,7 +85,7 @@
                                     r'.\aws --region "${Region}" s3 sync "s3://${CodeBucket}/${ScriptStorePrefix}" "${!BOOTSTRAP_SCRIPTS_DIR}" 2>&1 | Write-Output ',
                                     {
                                         "Region" : { "Ref" : "AWS::Region" },
-                                        "CodeBucket" : codeBucket,
+                                        "CodeBucket" : codeBucket(),
                                         "ScriptStorePrefix" : scriptStorePrefix
                                     }
                                 ]

--- a/aws/extensions/computetask_linux_hamletenv/extension.ftl
+++ b/aws/extensions/computetask_linux_hamletenv/extension.ftl
@@ -45,8 +45,8 @@
         "hamlet_environment" : environmentId,
         "hamlet_tier" : occurrence.Core.Tier.Id ,
         "hamlet_component" : occurrence.Core.Component.Id,
-        "hamlet_credentials" : credentialsBucket,
-        "hamlet_code" : codeBucket,
+        "hamlet_credentials" : credentialsBucket(),
+        "hamlet_code" : codeBucket(),
         "hamlet_logs" : operationsBucket,
         "hamlet_backups" : dataBucket
     }

--- a/aws/extensions/computetask_linux_userbootstrap/extension.ftl
+++ b/aws/extensions/computetask_linux_userbootstrap/extension.ftl
@@ -84,7 +84,7 @@
                                     r'aws --region "${Region}" s3 sync "s3://${CodeBucket}/${ScriptStorePrefix}" "${!BOOTSTRAP_SCRIPTS_DIR}"',
                                     {
                                         "Region" : { "Ref" : "AWS::Region" },
-                                        "CodeBucket" : codeBucket,
+                                        "CodeBucket" : codeBucket(),
                                         "ScriptStorePrefix" : scriptStorePrefix
                                     }
                                 ]

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -167,7 +167,7 @@
     computeTaskConfig
     environmentId
     keyPairId
-    sshFromProxy=sshFromProxySecurityGroup
+    sshFromProxy=sshFromProxySecurityGroup()
     dependencies=""
     outputId=""
 ]


### PR DESCRIPTION

## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Use accessor methods for a number of variables that were previously global variables provided set setContext.

## Motivation and Context
Part of [ADR0007](https://github.com/hamlet-io/architectural-decision-log/blob/main/adr/0007-placement-support.md) implementation.

SetContext had a number of AWS specific lookups which only work if the input state relates to an AWS deployment. Using accessors defers the calculations until this situation is in place.

A future refactor would be to change the accessors to work off the blueprint and in many cases, rework access once baseline access is done via locations.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- engine - TBC

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

