### PR TITLE
feat(apigateway): Execution Log Control

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -487,6 +487,10 @@
             logGroupName=executionLgName
             loggingProfile=loggingProfile
         /]
+    [#else]
+        [@warn
+            message="The API gateway must be run at least twice if log subscriptions are required"
+        /]
     [/#if]
 
     [#if deploymentSubsetRequired("apigateway", true)]

--- a/aws/components/apigateway/state.ftl
+++ b/aws/components/apigateway/state.ftl
@@ -127,17 +127,13 @@ created in either case.
     [#local certificateId = "" ]
 
     [#local lgId = formatDependentLogGroupId(stageId) ]
-    [#local lgName = {
-                        "Fn::Join" : [
-                            "",
-                            [
-                                "API-Gateway-Execution-Logs_",
-                                getExistingReference(apiId),
-                                "/",
-                                stageName
-                            ]
-                        ]
-                    }]
+    [#local lgName = [
+            "API-Gateway-Execution-Logs_",
+            getExistingReference(apiId),
+            "/",
+            stageName
+        ]?join("")
+    ]
 
     [#local accessLgId = formatDependentLogGroupId(stageId, "access") ]
     [#local accessLgName = formatAbsolutePath(core.FullAbsolutePath, "access")]


### PR DESCRIPTION

## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Support subscriptions and retention control on the execution log.

## Motivation and Context
The primary driver for this change is to permit the inclusion of execution logs in the log consolidation process via a log subscription.

Because the api gateway does not permit control over the execution log group name and includes the api id in the name it creates, special logic is required to control log group retention (normally set when creating the log group) and to create log subscriptions on the log group, for instance for log consolidation.

The change creates a pseudo stack for the execution log group and sets its retention according to the operational expiration setting.

In order that subscription processing works the same as if the execution log group could be created, the deployment unit of the pseudo stack is set to match what is used for the access log group. This also makes for a straightforward transition in the future to explicit control of the log group creation if/when AWS supports it.


## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- engine - https://github.com/hamlet-io/engine/pull/1869
- executor-bash - https://github.com/hamlet-io/executor-bash/pull/300

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

