### PR TITLE
feat: runbook module for pg_dump

### DIFF
--- a/aws/components/db/state.ftl
+++ b/aws/components/db/state.ftl
@@ -94,7 +94,8 @@
                 {
                     "USERNAME" : solution["rootCredential:Generated"].Username,
                     "PASSWORD" : getExistingReference(id, GENERATEDPASSWORD_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme),
-                    "URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme)
+                    "URL" : getExistingReference(id, URL_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme),
+                    "ENCRYPTION_SCHEME" : encryptionScheme
                 }
             )]
 

--- a/aws/modules/runbook_rds_pgdump/module.ftl
+++ b/aws/modules/runbook_rds_pgdump/module.ftl
@@ -1,0 +1,197 @@
+[#ftl]
+
+[@addModule
+    name="runbook_rds_pgdump"
+    description="Run a pgdump on a postgres db component and save the result locally"
+    provider=AWS_PROVIDER
+    properties=[
+        {
+            "Names" : "bastionLink",
+            "Description" : "A Link to an ssh bastion host which can access the db component",
+            "Mandatory" : true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        },
+        {
+            "Names" : "dbLink",
+            "Description" : "A link to the db component running postgres that the dump will be created from",
+            "Mandatory" : true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        }
+    ]
+/]
+
+[#macro aws_module_runbook_rds_pgdump
+        bastionLink
+        dbLink ]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                dbLink.Tier : {
+                    "Components" : {
+                        "${dbLink.Component}_pgdump" : {
+                            "Description" : "Creates a pg_dump of the database and saves it to a local file path",
+                            "Type" : "runbook",
+                            "Engine" : "hamlet",
+                            "Inputs" : {
+                                "outputfilepath" : {
+                                    "Type" : STRING_TYPE,
+                                    "Description" : "The local file path to save the dump file to",
+                                    "Mandatory" : true
+                                }
+                            },
+                            "Steps" : {
+                                "aws_login" : {
+                                    "Priority" : 5,
+                                    "Extensions" : [ "_runbook_get_provider_id" ],
+                                    "Task" : {
+                                        "Type" : "set_provider_credentials",
+                                        "Parameters" : {
+                                            "Account" : {
+                                                "Value" : "__setting:ACCOUNT__"
+                                            }
+                                        }
+                                    }
+                                },
+                                "ssh_key_decrypt" : {
+                                    "Priority" : 10,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Task" : {
+                                        "Type" : "aws_decrypt_kms_ciphertext",
+                                        "Parameters" : {
+                                            "Ciphertext" : {
+                                                "Value" : "__attribute:ssh_key:PRIVATE_KEY__"
+                                            },
+                                            "EncryptionScheme" : {
+                                                "Value" : "__attribute:ssh_key:ENCRYPTION_SCHEME__"
+                                            },
+                                            "AWSAccessKeyId" : {
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Value" : "__output:aws_login:aws_session_token__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "ssh_key" : {
+                                            "Tier" : "mgmt",
+                                            "Component" : "baseline",
+                                            "SubComponent" : "ssh",
+                                            "Type" : "baselinekey"
+                                        }
+                                    }
+                                },
+                                "dburl_key_decrypt" : {
+                                    "Priority" : 10,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Task" : {
+                                        "Type" : "aws_decrypt_kms_ciphertext",
+                                        "Parameters" : {
+                                            "Ciphertext" : {
+                                                "Value" : "__attribute:db:URL__"
+                                            },
+                                            "EncryptionScheme" : {
+                                                "Value" : "__attribute:db:ENCRYPTION_SCHEME__"
+                                            },
+                                            "AWSAccessKeyId" : {
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Value" : "__output:aws_login:aws_session_token__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "db" : dbLink
+                                    }
+                                },
+                                "install_pgdump" : {
+                                    "Priority" : 50,
+                                    "Task" : {
+                                        "Type" : "ssh_run_command",
+                                        "Parameters" : {
+                                            "Host" : {
+                                                "Value" : "__attribute:bastion:IP_ADDRESS__"
+                                            },
+                                            "Username" : {
+                                                "Value" : "ec2-user"
+                                            },
+                                            "SSHKey" : {
+                                                "Value" : "__output:ssh_key_decrypt:result__"
+                                            },
+                                            "Command" : {
+                                                "Value" : "which pg_dump || sudo amazon-linux-extras install postgresql13 -y"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "bastion" : bastionLink
+                                    }
+                                },
+                                "run_pgdump" : {
+                                    "Priority" : 75,
+                                    "Task" : {
+                                        "Type" : "ssh_run_command",
+                                        "Parameters" : {
+                                            "Host" : {
+                                                "Value" : "__attribute:bastion:IP_ADDRESS__"
+                                            },
+                                            "Username" : {
+                                                "Value" : "ec2-user"
+                                            },
+                                            "SSHKey" : {
+                                                "Value" : "__output:ssh_key_decrypt:result__"
+                                            },
+                                            "Command" : {
+                                                "Value" : "pg_dump -F c '__output:dburl_key_decrypt:result__' --file=/tmp/pg_dump_${dbLink.Tier}_${dbLink.Component}.dump"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "bastion" : bastionLink
+                                    }
+                                },
+                                "copy_pgdump_local" : {
+                                    "Priority" : 100,
+                                    "Task" : {
+                                        "Type" : "ssh_copy_file",
+                                        "Parameters" : {
+                                            "Host" : {
+                                                "Value" : "__attribute:bastion:IP_ADDRESS__"
+                                            },
+                                            "Username" : {
+                                                "Value" : "ec2-user"
+                                            },
+                                            "SSHKey" : {
+                                                "Value" : "__output:ssh_key_decrypt:result__"
+                                            },
+                                            "Direction" : {
+                                                "Value" : "RemoteToLocal"
+                                            },
+                                            "LocalPath" : {
+                                                "Value" : "__input:outputfilepath__"
+                                            },
+                                            "RemotePath" : {
+                                                "Value" : "/tmp/pg_dump_${dbLink.Tier}_${dbLink.Component}.dump"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "bastion" : bastionLink
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/aws/modules/ssh_bastion/module.ftl
+++ b/aws/modules/ssh_bastion/module.ftl
@@ -79,10 +79,7 @@
                                         "Type" : "set_provider_credentials",
                                         "Properties" : {
                                             "AccountId" : {
-                                                "Source" : "Setting",
-                                                "source:Setting" : {
-                                                    "Name" : "ACCOUNT"
-                                                }
+                                                "Value" : "__setting:ACCOUNT__"
                                             }
                                         }
                                     }
@@ -92,41 +89,21 @@
                                     "Extensions" : [ "_runbook_get_region" ],
                                     "Task" : {
                                         "Type" : "aws_decrypt_kms_ciphertext",
-                                        "Properties" : {
+                                        "Parameters" : {
                                             "Ciphertext" : {
-                                                "Source" : "Attribute",
-                                                "source:Attribute" : {
-                                                    "LinkId" : "ssh_key",
-                                                    "Name" : "PRIVATE_KEY"
-                                                }
+                                                "Value" : "__attribute:ssh_key:PRIVATE_KEY__"
                                             },
                                             "EncryptionScheme" : {
-                                                "Source" : "Attribute",
-                                                "source:Attribute" : {
-                                                    "LinkId" : "ssh_key",
-                                                    "Name" : "ENCRYPTION_SCHEME"
-                                                }
+                                                "Value" : "__attribute:ssh_key:ENCRYPTION_SCHEME__"
                                             },
                                             "AWSAccessKeyId" : {
-                                                "Source" : "Output",
-                                                "source:Output" : {
-                                                    "StepId" : "aws_login",
-                                                    "Name" : "aws_access_key_id"
-                                                }
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
                                             },
                                             "AWSSecretAccessKey" : {
-                                                "Source" : "Output",
-                                                "source:Output" : {
-                                                    "StepId" : "aws_login",
-                                                    "Name" : "aws_secret_access_key"
-                                                }
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
                                             },
                                             "AWSSessionToken" : {
-                                                "Source" : "Output",
-                                                "source:Output" : {
-                                                    "StepId" : "aws_login",
-                                                    "Name" : "aws_session_token"
-                                                }
+                                                "Value" : "__output:aws_login:aws_session_token__"
                                             }
                                         }
                                     },
@@ -142,27 +119,19 @@
                                 "start_ssh_shell" : {
                                     "Priority" : 50,
                                     "Task" : {
-                                        "Type" : "start_ssh_shell",
-                                        "Properties" : {
+                                        "Type" : "ssh_run_command",
+                                        "Parameters" : {
                                             "Host" : {
-                                                "Source" : "Attribute",
-                                                "source:Attribute" : {
-                                                    "LinkId" : "bastion",
-                                                    "Name" : "IP_ADDRESS"
-                                                }
+                                                "Value" : "__attribute:bastion:IP_ADDRESS__"
                                             },
                                             "Username" : {
-                                                "Source" : "Fixed",
-                                                "source:Fixed" : {
-                                                    "Value" : "ec2-user"
-                                                }
+                                                "Value" : "ec2-user"
                                             },
                                             "SSHKey" : {
-                                                "Source" : "Output",
-                                                "source:Output" : {
-                                                    "StepId" : "ssh_key_decrypt",
-                                                    "Name" : "result"
-                                                }
+                                                "Value" : "__output:ssh_key_decrypt:result__"
+                                            },
+                                            "Command" : {
+                                                "Value" : "/bin/bash"
                                             }
                                         }
                                     },


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a runbook module that uses an ssh bastion host to create a pg_dump of a postgres based db component and copy the file to the local machine
  - The runbook ensures that the latest postgres client is installed, installs it if not ( for awslinux2) then runs a pgdump and uses ssh(sftp) to copy the file to the local path provided as an input

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The primary motivation for this module is to support development teams who want to work from a local copy of a development database when developing new features. This can also be used for scheduled datatbase backup tasks where you don't want to use the AWS provided backups

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and on active deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1904

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

