### PR TITLE
fix(directory): handle the rename of root to Admin

### DIFF
--- a/aws/components/directory/setup.ftl
+++ b/aws/components/directory/setup.ftl
@@ -105,7 +105,7 @@
                     message="Root user used for older AD deployments"
                     detail="The username will be Admin instead of root"
                 /]
-            [#elseif ! directory.Username == "Admin" ]
+            [#elseif ! (directory.Username == "Admin") ]
                 [@fatal
                     message="Invalid username for directory engine"
                     detail="Only the user name Admin is permitted"

--- a/aws/components/directory/setup.ftl
+++ b/aws/components/directory/setup.ftl
@@ -100,7 +100,12 @@
     [#switch solution.Engine ]
         [#case "Simple"]
         [#case "ActiveDirectory" ]
-            [#if ((directory.Username)!"") != "Admin" ]
+            [#if directory.Username == "root" ]
+                [@warn
+                    message="Root user used for older AD deployments"
+                    detail="The username will be Admin instead of root"
+                /]
+            [#elseif ! directory.Username == "Admin" ]
                 [@fatal
                     message="Invalid username for directory engine"
                     detail="Only the user name Admin is permitted"

--- a/aws/components/directory/state.ftl
+++ b/aws/components/directory/state.ftl
@@ -41,8 +41,8 @@
                     {
                         "rootCredentials" : getComponentSecretResources(
                                                 occurrence,
-                                                "Admin",
-                                                "Admin",
+                                                solution.RootCredentials.Username,
+                                                solution.RootCredentials.Username,
                                                 cmkKeyId,
                                                 secretLink.Configuration.Solution.Engine,
                                                 "Admin credentials for directory services"


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->

- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Allows the use of the username root for directory components to align with legacy deployments
- Uses the username provided to form the id of the secret generated if that is being used

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Directory was being replaced when the new Admin credentials were being used

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with generated deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

