### PR TITLE
fix(s3): allow for notifications to be disabled

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -105,7 +105,7 @@
                 [/#if]
 
                 [#list subSolution.Notifications as id,notification ]
-                    [#if notification?is_hash]
+                    [#if notification?is_hash && notification.Enabled]
                         [#list notification.Links?values as link]
                             [#if link?is_hash]
                                 [#local linkTarget = getLinkTarget(subOccurrence, link, false) ]

--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -43,7 +43,7 @@
     [#local notifications = []]
 
     [#list solution.Notifications as id,notification ]
-        [#if notification?is_hash]
+        [#if notification?is_hash && notification.Enabled ]
             [#list notification.Links?values as link]
                 [#if link?is_hash]
                     [#local linkTarget = getLinkTarget(occurrence, link, false) ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds support for checking the enabled state of s3 notifications

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Required to work with the deployment dependencies that are setup between SNS topic policies and S3 notification configurations

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1873

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

