### PR TITLE
feat: add route53 resolver for AD domain

### DIFF
--- a/aws/components/directory/id.ftl
+++ b/aws/components/directory/id.ftl
@@ -14,7 +14,8 @@
         [
             AWS_VIRTUAL_PRIVATE_CLOUD_SERVICE,
             AWS_DIRECTORY_SERVICE,
-            AWS_SECRETS_MANAGER_SERVICE
+            AWS_SECRETS_MANAGER_SERVICE,
+            AWS_ROUTE53_SERVICE
         ]
 /]
 

--- a/aws/components/directory/state.ftl
+++ b/aws/components/directory/state.ftl
@@ -77,6 +77,40 @@
                     }
             )]
 
+            [#local networkLink = getOccurrenceNetwork(occurrence).Link!{} ]
+            [#local networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
+            [#local providerDNS = (networkLinkTarget.Configuration.Solution.DNS.UseProvider)!true ]
+
+            [#if providerDNS ]
+                [#local resources = mergeObjects(
+                    resources,
+                    {
+                        "resolver" : {
+                            "endpoint" : {
+                                "Id" : formatResourceId(AWS_ROUTE53_RESOLVER_ENDPOINT_RESOURCE_TYPE, core.Id),
+                                "Name" : core.FullName,
+                                "Type" : AWS_ROUTE53_RESOLVER_ENDPOINT_RESOURCE_TYPE
+                            },
+                            "rule" : {
+                                "Id" : formatResourceId(AWS_ROUTE53_RESOLVER_RULE_RESOURCE_TYPE, core.Id),
+                                "Name" : core.FullName,
+                                "Type" : AWS_ROUTE53_RESOLVER_RULE_RESOURCE_TYPE
+                            },
+                            "association" : {
+                                "Id" : formatResourceId(AWS_ROUTE53_RESOLVER_RULE_ASSOC_RESOURCE_TYPE, core.Id),
+                                "Name" : core.FullName,
+                                "Type" : AWS_ROUTE53_RESOLVER_RULE_ASSOC_RESOURCE_TYPE
+                            },
+                            "sg" : {
+                                "Id" : formatResourceId(AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id),
+                                "Name" : core.FullName,
+                                "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
+                            }
+                        }
+                    }
+                )]
+            [/#if]
+
             [#local attributes = mergeObjects(
                         attributes,
                         {

--- a/aws/services/ds/resource.ftl
+++ b/aws/services/ds/resource.ftl
@@ -49,6 +49,22 @@
     outputs=
         DIRECTORY_OUTPUT_MAPPINGS
     /]
+
+    [@cfOutput
+        formatId(id, IP_ADDRESS_ATTRIBUTE_TYPE),
+        {
+            "Fn::Join": [
+                ",",
+                {
+                    "Fn::GetAtt": [
+                        id,
+                        "DnsIpAddresses"
+                    ]
+                }
+            ]
+        },
+        false
+    /]
 [/#macro]
 
 

--- a/aws/services/route53/id.ftl
+++ b/aws/services/route53/id.ftl
@@ -27,3 +27,24 @@
     service=AWS_ROUTE53_SERVICE
     resource=AWS_ROUTE53_DNS_ZONE_RESOURCE_TYPE
 /]
+
+[#assign AWS_ROUTE53_RESOLVER_ENDPOINT_RESOURCE_TYPE = "route53ResolverEndpoint" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_ROUTE53_SERVICE
+    resource=AWS_ROUTE53_RESOLVER_ENDPOINT_RESOURCE_TYPE
+/]
+
+[#assign AWS_ROUTE53_RESOLVER_RULE_RESOURCE_TYPE = "route53ResolverRule" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_ROUTE53_SERVICE
+    resource=AWS_ROUTE53_RESOLVER_RULE_RESOURCE_TYPE
+/]
+
+[#assign AWS_ROUTE53_RESOLVER_RULE_ASSOC_RESOURCE_TYPE = "route53ResolverRuleAssoc" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_ROUTE53_SERVICE
+    resource=AWS_ROUTE53_RESOLVER_RULE_ASSOC_RESOURCE_TYPE
+/]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description

- Adds support for resolver endpoints and rules in the route53 service
- Adds support for adding resolver endpoints when deploying a directory component
- Fixes some bugs where missing configuration caused a stack trace

## Motivation and Context

fixes https://github.com/hamlet-io/engine/issues/1824

When deploying an AD directory component the DNS hosting for the AD environment isn't integrated with the default DNS resolver. To use the AD directory you either need to update the DHCP dns options to use the AD servers as the DNS resolvers or manually configure the specific servers you want to use the Ad environment. 

Using the outbound resolvers makes this available for all services on the VPC and removes the need for specific configuration. All DNS requests can still be logged or tracked as required 

## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

