### PR TITLE
fix(ecs): support aws prefix for awsvpc

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -661,7 +661,11 @@
         [#local taskName = resources["task"].Name ]
         [#local containers = getTaskContainers(occurrence, subOccurrence) ]
 
-        [#local networkMode = solution.NetworkMode ]
+        [#local networkMode = solution.NetworkMode]
+        [#if solution.NetworkMode == "aws:awsvpc"]
+            [#local networkMode = "awsvpc"]
+        [/#if]
+
         [#local lbTargetType = "instance"]
         [#local networkLinks = [] ]
         [#local executionRoleId = ""]

--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -220,7 +220,12 @@
 
     [#local parentResources = parent.State.Resources ]
 
-    [#if solution.NetworkMode == "awsvpc" ]
+    [#local networkMode = solution.NetworkMode]
+    [#if solution.NetworkMode == "aws:awsvpc"]
+        [#local networkMode = "awsvpc"]
+    [/#if]
+
+    [#if networkMode== "awsvpc" ]
         [#local securityGroupId = formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id ) ]
     [#else]
         [#local securityGroupId = parentResources["securityGroup"].Id ]
@@ -318,7 +323,7 @@
             ) +
             attributeIfTrue(
                 "securityGroup",
-                solution.NetworkMode == "awsvpc",
+                networkMode == "awsvpc",
                 {
                     "Id" : securityGroupId,
                     "Name" : core.FullName,
@@ -387,7 +392,12 @@
 
     [#local subnet = (getSubnets(core.Tier, networkResources))[0]]
 
-    [#if solution.NetworkMode == "awsvpc" ]
+    [#local networkMode = solution.NetworkMode]
+    [#if solution.NetworkMode == "aws:awsvpc"]
+        [#local networkMode = "awsvpc"]
+    [/#if]
+
+    [#if networkMode == "awsvpc" ]
         [#local securityGroupId = formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id ) ]
     [#else]
         [#local securityGroupId = parentResources["securityGroup"].Id ]
@@ -476,7 +486,7 @@
             ) +
             attributeIfTrue(
                 "securityGroup",
-                solution.NetworkMode == "awsvpc",
+                networkMode == "awsvpc",
                 {
                     "Id" : securityGroupId,
                     "Name" : core.FullName,
@@ -501,12 +511,12 @@
             ) +
             attributeIfTrue(
                 "SECURITY_GROUP",
-                solution.NetworkMode == "awsvpc",
+                networkMode == "awsvpc",
                 getExistingReference(securityGroupId)
             ) +
             attributeIfTrue(
                 "SUBNET",
-                solution.NetworkMode == "awsvpc",
+                networkMode == "awsvpc",
                 subnet
             ),
             "Roles" : {


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

- Adds support for the aws: prefix when using awsvpc mode as well as supporting the default prefix

## Motivation and Context

When using the aws: prefix for awsvpc mode the template generation fails

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

