### PR TITLE
fix(network): add outputs for key vpc resources

### DIFF
--- a/aws/services/vpc/resource.ftl
+++ b/aws/services/vpc/resource.ftl
@@ -292,6 +292,19 @@
     /]
 [/#macro]
 
+[#assign AWS_VPC_SECURITY_GROUP_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
+    mappings=AWS_VPC_SECURITY_GROUP_OUTPUT_MAPPINGS
+/]
+
 [#macro createSecurityGroup id name vpcId occurrence description="" ]
     [@cfResource
         id=id
@@ -310,9 +323,23 @@
                 occurrence.Core.Tier,
                 occurrence.Core.Component
             )
+        outputs=AWS_VPC_SECURITY_GROUP_OUTPUT_MAPPINGS
     /]
 
 [/#macro]
+
+[#assign AWS_VPC_FLOWLOG_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_VPC_FLOWLOG_RESOURCE_TYPE
+    mappings=AWS_VPC_FLOWLOG_OUTPUT_MAPPINGS
+/]
 
 [#macro createFlowLog
             id
@@ -395,6 +422,7 @@
                 },
                 {}
             )
+        outputs=AWS_VPC_FLOWLOG_OUTPUT_MAPPINGS
     /]
 [/#macro]
 
@@ -436,6 +464,19 @@
     /]
 [/#macro]
 
+[#assign AWS_VPC_IGW_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_VPC_IGW_RESOURCE_TYPE
+    mappings=AWS_VPC_IGW_OUTPUT_MAPPINGS
+/]
+
 [#macro createIGW
             id
             name
@@ -447,6 +488,7 @@
         type="AWS::EC2::InternetGateway"
         tags=getCfTemplateCoreTags(name)
         outputId=id
+        outputs=AWS_VPC_IGW_OUTPUT_MAPPINGS
     /]
 [/#macro]
 
@@ -519,6 +561,19 @@
 
     /]
 [/#macro]
+
+[#assign AWS_VPC_ROUTE_TABLE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_VPC_ROUTE_TABLE_RESOURCE_TYPE
+    mappings=AWS_VPC_ROUTE_TABLE_OUTPUT_MAPPINGS
+/]
 
 [#macro createRouteTable
             id
@@ -624,6 +679,19 @@
     /]
 [/#macro]
 
+[#assign AWS_VPC_NETWORK_ACL_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_VPC_NETWORK_ACL_RESOURCE_TYPE
+    mappings=AWS_VPC_NETWORK_ACL_OUTPUT_MAPPINGS
+/]
+
 [#macro createNetworkACL
             id,
             name,
@@ -636,7 +704,7 @@
                 "VpcId" : getReference(vpcId)
             }
         tags=getCfTemplateCoreTags(name)
-        outputs={}
+        outputs=AWS_VPC_NETWORK_ACL_OUTPUT_MAPPINGS
     /]
 [/#macro]
 
@@ -724,6 +792,19 @@
     /]
 [/#macro]
 
+[#assign AWS_VPC_SUBNET_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_VPC_SUBNET_TYPE
+    mappings=AWS_VPC_SUBNET_OUTPUT_MAPPINGS
+/]
+
 [#macro createSubnet
             id,
             name,
@@ -755,6 +836,7 @@
         tags=
             tags +
             getCfTemplateCoreTags(name, tier, "", zone)
+        outputs=AWS_VPC_SUBNET_OUTPUT_MAPPINGS
     /]
 [/#macro]
 
@@ -809,6 +891,19 @@
     /]
 [/#macro]
 
+[#assign AWS_VPC_VPCENDPOINT_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_VPC_VPCENDPOINT_RESOURCE_TYPE
+    mappings=AWS_VPC_VPCENDPOINT_OUTPUT_MAPPINGS
+/]
+
 [#macro createVPCEndpoint
             id,
             vpcId,
@@ -846,10 +941,22 @@
                 },
                 {}
             )
-
-        outputs={}
+        outputs=AWS_VPC_VPCENDPOINT_OUTPUT_MAPPINGS
     /]
 [/#macro]
+
+[#assign AWS_VPC_ENDPOINT_SERVICE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_VPC_ENDPOINT_SERVICE_RESOURCE_TYPE
+    mappings=AWS_VPC_ENDPOINT_SERVICE_OUTPUT_MAPPINGS
+/]
 
 [#macro createVPCEndpointService
     id
@@ -866,6 +973,7 @@
             "NetworkLoadBalancerArns" : getReferences(loadBalancerIds, ARN_ATTRIBUTE_TYPE)
         }
         dependencies=dependencies
+        outputs=AWS_VPC_ENDPOINT_SERVICE_OUTPUT_MAPPINGS
     /]
 [/#macro]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->

- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds outputs for key vpc based resources to ensure deployment checks pass for subcomponents

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When generating segment level components the VPC route table components weren't creating outputs which meant that none of the resources in the RouteTable subcomponent were considered deployed. This created warnings that could not be resolve by users

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

