### PR TITLE
feat(s3): bucket location permissions

### DIFF
--- a/aws/services/s3/policy.ftl
+++ b/aws/services/s3/policy.ftl
@@ -60,7 +60,8 @@
         getS3BucketStatement(
             [
                 "s3:ListBucket",
-                "s3:ListBucketVersions"
+                "s3:ListBucketVersions",
+                "s3:GetBucketLocation"
             ]
             bucket,
             key,
@@ -87,7 +88,8 @@
         getS3BucketStatement(
             [
                 "s3:ListBucket",
-                "s3:ListBucketVersions"
+                "s3:ListBucketVersions",
+                "s3:GetBucketLocation"
             ],
             bucket,
             key,
@@ -114,7 +116,8 @@
         getS3BucketStatement(
             [
                 "s3:ListBucket",
-                "s3:ListBucketVersions"
+                "s3:ListBucketVersions",
+                "s3:GetBucketLocation"
             ],
             bucket,
             key,
@@ -171,7 +174,8 @@
         getS3BucketStatement(
             [
                 "s3:ListBucket",
-                "s3:ListBucketVersions"
+                "s3:ListBucketVersions",
+                "s3:GetBucketLocation"
             ],
             bucket,
             key,
@@ -188,6 +192,7 @@
         getS3BucketStatement(
             [
                 "s3:ListBucket",
+                "s3:GetBucketLocation",
                 "s3:GetBucketLocation"
             ],
             bucket)]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Add GetBucketLocation permissions on all s3 policies to allow for applications to find the region the bucket lives in

## Motivation and Context

S3 buckets have a global name reference but are hosted within a region, an API call can be made to get where the s3 bucket is hosted. Adding this permissions allows this API to be called

## How Has This Been Tested?

Tested locally and with a Jenkins deployment 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

