### PR TITLE
fix: check for assigment type

### DIFF
--- a/aws/components/federatedrole/setup.ftl
+++ b/aws/components/federatedrole/setup.ftl
@@ -180,7 +180,7 @@
                     "ForAnyValue:StringLike": {
                         "cognito-identity.amazonaws.com:amr": valueIfTrue(
                                                                 "unauthenticated",
-                                                                subCore.Type == "Unauthenticated",
+                                                                subSolution.Type == "Unauthenticated",
                                                                 "authenticated"
                         )
                     }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
A minor fix for a check for an assignment type of a federated role assignment.

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
A correct trusted policy statement is required to use federated roles in scenarios like mobile integration with AWS Pinpoint service.
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally.
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

