### PR TITLE
feat(kinesis): ErrorType in prefix

### DIFF
--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -267,19 +267,27 @@
 
                 [#-- Establish bucket prefixes --]
                 [#local prefixIncludes = [ ] ]
+                [#local errorPrefixIncludes = [ ] ]
                 [#list includeOrder as includePrefix ]
                     [#if solution.Bucket.Include[includePrefix]!false]
                         [#switch includePrefix]
                             [#case "AccountId" ]
                                 [#local prefixIncludes += [ { "Ref" : "AWS::AccountId" } ] ]
+                                [#local errorPrefixIncludes += [ { "Ref" : "AWS::AccountId" } ] ]
                                 [#break]
 
                             [#case "ComponentPath" ]
                                 [#local prefixIncludes += [ occurrence.Core.FullRelativePath?remove_ending("/") ] ]
+                                [#local errorPrefixIncludes += [ occurrence.Core.FullRelativePath?remove_ending("/") ] ]
                                 [#break]
 
                             [#case "TimePath" ]
                                 [#local prefixIncludes += [ "!{timestamp:yyyy/MM/dd/HH}" ]]
+                                [#local errorPrefixIncludes += [ "!{timestamp:yyyy/MM/dd/HH}" ]]
+                                [#break]
+
+                            [#case "ErrorType" ]
+                                [#local errorPrefixIncludes += [ "!{firehose:error-output-type}" ]]
                                 [#break]
                         [/#switch]
                     [/#if]
@@ -298,7 +306,7 @@
                     "Fn::Join" : [
                         "/",
                         [ (solution.Bucket.ErrorPrefix)?remove_ending("/") ] +
-                        prefixIncludes +
+                        errorPrefixIncludes +
                         ["/"]
                     ]
                 }]


### PR DESCRIPTION


## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add ability to explicitly include error type in prefix.

## Motivation and Context
This only applies to the error prefix. For partitioning the error type must be present in the error prefix.

The error type has been put after the time path to maintain consistency with the good data path. Investigations also tend to focus on what happened at a particular time so having the error types after the time path collects all error types under a single point.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

