### PR TITLE
cd: remove junit reporting from testing pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,15 +34,6 @@ jobs:
           hamlet engine set-engine unicycle
           hamlet -i mock -p aws -p awstest -f cf deploy test-deployments -p '--junitxml=junit.xml' -o 'hamlet_tests/'
 
-      - name: Test Results
-        uses: mikepenz/action-junit-report@v2
-        with:
-          report_paths: 'hamlet_tests/junit.xml'
-          fail_on_failure: true
-          require_tests: true
-          check_name: deploy_tests results
-
-
   package:
     needs:
       - deploy_tests


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Removes the junit reporter to reduce false error reporting due to PR permissions

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The reporting tool was raising warnings on PRs as PRs only have write access to repos and can't create new checks that are required by the reporter. 
It also isn't too useful for hamlets testing approach which tests outputs rather than the code itsself

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Will be tested as part of PR

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

