### PR TITLE
fix: per AZ vpc endpoints

### DIFF
--- a/aws/components/gateway/state.ftl
+++ b/aws/components/gateway/state.ftl
@@ -315,7 +315,7 @@
     [#local parentSolution = parent.Configuration.Solution ]
     [#local engine = parentSolution.Engine ]
 
-    [#if multiAZ!false || ( engine == "vpcendpoint" || engine == "privateservice" ) ]
+    [#if (multiAZ!false) || ( engine == "vpcendpoint" || engine == "privateservice" ) ]
         [#local resourceZones = getZones() ]
     [#else]
         [#local resourceZones = [getZones()[0]] ]
@@ -349,7 +349,6 @@
 
         [#case "vpcendpoint"]
         [#case "privateservice"]
-
             [#local endpointZones = {} ]
             [#list resourceZones as zone]
                 [#local networkEndpoints = getNetworkEndpoints(solution.NetworkEndpointGroups, zone.Id, getRegion())]

--- a/aws/inputseeders/aws/regions.json
+++ b/aws/inputseeders/aws/regions.json
@@ -221,6 +221,10 @@
                         "ServiceName": "com.amazonaws.ap-southeast-2.kinesis-streams"
                     },
                     {
+                        "ServiceName": "com.amazonaws.ap-southeast-2.kinesis-firehose",
+                        "Type": "Interface"
+                    },
+                    {
                         "Type": "Interface",
                         "ServiceName": "com.amazonaws.ap-southeast-2.kms"
                     },
@@ -345,6 +349,10 @@
                     },
                     {
                         "ServiceName": "com.amazonaws.ap-southeast-2.kinesis-streams",
+                        "Type": "Interface"
+                    },
+                    {
+                        "ServiceName": "com.amazonaws.ap-southeast-2.kinesis-firehose",
                         "Type": "Interface"
                     },
                     {
@@ -473,6 +481,10 @@
                     {
                         "Type": "Interface",
                         "ServiceName": "com.amazonaws.ap-southeast-2.kinesis-streams"
+                    },
+                    {
+                        "ServiceName": "com.amazonaws.ap-southeast-2.kinesis-firehose",
+                        "Type": "Interface"
                     },
                     {
                         "Type": "Interface",


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Correct defaulting logic to ensure vpc endpoints are defined in all defined zones.

Also add the kinesis firehose vpc endpoints for ap-southeast-2.

## Motivation and Context
The missing value operator was being too greedy resulting in the ignoring of code to detect when vpc endpoints are being created.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

