### PR TITLE
feat: bastion module with ssh runbook

### DIFF
--- a/aws/modules/ssh_bastion/module.ftl
+++ b/aws/modules/ssh_bastion/module.ftl
@@ -1,0 +1,220 @@
+[#ftl]
+
+[@addModule
+    name="ssh_bastion"
+    description="Public bastion server with ssh support"
+    provider=AWS_PROVIDER
+    properties=[
+        {
+            "Names" : "tier",
+            "Type" : STRING_TYPE,
+            "Description" : "The tier to use to host the private bastion",
+            "Default" : "mgmt"
+        },
+        {
+            "Names" : "component",
+            "Type" : STRING_TYPE,
+            "Description" : "The component to use to host the private bastion",
+            "Default" : "ssh"
+        },
+        {
+            "Names" : "deploymentUnit",
+            "Type" : STRING_TYPE,
+            "Description" : "The deployment unit for the private bastion",
+            "Default" : "ssh"
+        },
+        {
+            "Names" : "activeDeploymentMode",
+            "Type" : STRING_TYPE,
+            "Description" : "The name of the deployment Mode to use to activate the bastion",
+            "Default" : "activebastion"
+        },
+        {
+            "Names" : "IPAddressGroups",
+            "Type" : ARRAY_OF_STRING_TYPE,
+            "Description" : "A list of IPAddressGroups that can access the bastion host",
+            "Default" : []
+        }
+    ]
+/]
+
+[#macro aws_module_ssh_bastion
+            tier
+            component
+            deploymentUnit
+            activeDeploymentMode
+            IPAddressGroups]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                tier : {
+                    "Components" : {
+                        component: {
+                            "Type" : "bastion",
+                            "deployment:Unit": deploymentUnit,
+                            "IPAddressGroups" : IPAddressGroups,
+                            "AutoScaling": {
+                                "DetailedMetrics": false,
+                                "ActivityCooldown": 180,
+                                "MinUpdateInstances": 0,
+                                "AlwaysReplaceOnUpdate": false
+                            },
+                            "Permissions": {
+                                "Decrypt": true
+                            },
+                            "Profiles" : {
+                                "Deployment" : [ "${tier}_${component}_active" ]
+                            }
+                        },
+                        "${component}_ssh-session" : {
+                            "Description" : "Starts an interactive SSH session with the bastion host using the baseline ssh key",
+                            "Type" : "runbook",
+                            "Engine" : "hamlet",
+                            "Steps" : {
+                                "aws_login" : {
+                                    "Priority" : 5,
+                                    "Extensions" : [ "_runbook_get_provider_id" ],
+                                    "Task" : {
+                                        "Type" : "set_provider_credentials",
+                                        "Properties" : {
+                                            "AccountId" : {
+                                                "Source" : "Setting",
+                                                "source:Setting" : {
+                                                    "Name" : "ACCOUNT"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "ssh_key_decrypt" : {
+                                    "Priority" : 10,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Task" : {
+                                        "Type" : "aws_decrypt_kms_ciphertext",
+                                        "Properties" : {
+                                            "Ciphertext" : {
+                                                "Source" : "Attribute",
+                                                "source:Attribute" : {
+                                                    "LinkId" : "ssh_key",
+                                                    "Name" : "PRIVATE_KEY"
+                                                }
+                                            },
+                                            "EncryptionScheme" : {
+                                                "Source" : "Attribute",
+                                                "source:Attribute" : {
+                                                    "LinkId" : "ssh_key",
+                                                    "Name" : "ENCRYPTION_SCHEME"
+                                                }
+                                            },
+                                            "AWSAccessKeyId" : {
+                                                "Source" : "Output",
+                                                "source:Output" : {
+                                                    "StepId" : "aws_login",
+                                                    "Name" : "aws_access_key_id"
+                                                }
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Source" : "Output",
+                                                "source:Output" : {
+                                                    "StepId" : "aws_login",
+                                                    "Name" : "aws_secret_access_key"
+                                                }
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Source" : "Output",
+                                                "source:Output" : {
+                                                    "StepId" : "aws_login",
+                                                    "Name" : "aws_session_token"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "ssh_key" : {
+                                            "Tier" : "mgmt",
+                                            "Component" : "baseline",
+                                            "SubComponent" : "ssh",
+                                            "Type" : "baselinekey"
+                                        }
+                                    }
+                                },
+                                "start_ssh_shell" : {
+                                    "Priority" : 50,
+                                    "Task" : {
+                                        "Type" : "start_ssh_shell",
+                                        "Properties" : {
+                                            "Host" : {
+                                                "Source" : "Attribute",
+                                                "source:Attribute" : {
+                                                    "LinkId" : "bastion",
+                                                    "Name" : "IP_ADDRESS"
+                                                }
+                                            },
+                                            "Username" : {
+                                                "Source" : "Fixed",
+                                                "source:Fixed" : {
+                                                    "Value" : "ec2-user"
+                                                }
+                                            },
+                                            "SSHKey" : {
+                                                "Source" : "Output",
+                                                "source:Output" : {
+                                                    "StepId" : "ssh_key_decrypt",
+                                                    "Name" : "result"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "bastion" : {
+                                            "Tier" : tier,
+                                            "Component" : component
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "NetworkProfiles": {
+                "default": {
+                    "BaseSecurityGroup": {
+                        "Links": {
+                            "sshBastion": {
+                                "Tier": tier,
+                                "Component": component,
+                                "Instance": "",
+                                "Version": "",
+                                "Direction": "inbound",
+                                "Role": "networkacl"
+                            }
+                        }
+                    }
+                }
+            },
+            "DeploymentProfiles" : {
+                "${tier}_${component}_active" : {
+                    "Modes" : {
+                        activeDeploymentMode : {
+                            "bastion" : {
+                                "Active" : true
+                            }
+                        }
+                    }
+                }
+            },
+            "DeploymentModes" : {
+                activeDeploymentMode : {
+                    "Operations": [ "update" ],
+                    "Membership": "priority",
+                    "Priority": {
+                        "GroupFilter": ".*",
+                        "Order": "LowestFirst"
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/aws/tasks/aws_decrypt_kms_ciphertext/id.ftl
+++ b/aws/tasks/aws_decrypt_kms_ciphertext/id.ftl
@@ -1,0 +1,51 @@
+[#ftl]
+
+[@addTask
+    type=AWS_DECRYPT_KMS_CIPHERTEXT_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Given an encrypted KMS ciphertext object decrypt it and return the plaintext result as a string"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Ciphertext",
+            "Description" : "The ciphertext value",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Base64Encoded",
+            "Description" : "Is the Ciphertext base64 encoded",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : true
+        },
+        {
+            "Names" : "EncryptionScheme",
+            "Description" : "A scheme prefix to show that the value is encrypted",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        }
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/task.ftl
+++ b/aws/tasks/task.ftl
@@ -1,0 +1,3 @@
+[#ftl]
+
+[#assign AWS_DECRYPT_KMS_CIPHERTEXT_TASK_TYPE = "aws_decrypt_kms_ciphertext" ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a public ssh based bastion module that includes 
   - the bastion itself 
   - a runbook to open an ssh session using the default baseline ssh key
   - a deployment mode to enable the bastion instance
- Adds a task to decrypt kms based cipher text with support for encryption prefixes and base64 encoded content

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This is an initial implementation and proof of concept for https://github.com/hamlet-io/engine/pull/1900 to show how they can be used and what is possible with them 
Creating a module of the bastion also allows for it to be easily enabled and disabled 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1900
- https://github.com/hamlet-io/engine/pull/1901
- https://github.com/hamlet-io/engine-plugin-aws/pull/493

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

