### PR TITLE
feat: vpn inside tunnel config

### DIFF
--- a/aws/components/externalnetwork/setup.ftl
+++ b/aws/components/externalnetwork/setup.ftl
@@ -130,9 +130,21 @@
 
                                 [#if deploymentSubsetRequired("cli", false) ]
                                     [@addCliToDefaultJsonOutput
-                                        id=vpnConnectionId
+                                        id=vpnConnectionTunnel1Id
                                         command=vpnOptionsCommand
-                                        content=getVPNTunnelOptionsCli(vpnSecurityProfile)
+                                        content=getVPNTunnelOptionsCli(
+                                            vpnSecurityProfile,
+                                            ((solution.SiteToSite.InsideTunnelCIDRs)![])[0]
+                                        )
+                                    /]
+
+                                    [@addCliToDefaultJsonOutput
+                                        id=vpnConnectionTunnel2Id
+                                        command=vpnOptionsCommand
+                                        content=getVPNTunnelOptionsCli(
+                                            vpnSecurityProfile,
+                                            ((solution.SiteToSite.InsideTunnelCIDRs)![])[1]
+                                        )
                                     /]
                                 [/#if]
 
@@ -150,8 +162,16 @@
                                                 r'       "' + getRegion() + r'" ' +
                                                 r'       "${STACK_NAME}"' +
                                                 r'       "' + vpnConnectionId + r'" ' +
+                                                r'       "0"' +
                                                 r'       "${tmpdir}/cli-' +
-                                                            vpnConnectionId + "-" + vpnOptionsCommand + r'.json" || return $?'
+                                                            vpnConnectionTunnel1Id + "-" + vpnOptionsCommand + r'.json" || return $?',
+                                                r'       update_vpn_options ' +
+                                                r'       "' + getRegion() + r'" ' +
+                                                r'       "${STACK_NAME}"' +
+                                                r'       "' + vpnConnectionId + r'" ' +
+                                                r'       "1"' +
+                                                r'       "${tmpdir}/cli-' +
+                                                            vpnConnectionTunnel2Id + "-" + vpnOptionsCommand + r'.json" || return $?',
                                                 r'      tunnel_ips=($(get_vpn_connection_tunnel_ips ' +
                                                 r'       "' + getRegion() + r'" ' +
                                                 r'       "${STACK_NAME}"' +

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -458,9 +458,21 @@
 
                                     [#if deploymentSubsetRequired("cli", false) ]
                                         [@addCliToDefaultJsonOutput
-                                            id=vpnConnectionId
+                                            id=vpnConnectionTunnel1Id
                                             command=vpnOptionsCommand
-                                            content=getVPNTunnelOptionsCli(vpnSecurityProfile)
+                                            content=getVPNTunnelOptionsCli(
+                                                vpnSecurityProfile,
+                                                ((solution.SiteToSite.InsideTunnelCIDRs)![])[0]
+                                            )
+                                        /]
+
+                                        [@addCliToDefaultJsonOutput
+                                            id=vpnConnectionTunnel2Id
+                                            command=vpnOptionsCommand
+                                            content=getVPNTunnelOptionsCli(
+                                                vpnSecurityProfile,
+                                                ((solution.SiteToSite.InsideTunnelCIDRs)![])[1]
+                                            )
                                         /]
                                     [/#if]
 
@@ -478,8 +490,16 @@
                                                     r'       "' + getRegion() + r'" ' +
                                                     r'       "${STACK_NAME}"' +
                                                     r'       "' + vpnConnectionId + r'" ' +
+                                                    r'       "0"' +
                                                     r'       "${tmpdir}/cli-' +
-                                                                vpnConnectionId + "-" + vpnOptionsCommand + r'.json" || return $?'
+                                                                vpnConnectionTunnel1Id + "-" + vpnOptionsCommand + r'.json" || return $?',
+                                                    r'       update_vpn_options ' +
+                                                    r'       "' + getRegion() + r'" ' +
+                                                    r'       "${STACK_NAME}"' +
+                                                    r'       "' + vpnConnectionId + r'" ' +
+                                                    r'       "1"' +
+                                                    r'       "${tmpdir}/cli-' +
+                                                                vpnConnectionTunnel2Id + "-" + vpnOptionsCommand + r'.json" || return $?',
                                                     r'      tunnel_ips=($(get_vpn_connection_tunnel_ips ' +
                                                     r'       "' + getRegion() + r'" ' +
                                                     r'       "${STACK_NAME}"' +

--- a/aws/services/vpngateway/resource.ftl
+++ b/aws/services/vpngateway/resource.ftl
@@ -173,7 +173,7 @@
     /]
 [/#macro]
 
-[#function getVPNTunnelOptionsCli securityProfile ]
+[#function getVPNTunnelOptionsCli securityProfile tunnelInsideCidr ]
 
     [#local ikeVersions =
                 (securityProfile.IKEVersions)?map( version -> { "Value" : version }) ]
@@ -216,7 +216,11 @@
                 "Phase2EncryptionAlgorithms": phase2EncryptionAlgorithms,
                 "Phase2IntegrityAlgorithms": phase2IntegrityAlgorithms,
                 "Phase2DHGroupNumbers": phase2DHGroupNumbers
-            }
+            } +
+            attributeIfContent(
+                "TunnelInsideCidr",
+                tunnelInsideCidr
+            )
         }
     ]
 [/#function]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds support for defining the tunnelinsideCIDR range on VPN connection  tunnels

## Motivation and Context

This configuration is used by some VPN peers to exchange BGP routes between the VPN gateways instead of requiring an IP on the remote network 

## How Has This Been Tested?

tested locally 

## Related Changes


### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1840
- https://github.com/hamlet-io/executor-bash/pull/291

### Dependent PRs:

- None

### Consumer Actions:

- None

