### PR TITLE
feat: ensure inline code changes on update

### DIFF
--- a/aws/extensions/cfredirect/README.md
+++ b/aws/extensions/cfredirect/README.md
@@ -1,0 +1,28 @@
+# cfredirect Hamlet Extension
+
+This is a Hamlet Deploy extension.
+
+See docs.hamlet.io for more information.
+
+## Description
+
+An AWS Lambda@Edge function used to send 301 redirections from any domains which are not the primary domain.
+
+The header **_X-Redirect-Primary-Domain-Name_** defines the primary domain name where requests should be redirected.
+
+## Provider
+
+`shared`
+
+## Aliases
+
+- `_cfredirect-v1`
+
+## Supported Types
+
+- `lambda`
+- `function`
+
+## Entrances
+
+- deployment

--- a/aws/extensions/cfredirect/extension.ftl
+++ b/aws/extensions/cfredirect/extension.ftl
@@ -1,0 +1,96 @@
+[#ftl]
+
+[@addExtension
+    id="cfredirect"
+    aliases=[
+        "_cfredirect-v1"
+    ]
+    description=[
+        "AWS Lambda@Edge function used to send 301 redirections from any domains which are not the primary domain",
+        "Headers from the CDN control how the redirect is performed",
+        "  - X-Redirect-Primary-Domain-Name defines the primary domain name where requests should be redirected",
+        "  - X-Redirect-Response-Code (Default: 301) sets the redirect response code to use ( 301, 302)",
+        "  - X-Redirect-Fixed-Path (Optional) sets a fixed path to use for all redirects"
+    ]
+    supportedTypes=[
+        LAMBDA_COMPONENT_TYPE,
+        LAMBDA_FUNCTION_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_cfredirect_deployment_setup occurrence ]
+
+    [@DefaultLinkVariables enabled=false /]
+    [@DefaultCoreVariables enabled=false /]
+    [@DefaultEnvironmentVariables enabled=false /]
+    [@DefaultBaselineVariables enabled=false /]
+
+    [#local redirectScript = [
+        "'use strict';",
+        "/* This function is used to perform redirects when an application has moved domains",
+        "    Any request that does not have a host header which matches the Primary Domain",
+        "    will be redirected to the same location with the new domain name */",
+        "exports.handler = (event, context, callback) => {",
+        "    const request = event.Records[0].cf.request;",
+        "    const headers = request.headers;",
+        "    const host = headers.host[0].value.toLowerCase();",
+        "    if ( request.origin.custom ) {",
+        "        var customHeaders = request.origin.custom.customHeaders;",
+        "        var originDomain  = request.origin.custom.domainName;",
+        "    }",
+        "    if ( request.origin.s3 ) { ",
+        "        var customHeaders = request.origin.s3.customHeaders;",
+        "        var originDomain  = request.origin.s3.domainName;",
+        "    }",
+        "",
+        "    const redirectPrimaryDomainHeaderName = 'X-Redirect-Primary-Domain-Name';",
+        "    const redirectResponseCodeHeaderName = 'X-Redirect-Response-Code';",
+        "    const redirectFixedPath = 'X-Redirect-Fixed-Path';",
+        "",
+        "    if ( customHeaders[redirectPrimaryDomainHeaderName.toLowerCase()]) {",
+        "        var primaryHost = (customHeaders[redirectPrimaryDomainHeaderName.toLowerCase()][0]).value;",
+        "    } else {",
+        "        var primaryHost = host;",
+        "    }",
+        "    if ( customHeaders[redirectResponseCodeHeaderName.toLowerCase()]) {",
+        "        var redirectCode = (customHeaders[redirectResponseCodeHeaderName.toLowerCase()][0]).value;",
+        "    } else {",
+        "        var redirectCode = '302';",
+        "    }",
+        "    /* If for primary domain, proceed with request */",
+        "    if ( host === primaryHost  ) {",
+        "        request.headers['host'] = [{key: 'Host', value: originDomain}];",
+        "        callback(null, request);",
+        "    } else {",
+        "        var redirectUrl = 'https://' + primaryHost;",
+        "        if ( customHeaders[redirectFixedPath.toLowerCase()] ) {",
+        "           redirectUrl = redirectUrl + customHeaders[redirectFixedPath.toLowerCase()][0].value;",
+        "        } else {",
+        "           if (request.uri != '/') {",
+        "               redirectUrl = redirectUrl + request.uri;",
+        "           }",
+        "           if (request.querystring != '') {",
+        "               redirectUrl = redirectUrl + '?' + request.querystring;",
+        "           }",
+        "        }",
+        "        /* Send the redirect */",
+        "        const response = {",
+        "            status: redirectCode,",
+        "            statusDescription: 'Relocated',",
+        "            headers: {",
+        "                location: [{",
+        "                    key: 'Location',",
+        "                    value: redirectUrl,",
+        "                }],",
+        "            },",
+        "        };",
+        "        callback(null, response);",
+        "    }",
+        "};"
+            ]]
+
+    [@lambdaAttributes
+        zipFile=redirectScript
+    /]
+
+[/#macro]

--- a/aws/services/lambda/resource.ftl
+++ b/aws/services/lambda/resource.ftl
@@ -131,7 +131,9 @@
             codeHash=""
             description=""
             dependencies=""
-            outputId="" ]
+            outputId=""
+            deletionPolicy=""
+            updateReplacePolicy="" ]
     [@cfResource
         id=id
         type="AWS::Lambda::Version"
@@ -150,6 +152,8 @@
         outputs=LAMBDA_VERSION_OUTPUT_MAPPINGS
         outputId=outputId
         dependencies=dependencies
+        updateReplacePolicy=updateReplacePolicy
+        deletionPolicy=deletionPolicy
     /]
 [/#macro]
 

--- a/aws/services/lambda/resource.ftl
+++ b/aws/services/lambda/resource.ftl
@@ -75,7 +75,14 @@
                 "Code" :
                     valueIfContent(
                         {
-                            "ZipFile" : settings.ZipFile!""
+                            "ZipFile" : {
+                                "Fn::Join" : [
+                                    "\n",
+                                    asFlattenedArray(
+                                        (settings.ZipFile)![]
+                                    )
+                                ]
+                            }
                         },
                         settings.ZipFile!"",
                         {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->

- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the ability to include the runId as part of inline code
- Moves the cfredirect extension over to the aws provider
- Adds support for a fixed path when performing redirects
- Sets the deletion policy for lambda versions to retain

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The main motivation around these changes is to handle updates to lambda@edge functions that are deployed using inline code.

- Including the run Id in inline zip files ensures that a new version can be created when version on deploy is used
- Moving cfredirect aligns with the extension being for cloudfront/ lambda@edge only
- The fixed path is for redirects between different services where paths might not align
- The deletion policy ensures that existing versions are retained when cloudfront keeps hold of them


## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally


## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

