### PR TITLE
feat(cdn): add support for origin connection timeouts

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -321,7 +321,9 @@
                                 _context.CustomOriginHeaders,
                                 originPath,
                                 originProtocol,
-                                originPort
+                                originPort,
+                                subSolution.Origin.TLSProtocols,
+                                subSolution.Origin.ConnectionTimeout
                             )]
                 [#local origins += origin ]
 
@@ -373,7 +375,9 @@
                                 _context.CustomOriginHeaders,
                                 originPath,
                                 protocol,
-                                port
+                                port,
+                                subSolution.Origin.TLSProtocols,
+                                subSolution.Origin.ConnectionTimeout
                             )]
                 [#local origins += origin ]
 

--- a/aws/services/cf/resource.ftl
+++ b/aws/services/cf/resource.ftl
@@ -81,7 +81,8 @@
         path=""
         protocol="HTTPS"
         port=443
-        tlsProtocols=["TLSv1.2"]]
+        tlsProtocols=["TLSv1.2"]
+        originTimeout=""]
     [#return
         [
             {
@@ -102,6 +103,10 @@
                             "HTTPPort" : port?number
                         },
                         {}
+                    ) +
+                    attributeIfContent(
+                        "OriginReadTimeout",
+                        originTimeout
                     )
             } +
             attributeIfContent("OriginCustomHeaders", asArray(headers)) +


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for setting the connection timeout for an origin
- Adds support for controlling the TLS protocol used for HTTP based backends

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for greater control of origin network connections 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

