### PR TITLE
fix(apigateway): execution log lookup and waf Id

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -1186,6 +1186,14 @@
             [/#if]
         [/#list]
 
+
+        [#local lgLookupName = [
+                "API-Gateway-Execution-Logs_",
+                r'${api_id}',
+                "/",
+                stageName
+            ]?join("")]
+
         [#-- Save the execution log group as a pseudo stack          --]
         [#-- Because the log group name includes the apiId, it isn't --]
         [#-- possible to pre-create it in the same way as the access --]
@@ -1193,8 +1201,8 @@
         [@addToDefaultBashScriptOutput
             content=
             [
-                "case $\{STACK_OPERATION} in",
-                "  create|update)"
+                r'case ${STACK_OPERATION} in',
+                r'  create|update)'
             ] +
             pseudoStackOutputScript(
                     "Execution Log Group",
@@ -1217,12 +1225,12 @@
             ) +
             [#-- Set the log retention otherwise the log never expires --]
             [
-                '       set_cloudwatch_log_group_retention "' + getRegion() + '" "' + executionLgName + '" "' + operationsExpiration?c + '" || return $?',
+                r'      api_id="$(get_cloudformation_stack_output "' + getRegion() + r'" "${STACK_NAME}" "' + apiId + r'" "ref" || return $?)"',
+                '       set_cloudwatch_log_group_retention "' + getRegion() + '" "' + lgLookupName + '" "' + operationsExpiration?c + '" || return $?',
                 "       ;;",
                 "       esac"
             ]
         /]
-
 
         [#-- If using an authoriser, give it a copy of the openapi spec --]
         [#-- Also include the definition because authorizers can't have --]

--- a/aws/components/apigateway/state.ftl
+++ b/aws/components/apigateway/state.ftl
@@ -272,7 +272,7 @@ created in either case.
             {
                 "acl" : {
                     "Id" : formatDependentWAFAclId(apiId),
-                    "Arn": (solution.WAF.Version == "v2")?then({ "Fn::GetAtt" : [ formatDependentWAFAclId(cfId), "Arn" ] }, ""),
+                    "Arn": (solution.WAF.Version == "v2")?then({ "Fn::GetAtt" : [ formatDependentWAFAclId(apiId), "Arn" ] }, ""),
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
                     "Type" : AWS_WAF_ACL_RESOURCE_TYPE
                 },


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->

- Gets the api id from the cloudformation stack so that it can be found on create actions
- fixes an issue where the wrong id lookup was used on v2 waf lookups

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Deployments failing on initial setup as the log group doesn't exist until the api is invoked 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->
- https://github.com/hamlet-io/executor-bash/pull/302

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

