### PR TITLE
fix: Kinesis delivery stream S3 permissions

### DIFF
--- a/aws/components/datafeed/state.ftl
+++ b/aws/components/datafeed/state.ftl
@@ -38,13 +38,13 @@
                     },
                     "backuplgstream" : {
                         "Id" : formatDependentResourceId(AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE, lgId, "backup"),
-                        "Name" : "S3Delivery",
+                        "Name" : "Backup",
                         "Type" : AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE,
                         "IncludeInDeploymentState" : false
                     },
                     "streamlgstream" : {
                         "Id" : formatDependentResourceId(AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE, lgId, "stream"),
-                        "Name" : "ElasticsearchDelivery",
+                        "Name" : "Delivery",
                         "Type" : AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE,
                         "IncludeInDeploymentState" : false
                     }

--- a/aws/components/datafeed/state.ftl
+++ b/aws/components/datafeed/state.ftl
@@ -38,13 +38,13 @@
                     },
                     "backuplgstream" : {
                         "Id" : formatDependentResourceId(AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE, lgId, "backup"),
-                        "Name" : "Backup",
+                        "Name" : "S3Delivery",
                         "Type" : AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE,
                         "IncludeInDeploymentState" : false
                     },
                     "streamlgstream" : {
                         "Id" : formatDependentResourceId(AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE, lgId, "stream"),
-                        "Name" : "Delivery",
+                        "Name" : "ElasticsearchDelivery",
                         "Type" : AWS_CLOUDWATCH_LOG_GROUP_STREAM_RESOURCE_TYPE,
                         "IncludeInDeploymentState" : false
                     }

--- a/aws/services/kinesis/resource.ftl
+++ b/aws/services/kinesis/resource.ftl
@@ -167,7 +167,10 @@
             [#case S3_COMPONENT_TYPE]
 
                 [#-- Handle target encryption --]
-                [#local isEncrypted = destinationSolution.Encryption.Enabled]
+                [#local isEncrypted =
+                    destinationSolution.Encryption.Enabled &&
+                    destinationSolution.Encryption.EncryptionSource == "EncryptionService" ]
+
                 [#if isEncrypted && !(cmkKeyId?has_content)]
                     [@fatal
                         message="Destination is encrypted, but CMK not provided."


### PR DESCRIPTION

## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
- when a delivery stream destination is an S3 bucket, ensure that the encryption configuration aligns with that of the bucket
- name processing log streams to better reflect their function
- correct an issue where creation of log subscriptions in an lg subset was failing because the iam resources needed to access a delivery stream were not being created.


## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->

## How Has This Been Tested?
- Template processing was failing
- Log consolidation was failing due to the presence of KMS encrypted objects

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

