### PR TITLE
feat(ecs): support for ecs exec

### DIFF
--- a/aws/components/ecs/id.ftl
+++ b/aws/components/ecs/id.ftl
@@ -74,6 +74,12 @@
             "Description" : "The version of the fargate platform to use",
             "Types" : STRING_TYPE,
             "Default" : "LATEST"
+        },
+        {
+            "Names" : "ExecuteCommand",
+            "Description" : "Enable Support for execute command through ECS Exec on tasks within the service",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : false
         }
     ]
     provider=AWS_PROVIDER

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -1314,6 +1314,7 @@
                     dependencies=dependencies
                     circuitBreaker=useCircuitBreaker
                     tags=getOccurrenceCoreTags(occurrence, serviceName )
+                    executeCommand=solution["aws:ExecuteCommand"]
                 /]
             [/#if]
         [/#if]
@@ -1354,6 +1355,24 @@
                         [#local dependencies += [policyId] ]
                     [/#if]
                 [/#list]
+
+                [#if (solution["aws:ExecuteCommand"])!false ]
+                    [@createPolicy
+                        id=formatDependentPolicyId(taskId, "ECSExecuteCommand")
+                        name="executecommand"
+                        statements=[
+                            getPolicyStatement(
+                                [
+                                    "ssmmessages:CreateControlChannel",
+                                    "ssmmessages:CreateDataChannel",
+                                    "ssmmessages:OpenControlChannel",
+                                    "ssmmessages:OpenDataChannel"
+                                ]
+                            )
+                        ]
+                        roles=roleId
+                    /]
+                [/#if]
 
                 [@createRole
                     id=roleId

--- a/aws/components/ecs/state.ftl
+++ b/aws/components/ecs/state.ftl
@@ -236,6 +236,9 @@
     [#local taskId = formatResourceId(AWS_ECS_TASK_RESOURCE_TYPE, core.Id) ]
     [#local taskName = core.Name]
 
+    [#local parentResources = parent.State.Resources ]
+    [#local ecsId = parentResources["cluster"].Id ]
+
     [#local lgId = formatDependentLogGroupId(taskId) ]
     [#local lgName = core.FullAbsolutePath ]
 
@@ -337,6 +340,7 @@
                 }) +
             autoScaling,
             "Attributes" : {
+                "CLUSTER_ARN" : getArn(ecsId),
                 "ARN": getArn(serviceId)
             },
             "Roles" : {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for configuring ecs exec on services along with the recommended setup required for it

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for remote access directly to ecs task containers via SSM. This is the approach to debug containers running on Fargate

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1907

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

