### PR TITLE
feat(lb): support for advanced conditions

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -303,7 +303,7 @@
             [#default]
                 [#if isPresent(solution.Conditions) ]
                     [@fatal
-                        message="Conditions not support for this engine type"
+                        message="Conditions not supported for this engine type"
                         context={
                             "Engine" : engine,
                             "Conditions" : solution.Conditions

--- a/aws/services/lb/resource.ftl
+++ b/aws/services/lb/resource.ftl
@@ -424,26 +424,71 @@
     ]
 [/#function]
 
-[#function getListenerRulePathCondition paths]
-    [#return
-        [
-            {
-                "Field": "path-pattern",
-                "Values": asArray(paths)
-            }
-        ]
-    ]
-[/#function]
+[#function getListenerRuleCondition type conditionValue ]
+    [#local result = {
+        "Field" : type
+    }]
 
-[#function getListenerRuleHostCondition hosts ]
-    [#return
-        [
-            {
-                "Field" : "host-header",
-                "Values" : asArray(hosts)
-            }
-        ]
-    ]
+    [#switch type ]
+        [#case "http-header" ]
+            [#local result += {
+                "HttpHeaderConfig" : {
+                    "HttpHeaderName" : conditionValue.HeaderName,
+                    "Values" : conditionValue.Values
+                }
+            }]
+            [#break]
+
+        [#case "query-string" ]
+            [#local result += {
+                "QueryStringConfig" : {
+                    "Values" : asFlattenedArray(conditionValue)
+                }
+            }]
+            [#break]
+
+        [#case "http-request-method" ]
+            [#local result += {
+                "HttpRequestMethodConfig" : {
+                    "Values"  : asFlattenedArray(conditionValue)
+                }
+            }]
+            [#break]
+
+        [#case "host-header" ]
+            [#local result += {
+                "HostHeaderConfig" : {
+                    "Values" : asFlattenedArray(conditionValue)
+                }
+            }]
+            [#break]
+
+        [#case "path-pattern" ]
+            [#local result += {
+                "PathPatternConfig" : {
+                    "Values" : asFlattenedArray(conditionValue)
+                }
+            }]
+            [#break]
+
+        [#case "source-ip" ]
+            [#local result += {
+                "SourceIpConfig" : {
+                    "Values" : asFlattenedArray(conditionValue)
+                }
+            }]
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Invalid Application Load balancer Rule Condition"
+                context={
+                    "Type" : type,
+                    "Values" : values
+                }
+            /]
+    [/#switch]
+    [#return [ result ]]
 [/#function]
 
 [#macro createListenerRule id listenerId actions=[] conditions=[] priority=100 dependencies=""]

--- a/awstest/modules/lb/module.ftl
+++ b/awstest/modules/lb/module.ftl
@@ -128,9 +128,11 @@
                                     "Path" : "Resources.listenerRuleXelbXhttpslbXhttpsX500.Properties.Conditions[1]",
                                     "Value" : {
                                         "Field": "host-header",
-                                        "Values": [
-                                            "test-integration.mock.local"
-                                        ]
+                                        "HostHeaderConfig": {
+                                            "Values": [
+                                                "test-integration.mock.local"
+                                            ]
+                                        }
                                     }
                                 },
                                 "HTTPSAction" : {
@@ -150,7 +152,7 @@
                         }
                     }
                 },
-                "validation" : {
+                "lint" : {
                     "OutputSuffix" : "template.json",
                     "Tools" : {
                         "CFNLint" : true,
@@ -161,7 +163,7 @@
             "TestProfiles" : {
                 "httpslb" : {
                     "lb" : {
-                        "TestCases" : [ "httpslb", "validation" ]
+                        "TestCases" : [ "httpslb", "lint" ]
                     }
                 }
             }
@@ -255,11 +257,13 @@
                                 },
                                 "HTTPCondition" : {
                                     "Path" : "Resources.listenerRuleXelbXhttplbXhttpX100.Properties.Conditions[1]",
-                                    "Value" : {
+                                    "Value" :           {
                                         "Field": "host-header",
-                                        "Values": [
-                                            "test-integration.mock.local"
-                                        ]
+                                        "HostHeaderConfig": {
+                                            "Values": [
+                                                "test-integration.mock.local"
+                                            ]
+                                        }
                                     }
                                 },
                                 "HTTPAction" : {
@@ -324,7 +328,7 @@
                         }
                     }
                 },
-                "validation" : {
+                "lint" : {
                     "OutputSuffix" : "template.json",
                     "Tools" : {
                         "CFNLint" : true,
@@ -335,7 +339,179 @@
             "TestProfiles" : {
                 "httplb" : {
                     "lb" : {
-                        "TestCases" : [ "httplb", "httplbfixeddefault", "validation" ]
+                        "TestCases" : [ "httplb", "httplbfixeddefault", "lint" ]
+                    }
+                }
+            }
+        }
+    /]
+
+    [#-- Condition Checking --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "elb" : {
+                    "Components" : {
+                        "conditionapplb" : {
+                            "LB" : {
+                                "Instances" : {
+                                    "default" : {
+                                        "DeploymentUnits" : ["aws-lb-app-condition"]
+                                    }
+                                },
+                                "Engine" : "application",
+                                "Logs" : true,
+                                "Profiles" : {
+                                    "Testing" : [ "conditionapplb" ]
+                                },
+                                "PortMappings" : {
+                                    "http" : {
+                                        "IPAddressGroups" : ["_global"],
+                                        "Conditions" : {
+                                            "httpHeader" : {
+                                                "Type" : "httpHeader",
+                                                "type:httpHeader" : {
+                                                    "HeaderName" : "TestHeader",
+                                                    "HeaderValues" : [ "testValue1" ]
+                                                }
+                                            },
+                                            "httpRequestMethod" : {
+                                                "Type" : "httpRequestMethod",
+                                                "type:httpRequestMethod" : {
+                                                    "Methods" : [ "GET", "HEAD" ]
+                                                }
+                                            },
+                                            "httpQueryString" : {
+                                                "Type" : "httpQueryString",
+                                                "type:httpQueryString" : {
+                                                    "query" : {
+                                                        "Key" : "query",
+                                                        "Value" : "queryValue1"
+                                                    }
+                                                }
+                                            },
+                                            "SourceIP" : {
+                                                "Type" : "SourceIP",
+                                                "type:SourceIP" : {
+                                                    "IPAddressGroups" : [ "_localnet" ]
+                                                }
+                                            }
+                                        },
+                                        "Forward" : {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "conditionapplb" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "httpListenerRule" : {
+                                    "Name" : "listenerRuleXelbXconditionapplbXhttpX100",
+                                    "Type" : "AWS::ElasticLoadBalancingV2::ListenerRule"
+                                },
+                                "httpListener" : {
+                                    "Name" : "listenerXelbXconditionapplbXhttp",
+                                    "Type" : "AWS::ElasticLoadBalancingV2::Listener"
+                                },
+                                "loadBalancer" : {
+                                    "Name" : "albXelbXconditionapplb",
+                                    "Type" : "AWS::ElasticLoadBalancingV2::LoadBalancer"
+                                }
+                            },
+                            "Output" : [
+                                "listenerXelbXconditionapplbXhttp"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "LBName" : {
+                                    "Path"  : "Resources.albXelbXconditionapplb.Properties.Name",
+                                    "Value" : "mockedup-int-elb-conditionapplb"
+                                },
+                                "HTTPConditionDefaultPath" : {
+                                    "Path" : "Resources.listenerRuleXelbXconditionapplbXhttpX100.Properties.Conditions[0]",
+                                    "Value" : {
+                                        "Field": "path-pattern",
+                                        "PathPatternConfig": {
+                                            "Values": [
+                                                "*"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "HTTPConditionHttpHeader" : {
+                                    "Path" : "Resources.listenerRuleXelbXconditionapplbXhttpX100.Properties.Conditions[1]",
+                                    "Value" :           {
+                                        "Field": "http-header",
+                                        "HttpHeaderConfig": {
+                                        "Values": [
+                                            "testValue1"
+                                        ],
+                                        "HttpHeaderName": "TestHeader"
+                                        }
+                                    }
+                                },
+                                "HTTPConditionRequestMethod" : {
+                                    "Path" : "Resources.listenerRuleXelbXconditionapplbXhttpX100.Properties.Conditions[2]",
+                                    "Value" : {
+                                        "Field": "http-request-method",
+                                        "HttpRequestMethodConfig": {
+                                        "Values": [
+                                            "GET",
+                                            "HEAD"
+                                        ]
+                                        }
+                                    }
+                                },
+                                "HTTPConditionSourceIP" : {
+                                    "Path" : "Resources.listenerRuleXelbXconditionapplbXhttpX100.Properties.Conditions[4]",
+                                    "Value" :           {
+                                        "Field": "source-ip",
+                                        "SourceIpConfig": {
+                                            "Values": [
+                                                "10.0.0.0/16"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "HTTPAction" : {
+                                    "Path" : "Resources.listenerRuleXelbXconditionapplbXhttpX100.Properties.Actions[0]",
+                                    "Value" : {
+                                        "Type": "forward",
+                                        "TargetGroupArn": "arn:aws:iam::123456789012:mock/tgXelbXconditionapplbXhttpXarn"
+                                    }
+                                }
+                            },
+                            "Length" : {
+                                "listenerRuleConditions" : {
+                                    "Path" : "Resources.listenerRuleXelbXconditionapplbXhttpX100.Properties.Conditions",
+                                    "Count" : 5
+                                }
+                            },
+                            "NotEmpty" : [
+                                "Resources.listenerRuleXelbXconditionapplbXhttpX100.Properties.Priority"
+                            ]
+                        }
+                    }
+                },
+                "lint" : {
+                    "OutputSuffix" : "template.json",
+                    "Tools" : {
+                        "CFNLint" : true,
+                        "CFNNag" : false
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "conditionapplb" : {
+                    "lb" : {
+                        "TestCases" : [ "conditionapplb", "lint" ]
                     }
                 }
             }


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description

- Adds support for advanced conditions on port mappings mostly around HTTP traffic details
- Updates the condition template syntax to align with the newer conditions requirements

## Motivation and Context

Allows for more complex routing requests on the application load balancers to allow for things like CDN fronting an LB and using an http header to filter access from the CDN vs other locations

## How Has This Been Tested?

Tested locally and with test cases

## Related Changes


### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1826

### Dependent PRs:

- None

### Consumer Actions:

- None

