### PR TITLE
feat(kinesis): Finer grained partition control

### DIFF
--- a/aws/components/apigateway/id.ftl
+++ b/aws/components/apigateway/id.ftl
@@ -21,6 +21,18 @@
                     "Description" : "Prevent the destruction of existing LogGroups when enabling KinesisFirehose.",
                     "Types" : BOOLEAN_TYPE,
                     "Default" : true
+                },
+                {
+                    "Names" : "aws:LogFormat",
+                    "Description" : "Log format control",
+                    "Children" : [
+                        {
+                            "Names" : "Syntax",
+                            "Types" : STRING_TYPE,
+                            "Values" : ["text", "json"],
+                            "Default" : "text"
+                        }
+                    ]
                 }
             ]
         }

--- a/aws/components/datafeed/id.ftl
+++ b/aws/components/datafeed/id.ftl
@@ -7,6 +7,36 @@
             "Description" : "Feed is intended for use with WAF. Enforces a strict naming convention required by the provider.",
             "Types" : BOOLEAN_TYPE,
             "Default" : false
+        },
+        {
+            "Names" : "Partitioning",
+            "Description" : "Control configuration of dynamic partitioning",
+            "Children" : [
+                {
+                    "Names" : "Enabled",
+                    "Description" : "Partitioning can only be set at time of creation so default it to false to cover existing deployments",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Names" : "Delimiter",
+                    "Description" : "Control configuration of delimiter processor",
+                    "Children" : [
+                        {
+                            "Names" : "Enabled",
+                            "Description" : "Delimiter processor is added after any lambda processors",
+                            "Types" : BOOLEAN_TYPE,
+                            "Default" : false
+                        },
+                        {
+                            "Names" : "Token",
+                            "Description" : "String added to the end of every datafeed record",
+                            "Types" : STRING_TYPE,
+                            "Default" : r"\n"
+                        }
+                    ]
+                }
+            ]
         }
     ]
     provider=AWS_PROVIDER

--- a/aws/services/kinesis/resource.ftl
+++ b/aws/services/kinesis/resource.ftl
@@ -121,8 +121,7 @@
     cloudwatchEnabled=true
     processorId=""
     cmkKeyId=""
-    dependencies=""
-    delimiter=r"\n" ]
+    dependencies="" ]
 
     [#local logPrefix  = {
             "Fn::Join" : [
@@ -228,8 +227,7 @@
                                 bufferSize
                             )
                         ],
-                        []),
-                        delimiter
+                        [])
                     )]
 
                 [#break]
@@ -417,21 +415,26 @@
         backupEnabled
         backupS3Destination
         lambdaProcessor=[]
+        dynamicPartitioningEnabled=false
         delimiter=""
+]
+
+[#local dynamicPartitioningRequired =
+    dynamicPartitioningEnabled &&
+    (
+        delimiter?has_content ||
+        prefixRequiresDynamicPartitioning(bucketPrefix) ||
+        prefixRequiresDynamicPartitioning(errorPrefix)
+    )
 ]
 
 [#local processors =
     asArray(lambdaProcessor) +
     arrayIfTrue(
         getFirehoseStreamDelimiterProcessor(delimiter),
+        dynamicPartitioningEnabled &&
         delimiter?has_content
     )
-]
-
-[#local dynamicPartitioningRequired =
-    delimiter?has_content ||
-    prefixRequiresDynamicPartitioning(bucketPrefix) ||
-    prefixRequiresDynamicPartitioning(errorPrefix)
 ]
 
 [#return


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description
- add solution configuration to permit configuration of the use of dynamic partitioning
- check conditions where partitioning should/shouldn't be enabled
- explicitly add line endings to firehose records for the api gateway, removing the need to use delimiters and partitioning if just directing logs to S3
- add config to the API gateway to permit control over the syntax used to format log records (text/json) - this applies to cloudwatch and firehose logs
- set defaults so existing  firehose deployments don't break, noting that partition settings can only be set when a firehose is created.



## Motivation and Context
Fixes https://github.com/hamlet-io/engine/issues/1863

A subsequent change will refine the information included in the API Gateway logs reflecting the functionality employed (waf, authorizer, integration).


## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

