### PR TITLE
fix: s3 versioning without lifecycle management

### DIFF
--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -19,7 +19,7 @@
 
     [#local roleId = resources["role"].Id ]
 
-    [#local versioningEnabled = solution.Lifecycle.Versioning ]
+    [#local versioningEnabled = solution.Versioning!solution.Lifecycle.Versioning ]
 
     [#local replicationEnabled = false]
     [#local replicationConfiguration = {} ]
@@ -468,7 +468,7 @@
             tier=core.Tier
             component=core.Component
             lifecycleRules=
-                (solution.Lifecycle.Configured && solution.Lifecycle.Enabled && ((solution.Lifecycle.Expiration!operationsExpiration)?has_content || (solution.Lifecycle.Offline!operationsOffline)?has_content))?then(
+                (isPresent(solution.Lifecycle) && ((solution.Lifecycle.Expiration!operationsExpiration)?has_content || (solution.Lifecycle.Offline!operationsOffline)?has_content))?then(
                         getS3LifecycleRule(solution.Lifecycle.Expiration!operationsExpiration, solution.Lifecycle.Offline!operationsOffline),
                         []
                 )

--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -21,6 +21,14 @@
 
     [#local versioningEnabled = solution.Versioning!solution.Lifecycle.Versioning ]
 
+    [#-- TODO(mfl): remove once Lifecycle.Versioning atribute is removed --]
+    [#if solution.Lifecycle.Versioning]
+        [@warn
+            message="Use of Lifecycle.Versioning have been deprecated"
+            detail="Please use the top level Versioning attribute instead. NOTE: Default behaviour if enabling versioning under Lifecycle WILL lifecycle objects even if only Versioning is enabled."
+        /]
+    [/#if]
+
     [#local replicationEnabled = false]
     [#local replicationConfiguration = {} ]
     [#local replicationBucket = ""]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Because of the location of the configuration controlling versioning of the s3 bucket, if versioning is turned on, the bucket will automatically be lifecycled.

## Motivation and Context
To permit versioning without lifecycle management, support a separate versioning attribute.

The Versioning attribute on Lifecycle will be deprecated to avoid lifecycle management as an unwanted side effect of enabling versioning.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- https://github.com/hamlet-io/engine/pull/1884

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

