### PR TITLE
fix(bastion): hanlde replacement for ec2 instances

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -1,6 +1,13 @@
 [#ftl]
 [#macro aws_bastion_cf_deployment_generationcontract_segment occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract
+        subsets="template"
+        alternatives=[
+            "primary",
+            { "subset" : "template", "alternative" : "replace1"},
+            { "subset" : "template", "alternative" : "replace2"}
+        ]
+    /]
 [/#macro]
 
 [#macro aws_bastion_cf_deployment_segment occurrence ]
@@ -66,6 +73,11 @@
     [#local osPatching = mergeObjects(environmentObject.OSPatching, solution.ComputeInstance.OSPatching )]
 
     [#local sshActive = sshActive || solution.Active ]
+
+    [#-- override sshActive on replace to ensure we bring the cluster down before a new instance --]
+    [#if getCLODeploymentUnitAlternative() == "replace1" && sshActive ]
+        [#local sshActive = false ]
+    [/#if]
 
     [#local processorProfile += {
                 "MaxCount" : 2,

--- a/aws/components/bastion/state.ftl
+++ b/aws/components/bastion/state.ftl
@@ -5,11 +5,13 @@
 
     [#local securityGroupToId = formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id )]
 
+    [#local eipId = formatEIPId(core.Id) ]
+
     [#assign componentState =
         {
             "Resources" : {
                 "eip" : {
-                    "Id" : formatEIPId(core.Id),
+                    "Id" : eipId,
                     "Name" : core.FullName,
                     "Type" : AWS_EIP_RESOURCE_TYPE
                 },
@@ -64,6 +66,7 @@
                 }
             },
             "Attributes" : {
+                "IP_ADDRESS" : getExistingReference(eipId)
             },
             "Roles" : {
                 "Inbound" : {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds alternative subsets to bring instances down before running an update replace
- Include the Public IP in attributes to easily find the IP for ssh access to the bastion

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for the elastic IP allocation startup script to run which  only works when one instance is running. When running some replacements the ASG creates a new instance before the other one can be shutdown 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

