### PR TITLE
feat: db secretstore support

### DIFF
--- a/aws/components/directory/state.ftl
+++ b/aws/components/directory/state.ftl
@@ -34,7 +34,7 @@
         [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
         [#local cmkKeyId = baselineComponentIds["Encryption" ]]
-        [#local secretLink = getLinkTarget(occurrence, solution.RootCredentials.Secret.Link, false)]
+        [#local secretLink = getLinkTarget(occurrence, solution.RootCredentials.Link, false)]
 
         [#local resources = mergeObjects(
                     resources,

--- a/aws/components/directory/state.ftl
+++ b/aws/components/directory/state.ftl
@@ -29,6 +29,13 @@
     }]
 
     [#if solution.RootCredentials.Secret.Source == "generated" ]
+
+        [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption"] )]
+        [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+
+        [#local cmkKeyId = baselineComponentIds["Encryption" ]]
+        [#local secretLink = getLinkTarget(occurrence, solution.RootCredentials.Secret.Link, false)]
+
         [#local resources = mergeObjects(
                     resources,
                     {
@@ -36,6 +43,8 @@
                                                 occurrence,
                                                 "Admin",
                                                 "Admin",
+                                                cmkKeyId,
+                                                secretLink.Configuration.Solution.Engine,
                                                 "Admin credentials for directory services"
                                             )
                     }

--- a/aws/components/queuehost/state.ftl
+++ b/aws/components/queuehost/state.ftl
@@ -11,10 +11,18 @@
     [#local segmentSeedId = formatSegmentSeedId() ]
     [#local segmentSeed = getExistingReference(segmentSeedId)]
 
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption"] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+
+    [#local cmkKeyId = baselineComponentIds["Encryption" ]]
+    [#local secretLink = getLinkTarget(occurrence, solution.RootCredentials.Secret.Link, false)]
+
     [#local rootCredentialResources = getComponentSecretResources(
                                         occurrence,
                                         "root",
                                         "root",
+                                        cmkKeyId,
+                                        secretLink.Configuration.Solution.Engine,
                                         "Root credentials for broker"
                                     )]
 

--- a/aws/components/queuehost/state.ftl
+++ b/aws/components/queuehost/state.ftl
@@ -15,7 +15,7 @@
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local cmkKeyId = baselineComponentIds["Encryption" ]]
-    [#local secretLink = getLinkTarget(occurrence, solution.RootCredentials.Secret.Link, false)]
+    [#local secretLink = getLinkTarget(occurrence, solution.RootCredentials.SecretStore, false)]
 
     [#local rootCredentialResources = getComponentSecretResources(
                                         occurrence,

--- a/aws/services/secretsmanager/resource.ftl
+++ b/aws/services/secretsmanager/resource.ftl
@@ -30,13 +30,15 @@
     ]
 [/#function]
 
-[#function getComponentSecretResources occurrence secretId secretName secretDescription="" ]
+[#function getComponentSecretResources occurrence secretId secretName cmkKeyId provider secretDescription="" ]
     [#return {
         "secret" : {
             "Id" : formatResourceId(AWS_SECRETS_MANAGER_SECRET_RESOURCE_TYPE, occurrence.Core.Id, secretId),
             "Name" : formatName(occurrence.Core.FullName, secretName),
             "Description" : secretDescription,
-            "Type" : AWS_SECRETS_MANAGER_SECRET_RESOURCE_TYPE
+            "Type" : AWS_SECRETS_MANAGER_SECRET_RESOURCE_TYPE,
+            "cmkKeyId" : cmkKeyId,
+            "Provider" : provider
         }
     }]
 [/#function]

--- a/awstest/modules/db/module.ftl
+++ b/awstest/modules/db/module.ftl
@@ -192,6 +192,82 @@
         }
     /]
 
+    [#-- Generated creds --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "db" : {
+                    "Components" : {
+                        "postgresdbsecretstore" : {
+                            "Type" : "db",
+                            "deployment:Unit" : "aws-db-postgres-secretstore",
+                            "Engine" : "postgres",
+                            "EngineVersion" : "11",
+                            "Profiles" : {
+                                "Testing" : [ "postgresdbsecretstore" ]
+                            },
+                            "rootCredential:Source" : "SecretStore",
+                            "rootCredential:SecretStore" : {
+                                "Link" : {
+                                    "Tier" : "db",
+                                    "Component": "postgresdbsecretstore-secretstore"
+                                }
+                            }
+                        },
+                        "postgresdbsecretstore-secretstore" : {
+                            "Type" : "secretstore",
+                            "deployment:Unit" : "aws-db-postgres-secretstore",
+                            "Engine" : "aws:secretsmanager"
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "postgresdbsecretstore" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "rdsInstance" : {
+                                    "Name" : "rdsXdbXpostgresdbsecretstore",
+                                    "Type" : "AWS::RDS::DBInstance"
+                                },
+                                "secret" : {
+                                    "Name" : "secretXdbXpostgresdbsecretstoreXRootCredentials",
+                                    "Type" : "AWS::SecretsManager::Secret"
+                                }
+                            },
+                            "Output" : [
+                                "rdsXdbXpostgresdbsecretstoreXdns",
+                                "rdsXdbXpostgresdbsecretstoreXport",
+                                "secretXdbXpostgresdbsecretstoreXRootCredentialsXarn"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "SecretGeneration" : {
+                                    "Path"  : "Resources.secretXdbXpostgresdbsecretstoreXRootCredentials.Properties.GenerateSecretString.SecretStringTemplate",
+                                    "Value" : getJSON({"username": "root"})
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "postgresdbsecretstore" : {
+                    "db" : {
+                        "TestCases" : [ "postgresdbsecretstore" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
+                    }
+                }
+            }
+        }
+    /]
+
+
     [#-- Maintenance Windows --]
     [@loadModule
         blueprint={


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the provider and CMK key id for secrets generated as part of components
- Adds support for create a secrets manager secret as part of the db component build
- Adds support for using different settings for settings based root credentials
- Refactors state routine to add to a standard set of resources, attributes and roles

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Adding support for AWS secrets manager allows for deeper integration between AWS services including ECS which has native support for secrets manager integration and allows for easy discovery of secrets when required by teams who need access to the db

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1865

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

