### PR TITLE
fix(lambda): ensure layers is not null

### DIFF
--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -136,7 +136,8 @@
             "CodeHash" : solution.FixedCodeVersion.CodeHash,
             "VersionDependencies" : [],
             "CreateVersionInExtension" : false,
-            "ZipFile" : []
+            "ZipFile" : [],
+            "Layers" : []
         }
     ]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Add the Layers to context to ensure that null detection does not include a value

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
template generation was failing to deploy template with Hamlet:Null in the layers field

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

