### PR TITLE
fix(s3): handle full access to buckets

### DIFF
--- a/aws/services/s3/policy.ftl
+++ b/aws/services/s3/policy.ftl
@@ -17,13 +17,15 @@
 [#function getS3BucketStatement actions bucket key="" object="" principals="" conditions={} ]
     [#local s3PrefixCondition = {} ]
     [#if key?has_content || object?has_content ]
-        [#local s3PrefixCondition =
-            {
-                "StringLike" : {
-                    "s3:prefix" : (key?has_content?then(key, "") + object?has_content?then("/" + object, ""))?remove_beginning("/")
+        [#if key?has_content && object != "*" ]
+            [#local s3PrefixCondition =
+                {
+                    "StringLike" : {
+                        "s3:prefix" : (key?has_content?then(key, "") + object?has_content?then("/" + object, ""))?remove_beginning("/")
+                    }
                 }
-            }
-        ]
+            ]
+        [/#if]
     [/#if]
     [#return
         [


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Removes the s3 prefix condition if a s3Bucket statement allows access to all keys on an s3 bucket

## Motivation and Context

Incorrect permissions applied when a user was given full access to a bucket

## How Has This Been Tested?

Tested locally and confirmed by development user 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

