### PR TITLE
feat(ecs): secret injection support

### DIFF
--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -299,6 +299,11 @@
                     "Id" : taskId,
                     "Name" : taskName,
                     "Type" : AWS_ECS_TASK_RESOURCE_TYPE
+                },
+                "executionRole" : {
+                    "Id" : formatDependentRoleId(taskId, "execution"),
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
                 }
             } +
             solution.TaskLogGroup?then(
@@ -330,15 +335,6 @@
                     "Ports" : availablePorts,
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 }) +
-            attributeIfTrue(
-                "executionRole",
-                (solution.Engine == "fargate" || solution.Engine == "aws:fargate"),
-                {
-                    "Id" : formatDependentRoleId(taskId, "execution"),
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
-                    "IncludeInDeploymentState" : false
-                }
-            ) +
             autoScaling,
             "Attributes" : {
                 "ARN": getArn(serviceId)

--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -449,6 +449,11 @@
                     "Name" : taskName,
                     "Type" : AWS_ECS_TASK_RESOURCE_TYPE
                 },
+                "executionRole" : {
+                    "Id" : executionRoleId,
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
+                    "IncludeInDeploymentState" : false
+                }
                 "schedules" : schedules
             } +
             solution.TaskLogGroup?then(
@@ -487,14 +492,6 @@
                     "Id" : securityGroupId,
                     "Name" : core.FullName,
                     "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
-                }) +
-            attributeIfTrue(
-                "executionRole",
-                ( solution.Engine == "fargate" || solution.Engine == "aws:fargate"),
-                {
-                    "Id" : executionRoleId,
-                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
-                    "IncludeInDeploymentState" : false
                 }
             ),
             "Attributes" : {

--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -453,7 +453,7 @@
                     "Id" : executionRoleId,
                     "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
                     "IncludeInDeploymentState" : false
-                }
+                },
                 "schedules" : schedules
             } +
             solution.TaskLogGroup?then(

--- a/aws/components/secretstore/id.ftl
+++ b/aws/components/secretstore/id.ftl
@@ -31,6 +31,7 @@
     resourceGroup=DEFAULT_RESOURCE_GROUP
     services=
         [
-            AWS_SECRETS_MANAGER_SERVICE
+            AWS_SECRETS_MANAGER_SERVICE,
+            AWS_KEY_MANAGEMENT_SERVICE
         ]
 /]

--- a/aws/services/secretsmanager/policy.ftl
+++ b/aws/services/secretsmanager/policy.ftl
@@ -1,0 +1,32 @@
+[#ftl]
+
+[#function getSecretsManagerStatement actions id principals="" conditions="" allow=true sid="" ]
+    [#return
+        [
+            getPolicyStatement(
+                actions,
+                getArn(id),
+                principals,
+                conditions,
+                allow,
+                sid
+            )
+        ]]
+[/#function]
+
+
+[#function secretsManagerReadPermission id kmsKeyId principals="" conditions={} allow=true sid="" ]
+    [#return
+        getSecretsManagerStatement(
+            [
+                "secretsmanager:GetSecretValue"
+            ],
+            id,
+            principals,
+            conditions,
+            allow,
+            sid
+        ) +
+        cmkDecryptPermission(kmsKeyId)
+        ]
+[/#function]


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Updates the execution role processing for ECS tasks to support the permissions required to access secret manage secrets
- Adds outbound roles when linking to a secret for read permissions
- Adds the configuration required in Task Definitions to reference secrets
-  Adds policies for Secrets manager secret access

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for secret manager secrets to be referenced in task definitions within ECS. When a new task starts up ECS will retrieve the specified secret value and set it as an environment variable 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1864

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

