### PR TITLE
fix: kinesis firehose s3 record delimiters

### DIFF
--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -311,7 +311,8 @@
                                                 streamLoggingConfiguration,
                                                 solution.Backup.Enabled,
                                                 streamS3BackupDestination,
-                                                streamProcessors
+                                                streamProcessors,
+                                                r"\n"
                 )]
 
                 [@createFirehoseStream


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Add support for appending delimiters to Kinesis records.

## Motivation and Context
When writing to S3, firehose does not include a delimiter by default but does provide a processor to enabled this to occur.

While a lambda processor could add delimiters, it seems cleaner and more consistent to use the delimiter processor.

All delivery streams targetting S3 will now add a linefeed delimiter.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

