### PR TITLE
feat: enable cfn-lint on all test profiles

### DIFF
--- a/aws/inputseeders/aws/id.ftl
+++ b/aws/inputseeders/aws/id.ftl
@@ -163,22 +163,42 @@
         provider=AWS_PROVIDER
         services=[
             AWS_VIRTUAL_PRIVATE_CLOUD_SERVICE,
-            AWS_NETWORK_FIREWALL_SERVICE
+            AWS_NETWORK_FIREWALL_SERVICE,
+            AWS_IDENTITY_SERVICE
+            AWS_SIMPLE_STORAGE_SERVICE
         ]
         deploymentFramework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
     /]
 
     [#switch id?split("X")?first ]
-        [#case AWS_VPC_RESOURCE_TYPE ]
-            [#-- this will return the value for all attribute lookups --]
-            [#-- VPC only has ref so that is ok --]
-            [#local value = "vpc-123456789abcdef12" ]
+        [#case AWS_IAM_MANAGED_POLICY_RESOURCE_TYPE]
+            [#if id?ends_with(ARN_ATTRIBUTE_TYPE)]
+                [#local value = "arn:aws:iam::123456789012:policy/managedPolicyXuserXappXapiuserbaseXlinksXarn"]
+            [/#if]
+            [#break]
+
+        [#case AWS_IAM_ROLE_RESOURCE_TYPE]
+            [#if id?ends_with(ARN_ATTRIBUTE_TYPE)]
+                [#local value = "arn:aws:iam::123456789012:role/managedPolicyXuserXappXapiuserbaseXlinksXarn"]
+            [/#if]
             [#break]
 
         [#case AWS_NETWORK_FIREWALL_RESOURCE_TYPE]
             [#if id?ends_with(INTERFACE_ATTRIBUTE_TYPE)]
                 [#local value = "ap-mock-1a:vpce-111122223333,ap-mock-1b:vpce-987654321098,ap-mock-1c:vpce-012345678901"]
             [/#if]
+            [#break]
+
+        [#case AWS_S3_RESOURCE_TYPE]
+            [#if id?ends_with(NAME_ATTRIBUTE_TYPE)]
+                [#local value = replaceAlphaNumericOnly(id)?lower_case]
+            [/#if]
+            [#break]
+
+        [#case AWS_VPC_RESOURCE_TYPE ]
+            [#-- this will return the value for all attribute lookups --]
+            [#-- VPC only has ref so that is ok --]
+            [#local value = "vpc-123456789abcdef12" ]
             [#break]
     [/#switch]
 

--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -222,6 +222,14 @@
                                 }
                             }
                         }
+                    },
+                    "TestCases": {
+                        "_cfn-lint" : {
+                            "OutputSuffix" : "template.json",
+                            "Tools" : {
+                                "cfn-lint" : {}
+                            }
+                        }
                     }
                 },
                 FIXTURE_SHARED_INPUT_STAGE

--- a/awstest/modules/apigateway/module.ftl
+++ b/awstest/modules/apigateway/module.ftl
@@ -102,6 +102,9 @@
                 "apigatewaybase" : {
                     "apigateway" : {
                         "TestCases" : [ "apigatewaybase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             },
@@ -257,6 +260,9 @@
                 "apigatewaydomain" : {
                     "apigateway" : {
                         "TestCases" : [ "apigatewaydomain" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             },
@@ -389,6 +395,9 @@
                 "apigatewaycfdistro" : {
                     "apigateway" : {
                         "TestCases" : [ "apigatewaycfdistro" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             },

--- a/awstest/modules/apiusageplan/module.ftl
+++ b/awstest/modules/apiusageplan/module.ftl
@@ -146,6 +146,9 @@
                 "apiusageplanbase" : {
                     "apiusageplan" : {
                         "TestCases" : [ "apiusageplanbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             },

--- a/awstest/modules/apiuser/module.ftl
+++ b/awstest/modules/apiuser/module.ftl
@@ -146,6 +146,9 @@
                 "apiuserbase" : {
                     "user" : {
                         "TestCases" : [ "apiuserbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             },

--- a/awstest/modules/bastion/module.ftl
+++ b/awstest/modules/bastion/module.ftl
@@ -34,9 +34,6 @@
             "TestCases" : {
                 "bastionbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -86,6 +83,9 @@
                 "bastionbase" : {
                     "bastion" : {
                         "TestCases" : [ "bastionbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/cache/module.ftl
+++ b/awstest/modules/cache/module.ftl
@@ -83,6 +83,9 @@
                 "cachebase" : {
                     "cache" : {
                         "TestCases" : [ "cachebase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/cdn/module.ftl
+++ b/awstest/modules/cdn/module.ftl
@@ -94,9 +94,6 @@
             "TestCases" : {
                 "cdnbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -125,6 +122,9 @@
                 "cdnbase" : {
                     "cdn" : {
                         "TestCases" : [ "cdnbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/computecluster/module.ftl
+++ b/awstest/modules/computecluster/module.ftl
@@ -36,9 +36,6 @@
             "TestCases" : {
                 "computeclusterbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -71,6 +68,9 @@
                 "computeclusterbase" : {
                     "computecluster" : {
                         "TestCases" : [ "computeclusterbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/correspondent/module.ftl
+++ b/awstest/modules/correspondent/module.ftl
@@ -34,9 +34,6 @@
             "TestCases" : {
                 "correspondentbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -57,6 +54,9 @@
                 "correspondentbase" : {
                     "correspondent" : {
                         "TestCases" : [ "correspondent" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/datapipeline/module.ftl
+++ b/awstest/modules/datapipeline/module.ftl
@@ -114,6 +114,9 @@
                 "datapipelinebase" : {
                     "datapipeline" : {
                         "TestCases" : [ "datapipelinebasecli" ,"datapipelinebaseconfig", "datapipelinebasetemplate" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/db/module.ftl
+++ b/awstest/modules/db/module.ftl
@@ -47,9 +47,6 @@
             "TestCases" : {
                 "postgresdbbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -102,6 +99,9 @@
                 "postgresdbbase" : {
                     "db" : {
                         "TestCases" : [ "postgresdbbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }
@@ -139,9 +139,6 @@
             "TestCases" : {
                 "postgresdbgenerated" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -186,6 +183,9 @@
                 "postgresdbgenerated" : {
                     "db" : {
                         "TestCases" : [ "postgresdbgenerated" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }
@@ -227,9 +227,6 @@
             "TestCases" : {
                 "postgresdbmaintenance" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -258,6 +255,9 @@
                 "postgresdbmaintenance" : {
                     "db" : {
                         "TestCases" : [ "postgresdbmaintenance" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/directory/module.ftl
+++ b/awstest/modules/directory/module.ftl
@@ -78,9 +78,6 @@
             "TestCases" : {
                 "directorysimplebase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -105,6 +102,9 @@
                 "directorysimplebase" : {
                     "directory" : {
                         "TestCases" : [ "directorysimplebase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }
@@ -180,9 +180,6 @@
             "TestCases" : {
                 "directoryadbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -207,6 +204,9 @@
                 "directoryadbase" : {
                     "directory" : {
                         "TestCases" : [ "directoryadbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/ec2/module.ftl
+++ b/awstest/modules/ec2/module.ftl
@@ -33,9 +33,6 @@
             "TestCases" : {
                 "ec2base" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -80,6 +77,9 @@
                 "ec2base" : {
                     "ec2" : {
                         "TestCases" : [ "ec2base" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/ecs/module.ftl
+++ b/awstest/modules/ecs/module.ftl
@@ -34,9 +34,6 @@
             "TestCases" : {
                 "ecsbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -104,6 +101,9 @@
                 "ecsbase" : {
                     "ecs" : {
                         "TestCases" : [ "ecsbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/filetransfer/module.ftl
+++ b/awstest/modules/filetransfer/module.ftl
@@ -59,6 +59,9 @@
                 "filetransferbase" : {
                     "filetransfer" : {
                         "TestCases" : [ "filetransferbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/firewall/module.ftl
+++ b/awstest/modules/firewall/module.ftl
@@ -41,9 +41,6 @@
             "TestCases" : {
                 "firewallbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -73,6 +70,9 @@
                 "firewallbase" : {
                     "firewall" : {
                         "TestCases" : [ "firewallbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }
@@ -130,9 +130,6 @@
             "TestCases" : {
                 "firewallsimplenet" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -170,6 +167,9 @@
                 "firewallsimplenet" : {
                     "firewall" : {
                         "TestCases" : [ "firewallsimplenet" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }
@@ -228,9 +228,6 @@
             "TestCases" : {
                 "firewalldomainfilter" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -268,6 +265,9 @@
                 "firewalldomainfilter" : {
                     "firewall" : {
                         "TestCases" : [ "firewalldomainfilter" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/healthcheck/module.ftl
+++ b/awstest/modules/healthcheck/module.ftl
@@ -107,9 +107,6 @@
             "TestCases" : {
                 "healthchecksimplebase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -126,9 +123,6 @@
                 },
                 "healthcheckcomplexbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -164,11 +158,17 @@
                 "healthchecksimplebase" : {
                     "healthcheck" : {
                         "TestCases" : [ "healthchecksimplebase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 },
                 "healthcheckcomplexbase" : {
                     "healthcheck" : {
                         "TestCases" : [ "healthcheckcomplexbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/lb/module.ftl
+++ b/awstest/modules/lb/module.ftl
@@ -151,18 +151,15 @@
                             ]
                         }
                     }
-                },
-                "lint" : {
-                    "OutputSuffix" : "template.json",
-                    "Tools" : {
-                        "cfn-lint" : {}
-                    }
                 }
             },
             "TestProfiles" : {
                 "httpslb" : {
                     "lb" : {
-                        "TestCases" : [ "httpslb", "lint" ]
+                        "TestCases" : [ "httpslb" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }
@@ -326,18 +323,15 @@
                             }
                         }
                     }
-                },
-                "lint" : {
-                    "OutputSuffix" : "template.json",
-                    "Tools" : {
-                        "cfn-lint" : {}
-                    }
                 }
             },
             "TestProfiles" : {
                 "httplb" : {
                     "lb" : {
-                        "TestCases" : [ "httplb", "httplbfixeddefault", "lint" ]
+                        "TestCases" : [ "httplb", "httplbfixeddefault" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }
@@ -497,18 +491,15 @@
                             ]
                         }
                     }
-                },
-                "lint" : {
-                    "OutputSuffix" : "template.json",
-                    "Tools" : {
-                        "cfn-lint" : {}
-                    }
                 }
             },
             "TestProfiles" : {
                 "conditionapplb" : {
                     "lb" : {
-                        "TestCases" : [ "conditionapplb", "lint" ]
+                        "TestCases" : [ "conditionapplb" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/mobileapp/module.ftl
+++ b/awstest/modules/mobileapp/module.ftl
@@ -65,7 +65,7 @@
                                     "Value" : "ios,android"
                                 },
                                 "BUILD_REFERENCE" : {
-                                    "Path" : "BuildConfig.BUILD_REFERENCE]",
+                                    "Path" : "BuildConfig.BUILD_REFERENCE",
                                     "Value" : "123456789#MockCommit#"
                                 },
                                 "RELEASE_CHANNEL" : {

--- a/awstest/modules/network/module.ftl
+++ b/awstest/modules/network/module.ftl
@@ -33,9 +33,6 @@
             "TestCases" : {
                 "networkbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                        "cfn-lint" : {}
-                    },
                     "Structural" : {
                     }
                 }
@@ -44,6 +41,9 @@
                 "networkbase" : {
                     "network" : {
                         "TestCases" : [ "networkbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }
@@ -145,9 +145,6 @@
             "TestCases" : {
                 "networksubnet" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                        "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -220,6 +217,9 @@
                 "networksubnet" : {
                     "network" : {
                         "TestCases" : [ "networksubnet" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }
@@ -263,9 +263,6 @@
             "TestCases" : {
                 "networklogging" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                        "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -310,6 +307,9 @@
                 "networklogging" : {
                     "network" : {
                         "TestCases" : [ "networklogging" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/queuehost/module.ftl
+++ b/awstest/modules/queuehost/module.ftl
@@ -56,9 +56,6 @@
             "TestCases" : {
                 "queuehostbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -88,6 +85,9 @@
                 "queuehostbase" : {
                     "queuehost" : {
                         "TestCases" : [ "queuehostbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }
@@ -146,9 +146,6 @@
             "TestCases" : {
                 "queuehostmaintenance" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -181,6 +178,9 @@
                 "queuehostmaintenance" : {
                     "queuehost" : {
                         "TestCases" : [ "queuehostmaintenance" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/s3/module.ftl
+++ b/awstest/modules/s3/module.ftl
@@ -151,21 +151,33 @@
                 "s3base" : {
                     "s3" : {
                         "TestCases" : [ "s3base" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 },
                 "s3notify" : {
                     "s3" : {
                         "TestCases" : [ "s3notify" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 },
                 "s3replica" : {
                     "s3" : {
                         "TestCases" : [ "s3replica" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 },
                 "s3replicaext" : {
                     "s3" : {
                         "TestCases" : [ "s3replicaext" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             },

--- a/awstest/modules/service/module.ftl
+++ b/awstest/modules/service/module.ftl
@@ -71,9 +71,6 @@
             "TestCases" : {
                 "servicebase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -103,6 +100,9 @@
                 "servicebase" : {
                     "service" : {
                         "TestCases" : [ "servicebase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/sqs/module.ftl
+++ b/awstest/modules/sqs/module.ftl
@@ -32,9 +32,6 @@
             "TestCases" : {
                 "sqsbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -64,6 +61,9 @@
                 "sqsbase" : {
                     "sqs" : {
                         "TestCases" : [ "sqsbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/task/module.ftl
+++ b/awstest/modules/task/module.ftl
@@ -72,9 +72,6 @@
             "TestCases" : {
                 "taskbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -103,6 +100,9 @@
                 "taskbase" : {
                     "task" : {
                         "TestCases" : [ "taskbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/topic/module.ftl
+++ b/awstest/modules/topic/module.ftl
@@ -33,9 +33,6 @@
             "TestCases" : {
                 "topicbase" : {
                     "OutputSuffix" : "template.json",
-                    "Tools" : {
-                       "cfn-lint" : {}
-                    },
                     "Structural" : {
                         "CFN" : {
                             "Resource" : {
@@ -60,6 +57,9 @@
                 "topicbase" : {
                     "topic" : {
                         "TestCases" : [ "topicbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }

--- a/awstest/modules/userpool/module.ftl
+++ b/awstest/modules/userpool/module.ftl
@@ -68,6 +68,9 @@
                 "userpoolbase" : {
                     "userpool" : {
                         "TestCases" : [ "userpoolbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
                     }
                 }
             }


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

- Adds a cfn-lint default test case in the awstest masterdata
- Adds the testcase to all current test profiles
- Adds arn and naming for resources which are matched on policy

## Motivation and Context

closes https://github.com/hamlet-io/engine/issues/1816 

## How Has This Been Tested?

Tested locally and will be tested in PR

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

