### PR TITLE
refactor(topic): move sns topic policy to topic

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -160,17 +160,19 @@
                                         [#case TOPIC_COMPONENT_TYPE]
                                             [#local resourceId = linkTargetResources["topic"].Id ]
                                             [#local resourceType = linkTargetResources["topic"].Type ]
-                                            [#local policyId =
-                                                formatS3NotificationPolicyId(
-                                                    bucketId,
-                                                    resourceId) ]
 
-                                            [#local bucketDependencies += [ policyId ]]
-                                            [@createSNSPolicy
-                                                id=policyId
-                                                topics=resourceId
-                                                statements=snsS3WritePermission(resourceId, bucketName)
-                                            /]
+                                            [#if ! (notification["aws:TopicPermissionMigration"]) ]
+                                                [@fatal
+                                                    message="Topic Permissions update required"
+                                                    detail=[
+                                                        "SNS policies have been migrated to the topic component",
+                                                        "For each S3 bucket add an inbound-invoke link from the Topic to the bucket",
+                                                        "When this is completed update the configuration of this notification to TopicPermissionMigration : true"
+                                                    ]?join(',')
+                                                    context=notification
+                                                /]
+                                            [/#if]
+
                                     [/#switch]
 
                                     [#list notification.Events as event ]

--- a/aws/components/mta/setup.ftl
+++ b/aws/components/mta/setup.ftl
@@ -107,8 +107,8 @@
                                     {}
                                 )
                             ]
-                            [#-- CloudFormation cannot update a stack when a custom-named resource requires replacing and 
-                                 configsets are custom-named, hence when tags are added, care is needed. Currently only 
+                            [#-- CloudFormation cannot update a stack when a custom-named resource requires replacing and
+                                 configsets are custom-named, hence when tags are added, care is needed. Currently only
                                  attribute is name which can not change --]
                             [@addToDefaultBashScriptOutput
                                 content=
@@ -127,12 +127,25 @@
                                     "esac"
                                 ]
                             /]
+
+                            [#if getExistingReference(formatResourceId(AWS_SNS_TOPIC_POLICY_RESOURCE_TYPE, ruleId, link.Id))?has_content ]
+                                [@warn
+                                    message="Topic Permissions update required"
+                                    detail=[
+                                        "SNS policies have been migrated to the topic component",
+                                        "For each S3 bucket add an inbound-invoke link from the Topic to the bucket",
+                                        "When this is completed update the configuration of this notification to TopicPermissionMigration : true"
+                                    ]?join(',')
+                                    context=subOccurrence.Core.RawId
+                                /]
+                            [/#if]
+                            [#break]
                         [/#if]
                     [/#if]
                 [/#if]
             [/#list]
         [#break]
-        
+
         [#case "receive"]
             [#local ruleSetName = attributes["RULESET"] ]
             [#if ! ruleSetName?has_content ]

--- a/aws/components/mta/setup.ftl
+++ b/aws/components/mta/setup.ftl
@@ -60,23 +60,15 @@
                                     [#continue]
                                 [/#if]
                                 [#if linkTarget.Core.Type == TOPIC_COMPONENT_TYPE ]
-                                    [#local topicArn = linkTarget.State.Attributes["ARN"] ]
-                                    [#if deploymentSubsetRequired(MTA_COMPONENT_TYPE, true) ]
-                                        [@createSNSPolicy
-                                            id=formatResourceId(AWS_SNS_TOPIC_POLICY_RESOURCE_TYPE, configId, link.Id)
-                                            topics=topicArn
-                                            statements=getSnsStatement(
-                                                "sns:Publish",
-                                                topicArn
-                                                {
-                                                    "Service" : "ses.amazonaws.com"
-                                                },
-                                                {
-                                                    "StringEquals" : {
-                                                        "AWS:SourceAccount" : { "Ref" : "AWS::AccountId" }
-                                                    }
-                                                }
-                                            )
+                                    [#if getExistingReference(formatResourceId(AWS_SNS_TOPIC_POLICY_RESOURCE_TYPE, ruleId, link.Id))?has_content ]
+                                        [@warn
+                                            message="Topic Permissions update required"
+                                            detail=[
+                                                "SNS policies have been migrated to the topic component",
+                                                "For each S3 bucket add an inbound-invoke link from the Topic to the bucket",
+                                                "When this is completed update the configuration of this notification to TopicPermissionMigration : true"
+                                            ]?join(',')
+                                            context=subOccurrence.Core.RawId
                                         /]
                                     [/#if]
                                     [#break]
@@ -127,18 +119,6 @@
                                     "esac"
                                 ]
                             /]
-
-                            [#if getExistingReference(formatResourceId(AWS_SNS_TOPIC_POLICY_RESOURCE_TYPE, ruleId, link.Id))?has_content ]
-                                [@warn
-                                    message="Topic Permissions update required"
-                                    detail=[
-                                        "SNS policies have been migrated to the topic component",
-                                        "For each S3 bucket add an inbound-invoke link from the Topic to the bucket",
-                                        "When this is completed update the configuration of this notification to TopicPermissionMigration : true"
-                                    ]?join(',')
-                                    context=subOccurrence.Core.RawId
-                                /]
-                            [/#if]
                             [#break]
                         [/#if]
                     [/#if]
@@ -194,24 +174,17 @@
                                 [/#if]
 
                                 [#if linkTarget.Core.Type == TOPIC_COMPONENT_TYPE ]
-                                    [#local topicArn = linkTarget.State.Attributes["ARN"] ]
-
-                                    [@createSNSPolicy
-                                        id=formatResourceId(AWS_SNS_TOPIC_POLICY_RESOURCE_TYPE, ruleId, link.Id)
-                                        topics=topicArn
-                                        statements=getSnsStatement(
-                                            "sns:Publish",
-                                            topicArn
-                                            {
-                                                "Service" : "ses.amazonaws.com"
-                                            },
-                                            {
-                                                "StringEquals" : {
-                                                    "AWS:SourceAccount" : { "Ref" : "AWS::AccountId" }
-                                                }
-                                            }
-                                        )
-                                    /]
+                                    [#if getExistingReference(formatResourceId(AWS_SNS_TOPIC_POLICY_RESOURCE_TYPE, ruleId, link.Id))?has_content ]
+                                        [@warn
+                                            message="Topic Permissions update required"
+                                            detail=[
+                                                "SNS policies have been migrated to the topic component",
+                                                "For each S3 bucket add an inbound-invoke link from the Topic to the bucket",
+                                                "When this is completed update the configuration of this notification to TopicPermissionMigration : true"
+                                            ]?join(',')
+                                            context=subOccurrence.Core.RawId
+                                        /]
+                                    [/#if]
                                     [#break]
                                 [/#if]
                             [/#if]

--- a/aws/components/mta/state.ftl
+++ b/aws/components/mta/state.ftl
@@ -10,7 +10,12 @@
             "Resources" : {},
             "Attributes" : {},
             "Roles" : {
-                "Inbound" : {},
+                 "Inbound" : {
+                    "invoke" : {
+                        "Principal" : "ses.amazonaws.com",
+                        "SourceAccount" : { "Ref" : "AWS::AccountId" }
+                    }
+                },
                 "Outbound" : {}
             }
         }
@@ -31,20 +36,6 @@
     [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
     [#local hostName = getHostName(certificateObject, occurrence) ]
 
-
-    [#-- local invoke permissions for log forwardning --]
-    [#assign componentState +=
-        {
-            "Roles" : {
-                 "Inbound" : {
-                    "invoke" : {
-                        "Principal" : "ses.amazonaws.com",
-                        "SourceAccount" : { "Ref" : "AWS::AccountId" }
-                    }
-                }
-            }
-        }
-    ]
 
     [#-- Direction controls state --]
     [#switch solution.Direction ]

--- a/aws/components/mta/state.ftl
+++ b/aws/components/mta/state.ftl
@@ -31,6 +31,21 @@
     [#local primaryDomainObject = getCertificatePrimaryDomain(certificateObject) ]
     [#local hostName = getHostName(certificateObject, occurrence) ]
 
+
+    [#-- local invoke permissions for log forwardning --]
+    [#assign componentState +=
+        {
+            "Roles" : {
+                 "Inbound" : {
+                    "invoke" : {
+                        "Principal" : "ses.amazonaws.com",
+                        "SourceAccount" : { "Ref" : "AWS::AccountId" }
+                    }
+                }
+            }
+        }
+    ]
+
     [#-- Direction controls state --]
     [#switch solution.Direction ]
         [#case "send" ]

--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -103,19 +103,19 @@
                             [#case TOPIC_COMPONENT_TYPE]
                                 [#local resourceId = linkTargetResources["topic"].Id ]
                                 [#local resourceType = linkTargetResources["topic"].Type ]
-                                [#local policyId =
-                                    formatS3NotificationPolicyId(
-                                        s3Id,
-                                        resourceId) ]
 
-                                [#local dependencies += [ policyId ]]
-
-                                [#if deploymentSubsetRequired("s3", true )]
-                                    [@createSNSPolicy
-                                        id=policyId
-                                        topics=resourceId
-                                        statements=snsS3WritePermission(resourceId, s3Name)
-                                    /]
+                                [#if ! (notification["aws:QueuePermissionMigration"]) ]
+                                    [#if deploymentSubsetRequired(S3_COMPONENT_TYPE, true)]
+                                        [@fatal
+                                            message="Topic Permissions update required"
+                                            detail=[
+                                                "SNS policies have been migrated to the topic component",
+                                                "For each S3 bucket add an inbound-invoke link from the Topic to the bucket",
+                                                "When this is completed update the configuration of this notification to TopicPermissionMigration : true"
+                                            ]?join(',')
+                                            context=subOccurrence.Core.RawId
+                                        /]
+                                    [/#if]
                                 [/#if]
                         [/#switch]
 

--- a/aws/components/topic/setup.ftl
+++ b/aws/components/topic/setup.ftl
@@ -89,14 +89,30 @@
                 [#case "inbound" ]
                     [#switch linkRole ]
                         [#case "invoke" ]
+
+                            [#local sourceCondition = {}]
+
+                            [#switch linkTargetCore.Type ]
+                                [#case MTA_COMPONENT_TYPE ]
+                                    [#local sourceCondition = {
+                                        "StringEquals" : {
+                                            "AWS:SourceAccount" : linkTargetRoles.Inbound["invoke"].SourceAccount
+                                        }
+                                    }]
+                                    [#break]
+
+                                [#default]
+                                    [#local sourceCondition = {
+                                        "ArnLike" : {
+                                            "aws:sourceArn" : linkTargetRoles.Inbound["invoke"].SourceArn
+                                        }
+                                    }]
+                            [/#switch]
+
                             [#local topicPolicyStatements += [ snsPublishPermission(
                                                                 topicId,
                                                                 { "Service" : linkTargetRoles.Inbound["invoke"].Principal },
-                                                                {
-                                                                    "ArnLike" : {
-                                                                        "aws:sourceArn" : linkTargetRoles.Inbound["invoke"].SourceArn
-                                                                    }
-                                                                },
+                                                                sourceCondition,
                                                                 true,
                                                                 linkId
                                                             )] ]

--- a/aws/components/topic/state.ftl
+++ b/aws/components/topic/state.ftl
@@ -14,6 +14,10 @@
                     "Name" : core.FullName,
                     "Type" : AWS_SNS_TOPIC_RESOURCE_TYPE,
                     "Monitored" : true
+                },
+                "policy" : {
+                    "Id" : formatResourceId(AWS_SNS_TOPIC_POLICY_RESOURCE_TYPE, core.Id),
+                    "Type" : AWS_SNS_TOPIC_POLICY_RESOURCE_TYPE
                 }
             },
             "Attributes" : {

--- a/aws/services/sns/policy.ftl
+++ b/aws/services/sns/policy.ftl
@@ -40,7 +40,7 @@
             id)]
 [/#function]
 
-[#function snsPublishPermission id="" principals="*" conditions={} allow=true sid="" ]
+[#function snsPublishPermission id="" principals="" conditions={} allow=true sid="" ]
     [#return
         getSnsStatement(
             [

--- a/aws/services/sns/policy.ftl
+++ b/aws/services/sns/policy.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#function getSnsStatement actions id="" principals="" conditions=""]
+[#function getSnsStatement actions id="" principals="" conditions="" allow=true sid="" ]
     [#local result = [] ]
     [#if id?has_content]
         [#local result +=
@@ -9,7 +9,9 @@
                     actions,
                     getArn(id),
                     principals,
-                    conditions
+                    conditions,
+                    allow,
+                    sid
                 )
             ]
         ]
@@ -20,7 +22,9 @@
                     actions,
                     "*",
                     principals
-                    conditions
+                    conditions,
+                    allow,
+                    sid
                 )
             ]
         ]
@@ -29,18 +33,25 @@
     [return result]
 [/#function]
 
-[#function snsAdminPermission id=""]
+[#function snsAdminPermission id="" ]
     [#return
         getSnsStatement(
             "sns:*",
             id)]
 [/#function]
 
-[#function snsPublishPermission id="" ]
+[#function snsPublishPermission id="" principals="*" conditions={} allow=true sid="" ]
     [#return
         getSnsStatement(
-            "sns:Publish",
-            id)]
+            [
+                "sns:Publish"
+            ],
+            id,
+            principals,
+            conditions,
+            allow,
+            sid
+        )]
 [/#function]
 
 [#function snsSMSPermission ]


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)


## Description

- Moves the topic policy creation from the linking components to the topic component itself
- Adds support for providing a Sid on SNS topic policy statements
- Adds warnings and fatal exceptions for topic links that used the old policy approach

## Motivation and Context

While the SNS topic policy is a separate resource to the topic the policy resource can only be applied to a single topic once. Any further use of the topic policy overrides the existing policy. 

This update moves to defining a single policy on the topic component and requires permissions for topics to be set on the topic through inbound links instead of as part of the component sending data to the topic 

Warnings and errors have been included on the links that are effected 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1859

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- Users who are using MTA or S3 component notifications to SNS topics will need to add an inbound link on each topic that receives notifications. The link should be to the MTA or S3 component with Direction set to inbound and role set to invoke. 

