### PR TITLE
fix: ebs volume zone lookup

### DIFF
--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -445,7 +445,7 @@
         id=id
         type="AWS::EC2::Volume"
         properties={
-            "AvailabilityZone" : getCFAWSAzReference(zone.AWSZone),
+            "AvailabilityZone" : getCFAWSAzReference(zone.Id),
             "VolumeType" : volumeType,
             "Size" : size
         } +


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->

- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Fixes the zone Id used when determining the AWS availability zone to use for an ebs volume

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Template generation was creating a template with an invalid parameter lookup

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

