### PR TITLE
feat: add s3 replica to account deployments

### DIFF
--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -1384,6 +1384,11 @@
                     "deployment:Priority" : 40,
                     "GroupDeploymentUnit" : false
                 },
+                "s3replica" : {
+                    "deployment:Unit" : "s3replica",
+                    "deployment:Priority" : 45,
+                    "GroupDeploymentUnit" : false
+                },
                 "s3" : {
                     "deployment:Unit" : "s3",
                     "deployment:Priority" : 50,


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds the s3replica account deployment into the account level resource groups

## Motivation and Context

The s3replica unit wasn't available when running list-deployments on the account district

## How Has This Been Tested?

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

