### PR TITLE
refactor: make transitgw routes based on CIDR

### DIFF
--- a/aws/components/externalnetwork/setup.ftl
+++ b/aws/components/externalnetwork/setup.ftl
@@ -115,8 +115,13 @@
                                 [#local vpnConnectionTunnel2Id = resources["VpnConnections"][id]["vpnTunnel2"].Id ]
 
                                 [#local transitGateway = getReference( linkTargetResources["transitGateway"].Id ) ]
-                                [#local transitGatewayRouteTable = getReference( linkTargetResources["routeTable"].Id )]
+                                [#local transitGatewayRouteTableId = linkTargetResources["routeTable"].Id  ]
+                                [#local transitGatewayRouteTable = getReference( transitGatewayRouteTableId )]
                                 [#local transGatewayAttachmentId =  formatId(vpnConnectionId, "attach") ]
+
+
+                                [#local externalNetworkCIDRs = getGroupCIDRs(parentSolution.IPAddressGroups, true, occurrence)]
+
 
                                 [#if deploymentSubsetRequired(EXTERNALNETWORK_COMPONENT_TYPE, true)]
                                     [@createVPNConnection
@@ -222,17 +227,12 @@
                                                     transitGatewayRouteTable=transitGatewayRouteTable
                                             /]
                                         [/#if]
-
                                     [#else]
-
-                                        [#local externalNetworkCIDRs = getGroupCIDRs(parentSolution.IPAddressGroups, true, occurrence)]
-
                                         [#list externalNetworkCIDRs as externalNetworkCIDR ]
                                             [#local vpnRouteId = formatResourceId(
                                                     AWS_TRANSITGATEWAY_ROUTE_RESOURCE_TYPE,
-                                                    core.Id,
-                                                    linkTarget.Core.Id,
-                                                    externalNetworkCIDR?index
+                                                    transitGatewayRouteTableId,
+                                                    replaceAlphaNumericOnly(externalNetworkCIDR)
                                             )]
 
                                             [#if deploymentSubsetRequired(EXTERNALNETWORK_COMPONENT_TYPE, true)]
@@ -245,6 +245,7 @@
                                             [/#if]
                                         [/#list]
                                     [/#if]
+
                                 [#else]
 
                                     [#if deploymentSubsetRequired("epilogue", false) ]

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -161,6 +161,7 @@
             [#case "router"]
                 [#local transitGateway = ""]
                 [#local transitGatewayRouteTable = ""]
+                [#local transitGatewayRouteTableId = ""]
 
                 [#local localRouter = true]
                 [#local routerFound = false]
@@ -294,7 +295,8 @@
 
                             [#local routerFound = true ]
                             [#local transitGateway = getExistingReference( linkTargetResources["transitGateway"].Id ) ]
-                            [#local transitGatewayRouteTable = getExistingReference( linkTargetResources["routeTable"].Id ) ]
+                            [#local transitGatewayRouteTableId = linkTargetResources["routeTable"].Id]
+                            [#local transitGatewayRouteTable = getExistingReference(transitGatewayRouteTableId) ]
 
                         [/#if]
                         [#break]
@@ -351,8 +353,8 @@
                             [#list sourceCidrs as souceCidr ]
                                 [#local vpcRouteId = formatResourceId(
                                         AWS_TRANSITGATEWAY_ROUTE_RESOURCE_TYPE,
-                                        gwCore.Id,
-                                        souceCidr?index
+                                        transitGatewayRouteTableId,
+                                        replaceAlphaNumericOnly(souceCidr)
                                 )]
 
                                 [@createTransitGatewayRoute


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

- Updates the naming of transit gw routes based on the Transit gateway and destination CIDR range to ensure only one route is created per CIDR

## Motivation and Context

When HA deployments are created for the transit gateway that offer the same CIDR when adding static routes to these destinations you can only specify a CIDR once, this ensures that at least one of the static routes will be in place and BGP handles offering the network for the other device 

## How Has This Been Tested?

Tested locally 

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

