### PR TITLE
fix(lb): handle missing alerts on lbport

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -623,7 +623,7 @@
 
         [#-- LB level Alerts --]
         [#if deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
-            [#list solution.Alerts?values as alert ]
+            [#list ((solution.Alerts)!{})?values as alert ]
 
                 [#local monitoredResources = getCWMonitoredResources(core.Id, resources, alert.Resource)]
                 [#list monitoredResources as name,monitoredResource ]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

when lbports don't have alerts provide an empty object

## Motivation and Context

Template generation failing on missing alerts

## How Has This Been Tested?

Tested locallly

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

