### PR TITLE
fix(directory): add dependency on root creds

### DIFF
--- a/aws/components/directory/setup.ftl
+++ b/aws/components/directory/setup.ftl
@@ -218,6 +218,9 @@
                 shortName=shortName
                 size=size
                 vpcSettings=vpcSettings
+                dependencies=[
+                    resources["rootCredentials"]["secret"].Id
+                ]
             /]
 
             [@cfOutput


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Adds an explicit dependency on the secrets manager credentials from the directory component

## Motivation and Context

Secret refs don't create implicit dependencies between resources when used

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

