### PR TITLE
fix(lb): target group id lookup

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -834,7 +834,7 @@
                         "deregistration_delay.timeout_seconds" : solution.Forward.DeregistrationTimeout
                     }]
 
-                [#if engine == "network"]
+                [#if engine == "network" && deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
                     [@createTargetGroup
                         id=targetGroupId
                         name=targetGroupName

--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -254,7 +254,7 @@
             [#local targetGroupArn = getExistingReference(defaultTargetGroupId, ARN_ATTRIBUTE_TYPE)]
 
             [#local resources += {
-                "defaulttg" : {
+                "targetgroup" : {
                     "Id" : defaultTargetGroupId,
                     "Name" : defaultTargetGroupName,
                     "Type" : AWS_ALB_TARGET_GROUP_RESOURCE_TYPE


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Fixes the naming of the network load balancer target group in state
- Adds subset check for deployment to ensure the target group isn't included in resource sets

## Motivation and Context

Template generation was failing and resource Id was empty

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

