### PR TITLE
fix: ses account deployment unit name

### DIFF
--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -1409,8 +1409,8 @@
                     "deployment:Priority" : 100,
                     "GroupDeploymentUnit" : false
                 },
-                "ses" : {
-                    "deployment:Unit" : "ses",
+                "sesruleset" : {
+                    "deployment:Unit" : "sesruleset",
                     "deployment:Priority" : 100,
                     "GroupDeploymentUnit" : false
                 },


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)


## Description

- renames the ses account deployment unit to sesruleset used to create the default rule set to align with the legacy deployment fragment

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->

fixes https://github.com/hamlet-io/engine/issues/1857


## How Has This Been Tested?

Tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

