### PR TITLE
fix(s3): replication validation checking

### DIFF
--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -301,12 +301,10 @@
                                     [/#if]
                                     [#local replicationBucket = linkTargetAttributes["ARN"]]
                                 [#else]
-
-                                        [@fatal
-                                            message="Only one replication destination is supported"
-                                            context=links
-                                        /]
-                                    [/#if]
+                                    [@fatal
+                                        message="Only one replication destination is supported"
+                                        context=links
+                                    /]
                                 [/#if]
                             [/#if]
                             [#break]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- fixes a typo in deploymentMode details lookup used for validation
- Disables validation of S3 replication checking unless we are in the s3 subset

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Template generation for subsets was failing and could not be fixed until other deployments completed

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

