### PR TITLE
feat(kinesis): Prefix time path control

### DIFF
--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -268,11 +268,20 @@
                 [#-- Establish bucket prefixes --]
                 [#local prefixIncludes = [ ] ]
                 [#list includeOrder as includePrefix ]
-                    [#if includePrefix == "AccountId" && solution.Bucket.Include.AccountId ]
-                        [#local prefixIncludes += [ { "Ref" : "AWS::AccountId" } ]]
-                    [/#if]
-                    [#if includePrefix == "ComponentPath" && solution.Bucket.Include.ComponentPath ]
-                        [#local prefixIncludes += [ occurrence.Core.FullRelativePath?ensure_ends_with("/") ]]
+                    [#if solution.Bucket.Include[includePrefix]!false]
+                        [#switch includePrefix]
+                            [#case "AccountId" ]
+                                [#local prefixIncludes += [ { "Ref" : "AWS::AccountId" } ] ]
+                                [#break]
+
+                            [#case "ComponentPath" ]
+                                [#local prefixIncludes += [ occurrence.Core.FullRelativePath?remove_ending("/") ] ]
+                                [#break]
+
+                            [#case "TimePath" ]
+                                [#local prefixIncludes += [ "!{timestamp:yyyy/MM/dd/HH}" ]]
+                                [#break]
+                        [/#switch]
                     [/#if]
                 [/#list]
 
@@ -280,7 +289,8 @@
                     "Fn::Join" : [
                         "/",
                         [  (solution.Bucket.Prefix)?remove_ending("/") ] +
-                        prefixIncludes
+                        prefixIncludes +
+                        ["/"]
                     ]
                 }]
 
@@ -288,7 +298,8 @@
                     "Fn::Join" : [
                         "/",
                         [ (solution.Bucket.ErrorPrefix)?remove_ending("/") ] +
-                        prefixIncludes
+                        prefixIncludes +
+                        ["/"]
                     ]
                 }]
 


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add the ability to include the year, month, day and hour in the prefix.

## Motivation and Context
While the time path is added automatically when not using partitioning, it must be explicitly added when partitioning is used.


## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

