### PR TITLE
feat: add support for startup action on vpngw

### DIFF
--- a/aws/services/vpngateway/resource.ftl
+++ b/aws/services/vpngateway/resource.ftl
@@ -196,6 +196,8 @@
     [#local phase2DHGroupNumbers =
                 (securityProfile.Phase1.DiffeHellmanGroups)?map( groupNumber -> { "Value" : groupNumber})]
 
+    [#local startupAction = (securityProfile.StartupAction)?lower_case]
+
     [#return
         {
             "TunnelOptions": {
@@ -215,7 +217,9 @@
                 "Phase2LifetimeSeconds": securityProfile.Phase2.Lifetime,
                 "Phase2EncryptionAlgorithms": phase2EncryptionAlgorithms,
                 "Phase2IntegrityAlgorithms": phase2IntegrityAlgorithms,
-                "Phase2DHGroupNumbers": phase2DHGroupNumbers
+                "Phase2DHGroupNumbers": phase2DHGroupNumbers,
+
+                "StartupAction" : startupAction
             } +
             attributeIfContent(
                 "TunnelInsideCidr",


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds the startup action to the tunnel options for VPN gateways

## Motivation and Context

Allows for extra control over how VPN gateways are configured 

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- https://github.com/hamlet-io/engine/pull/1843

### Dependent PRs:

- None

### Consumer Actions:

- None

