### PR TITLE
feat: extended runbooks for access

### DIFF
--- a/aws/components/network/state.ftl
+++ b/aws/components/network/state.ftl
@@ -182,6 +182,7 @@
                 dnsQueryLoggers
             ),
             "Attributes" : {
+                "VPC_ID" : getExistingReference(legacyVpc?then(formatVPCId(), vpcId))
             },
             "Roles" : {
                 "Inbound" : {},

--- a/aws/extensions/runbook_get_ec2_ip/extension.ftl
+++ b/aws/extensions/runbook_get_ec2_ip/extension.ftl
@@ -1,0 +1,34 @@
+[#ftl]
+
+[@addExtension
+    id="runbook_get_ec2_ip"
+    aliases=[
+        "_runbook_get_ec2_ip"
+    ]
+    description=[
+        "Run a boto3 command to return an ec2 IP address"
+    ]
+    supportedTypes=[
+        RUNBOOK_STEP_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_runbook_get_ec2_ip_runbook_setup occurrence ]
+
+    [#local aws_login_step =  (_context.DefaultEnvironment["AWS_LOGIN_STEP"])!"aws_login" ]
+    [#local ec2_instance_id = (_context.DefaultEnvironment["ec2_instance_id"])!"__output:select_instance:result__" ]
+
+    [#assign _context = mergeObjects(
+        _context,
+        {
+            "TaskParameters" : {
+                "Command" : [
+                    "export AWS_ACCESS_KEY_ID='__output:${aws_login_step}:aws_access_key_id__'",
+                    "export AWS_SECRET_ACCESS_KEY='__output:${aws_login_step}:aws_secret_access_key__'",
+                    "export AWS_SESSION_TOKEN='__output:${aws_login_step}:aws_session_token__'",
+                    r"python3 -c '" + r'import boto3; ec2=boto3.resource("ec2"); print(ec2.Instance("' + ec2_instance_id + r'").private_ip_address)' + r"'"
+                ]?join("; ")
+            }
+        }
+    )]
+[/#macro]

--- a/aws/extensions/runbook_get_vpc_id/extension.ftl
+++ b/aws/extensions/runbook_get_vpc_id/extension.ftl
@@ -1,0 +1,33 @@
+[#ftl]
+
+[@addExtension
+    id="runbook_get_vpc_id"
+    aliases=[
+        "_runbook_get_vpc_id"
+    ]
+    description=[
+        "Use a host on the network to get the vpcId"
+    ]
+    supportedTypes=[
+        RUNBOOK_STEP_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_runbook_get_vpc_id_runbook_setup occurrence ]
+
+    [#local host = _context.Links["host"]]
+
+    [#local occurrenceNetwork = getOccurrenceNetwork(_context.Links["host"]) ]
+    [#local networkLink = occurrenceNetwork.Link!{} ]
+    [#local networkLinkTarget = getLinkTarget(_context.Links["host"], networkLink ) ]
+    [#local vpcId = networkLinkTarget.State.Attributes["VPC_ID"]]
+
+    [#assign _context = mergeObjects(
+        _context,
+        {
+            "TaskParameters" : {
+                "VpcId" : vpcId
+            }
+        }
+    )]
+[/#macro]

--- a/aws/modules/runbook_service_console/module.ftl
+++ b/aws/modules/runbook_service_console/module.ftl
@@ -1,0 +1,149 @@
+[#ftl]
+
+[@addModule
+    name="runbook_service_exec_command"
+    description="Run an interactive command on a container running as part of a service using ecs exec"
+    provider=AWS_PROVIDER
+    properties=[
+        {
+            "Names" : "id",
+            "Description" : "A unique id for this exec command - allows for multiple commands on the same service",
+            "Types" : STRING_TYPE,
+            "Default" : "sh"
+        },
+        {
+            "Names" : "serviceLink",
+            "Description" : "A Link to a service you want to open the shell on",
+            "Mandatory" : true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        },
+        {
+            "Names" : "containerId",
+            "Description" : "The id of the container to run the command on",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "command",
+            "Description" : "The command to run on the container",
+            "Types" : STRING_TYPE,
+            "Default" : "/bin/sh"
+        }
+    ]
+/]
+
+[#macro aws_module_runbook_service_exec_command
+        id
+        serviceLink
+        command
+        containerId ]
+
+
+    [#local componentId = ((serviceLink.SubComponent)!serviceLink.Service)!"" ]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                serviceLink.Tier : {
+                    "Components" : {
+                        "${componentId}-exec_command-${id}" : {
+                            "Description" : "Runs an interactive command on a service container",
+                            "Type" : "runbook",
+                            "Engine" : "hamlet",
+                            "Steps" : {
+                                "aws_login" : {
+                                    "Priority" : 5,
+                                    "Extensions" : [ "_runbook_get_provider_id" ],
+                                    "Task" : {
+                                        "Type" : "set_provider_credentials",
+                                        "Parameters" : {
+                                            "Account" : {
+                                                "Value" : "__setting:ACCOUNT__"
+                                            }
+                                        }
+                                    }
+                                },
+                                "select_task" : {
+                                    "Priority" : 10,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Task" : {
+                                        "Type" : "aws_ecs_select_task",
+                                        "Parameters" : {
+                                            "ClusterArn" : {
+                                                "Value" : "__attribute:service:CLUSTER_ARN__"
+                                            },
+                                            "ServiceName" : {
+                                                "Value" : "__attribute:service:ARN__"
+                                            },
+                                            "AWSAccessKeyId" : {
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Value" : "__output:aws_login:aws_session_token__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "service" : serviceLink
+                                    }
+                                },
+                                "run_command" : {
+                                    "Priority" : 10,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Task" : {
+                                        "Type" : "aws_ecs_run_command",
+                                        "Parameters" : {
+                                            "ClusterArn" : {
+                                                "Value" : "__attribute:service:CLUSTER_ARN__"
+                                            },
+                                            "Command" : {
+                                                "Value" : command
+                                            },
+                                            "ContainerName" : {
+                                                "Value" : containerId?split("-")[0]
+                                            },
+                                            "TaskArn" : {
+                                                "Value" : "__output:select_task:result__"
+                                            },
+                                            "AWSAccessKeyId" : {
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Value" : "__output:aws_login:aws_session_token__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "service" : serviceLink
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "DeploymentProfiles" : {
+                "${serviceLink.Tier}_${componentId}_ecs-exec" : {
+                    "Modes" : {
+                        "*" : {
+                            "service" : {
+                                "aws:ExecuteCommand" : true,
+                                "Containers" : {
+                                    containerId : {
+                                        "InitProcess" : true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/aws/tasks/aws_ec2_select_instance/id.ftl
+++ b/aws/tasks/aws_ec2_select_instance/id.ftl
@@ -1,0 +1,43 @@
+[#ftl]
+
+[@addTask
+    type=AWS_EC2_SELECT_INSTANCE_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Lists the available instances and allows the user to select one - returns the selected instance id"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "VpcId",
+            "Description" : "The VPCId that instances are assiged to",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Tags",
+            "Description" : "An object of Key=Value tags that the instances must have",
+            "Types" : OBJECT_TYPE
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        }
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/aws_ecs_run_command/id.ftl
+++ b/aws/tasks/aws_ecs_run_command/id.ftl
@@ -1,0 +1,55 @@
+[#ftl]
+
+[@addTask
+    type=AWS_ECS_RUN_COMMAND_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Runs an interactive task on a provided task arn"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "ClusterArn",
+            "Description" : "The ARN of the ECS Cluster to list running tasks from",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "TaskArn",
+            "Description" : "The Arn or Name of a running task to run the command on",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Command",
+            "Description" : "The command to run in the command",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "ContainerName",
+            "Description" : "The name of the container in the task definition",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        }
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/aws_ecs_select_task/id.ftl
+++ b/aws/tasks/aws_ecs_select_task/id.ftl
@@ -1,0 +1,49 @@
+[#ftl]
+
+[@addTask
+    type=AWS_ECS_SELECT_TASK_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "List the running tasks for a service or task family and return the user selected task"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "ClusterArn",
+            "Description" : "The ARN of the ECS Cluster to list running tasks from",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "ServiceName",
+            "Description" : "The Arn or Name of a service deployed to the cluster",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "TaskFamily",
+            "Description" : "The name of a Task definition family that to show tasks for",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        }
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/task.ftl
+++ b/aws/tasks/task.ftl
@@ -1,3 +1,6 @@
 [#ftl]
 
 [#assign AWS_DECRYPT_KMS_CIPHERTEXT_TASK_TYPE = "aws_decrypt_kms_ciphertext" ]
+[#assign AWS_ECS_SELECT_TASK_TASK_TYPE = "aws_ecs_select_task" ]
+[#assign AWS_ECS_RUN_COMMAND_TASK_TYPE = "aws_ecs_run_command" ]
+[#assign AWS_EC2_SELECT_INSTANCE_TASK_TYPE = "aws_ec2_select_instance" ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
A collection of changes to support runbook based access to vpc based resources
- Adds tasks to select from active ec2 intsances and ecs tasks
- Adds the vpcid as an attribute of vpc
- Extends the bastion runbook to incldue a runbook for accessing active instances within the vpc through the bastion as a gateway host
- Adds a new module which adds support for using ecs exec to directly access a running container as a root user

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for simple access to all running containers and instances within a deployment without having to go into the AWS console or know the details of running tasks or active instances

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1908
- https://github.com/hamlet-io/engine/pull/1907

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

