### PR TITLE
feat(logs): add support for at rest encryption of cw logs

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -459,6 +459,7 @@
                 bucketPrefix="APIGatewayAccess"
                 cloudwatchEnabled=true
                 cmkKeyId=kmsKeyId
+                loggingProfile=loggingProfile
             /]
 
         [/#if]
@@ -473,6 +474,7 @@
                 logGroupId=accessLgId
                 logGroupName=accessLgName
                 loggingProfile=loggingProfile
+                kmsKeyId=kmsKeyId
             /]
         [/#if]
     [/#if]
@@ -829,6 +831,7 @@
                 cloudwatchEnabled=true
                 cmkKeyId=kmsKeyId
                 version=solution.WAF.Version
+                loggingProfile=loggingProfile
             /]
 
             [@enableWAFLogging

--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -42,6 +42,7 @@
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
     [#local sshKeyPairId = baselineComponentIds["SSHKey"]!"HamletFatal: sshKeyPairId not found" ]
+    [#local kmsKeyId = baselineComponentIds["Encryption"]]
 
     [#if deploymentSubsetRequired("eip", false) || deploymentSubsetRequired("bastion", true) ]
         [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
@@ -201,6 +202,7 @@
             logGroupId=bastionLgId
             logGroupName=bastionLgName
             loggingProfile=loggingProfile
+            kmsKeyId=kmsKeyId
         /]
 
         [#if deploymentSubsetRequired("bastion", true)]

--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -519,6 +519,7 @@
                 cloudwatchEnabled=true
                 cmkKeyId=kmsKeyId
                 version=solution.WAF.Version
+                loggingProfile=loggingProfile
             /]
 
             [@enableWAFLogging

--- a/aws/components/clientvpn/setup.ftl
+++ b/aws/components/clientvpn/setup.ftl
@@ -13,6 +13,9 @@
     [#local vpnEndpointId = resources["endpoint"].Id]
     [#local vpnEndpointName = resources["endpoint"].Name]
 
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption" ] )]
+    [#local kmsKeyId = baselineComponentIds["Encryption"]]
 
     [#local certificateObject = getCertificateObject( solution.Certificate ) ]
     [#local hostName = getHostName(certificateObject, occurrence) ]
@@ -65,6 +68,7 @@
             logGroupId=lgId
             logGroupName=lgName
             loggingProfile=loggingProfile
+            kmsKeyId=kmsKeyId
         /]
 
         [@createLogStream

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -38,6 +38,7 @@
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
+    [#local kmsKeyId = baselineComponentIds["Encryption"]]
 
     [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
     [#local networkLink = occurrenceNetwork.Link!{} ]
@@ -339,6 +340,7 @@
         logGroupId=computeClusterLogGroupId
         logGroupName=computeClusterLogGroupName
         loggingProfile=loggingProfile
+        kmsKeyId=kmsKeyId
     /]
 
     [#if deploymentSubsetRequired(COMPUTECLUSTER_COMPONENT_TYPE, true)]

--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -60,6 +60,7 @@
             logGroupId=streamLgId
             logGroupName=streamLgName
             loggingProfile=loggingProfile
+            kmsKeyId=cmkKeyId
         /]
 
         [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(streamLgId) ]

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -46,6 +46,7 @@
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
     [#local sshKeyPairId = baselineComponentIds["SSHKey"]!"HamletFatal: sshKeyPairId not found" ]
+    [#local kmsKeyId = baselineComponentIds["Encryption"]]
 
     [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
     [#local networkLink = occurrenceNetwork.Link!{} ]
@@ -289,6 +290,7 @@
         logGroupId=ec2LogGroupId
         logGroupName=ec2LogGroupName
         loggingProfile=loggingProfile
+        kmsKeyId=kmsKeyId
     /]
 
     [#if deploymentSubsetRequired(EC2_COMPONENT_TYPE, true)]

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -62,6 +62,7 @@
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
     [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
     [#local sshKeyPairId = baselineComponentIds["SSHKey"]!"HamletFatal: sshKeyPairId not found" ]
+    [#local kmsKeyId = baselineComponentIds["Encryption"]]
 
     [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
     [#local networkLink = occurrenceNetwork.Link!{} ]
@@ -191,6 +192,7 @@
             logGroupId=ecsLogGroupId
             logGroupName=ecsLogGroupName
             loggingProfile=loggingProfile
+            kmsKeyId=kmsKeyId
         /]
     [/#if]
 
@@ -199,6 +201,7 @@
         logGroupId=ecsInstanceLogGroupId
         logGroupName=ecsInstanceLogGroupName
         loggingProfile=loggingProfile
+        kmsKeyId=kmsKeyId
     /]
 
     [#local capacityProviderScalingPolicy = { "managedScaling" : false, "managedTermination" : false } ]
@@ -1519,6 +1522,7 @@
                 logGroupId=lgId
                 logGroupName=lgName
                 loggingProfile=loggingProfile
+                kmsKeyId=kmsKeyId
             /]
         [/#if]
 
@@ -1530,6 +1534,7 @@
                         logGroupId=lgId
                         logGroupName=container.LogGroup.Name
                         loggingProfile=loggingProfile
+                        kmsKeyId=kmsKeyId
                     /]
             [/#if]
 

--- a/aws/components/es/setup.ftl
+++ b/aws/components/es/setup.ftl
@@ -314,6 +314,7 @@
             logGroupId=lgId
             logGroupName=lgName
             loggingProfile=loggingProfile
+            kmsKeyId=cmkKeyId
         /]
     [/#if]
 

--- a/aws/components/firewall/setup.ftl
+++ b/aws/components/firewall/setup.ftl
@@ -25,6 +25,11 @@
     [#local networkLink = occurrenceNetwork.Link!{} ]
     [#local networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
 
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(occurrence, ["Encryption" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+    [#local kmsKeyId = baselineComponentIds["Encryption"] ]
+
     [#if deploymentSubsetRequired(FIREWALL_COMPONENT_TYPE, true)]
 
         [#if ! networkLinkTarget?has_content ]
@@ -83,6 +88,7 @@
                     logGroupId=logGroupId
                     logGroupName=logGroupName
                     loggingProfile=loggingProfile
+                    kmsKeyId=kmsKeyId
                 /]
                 [#break]
 

--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -355,6 +355,7 @@
             logGroupId=fnLgId
             logGroupName=fnLgName
             loggingProfile=loggingProfile
+            kmsKeyId=cmkKeyId
         /]
     [/#if]
 

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -970,6 +970,7 @@
                     cloudwatchEnabled=true
                     cmkKeyId=kmsKeyId
                     version=solution.WAF.Version
+                    loggingProfile=loggingProfile
                 /]
 
                 [@enableWAFLogging

--- a/aws/components/mobilenotifier/setup.ftl
+++ b/aws/components/mobilenotifier/setup.ftl
@@ -22,6 +22,11 @@
 
     [#local hasPlatformApp = false]
 
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+    [#local kmsKeyId = baselineComponentIds["Encryption"] ]
+
     [#list occurrence.Occurrences![] as subOccurrence]
 
         [#local core = subOccurrence.Core ]
@@ -122,6 +127,7 @@
                     logGroupId=lgId
                     logGroupName=lgName
                     loggingProfile=loggingProfile
+                    kmsKeyId=kmsKeyId
                 /]
 
                 [@setupLogGroup
@@ -129,6 +135,7 @@
                     logGroupId=lgFailureId
                     logGroupName=lgFailureName
                     loggingProfile=loggingProfile
+                    kmsKeyId=kmsKeyId
                 /]
             [/#if]
 

--- a/aws/components/network/setup.ftl
+++ b/aws/components/network/setup.ftl
@@ -20,6 +20,11 @@
 
     [#local loggingProfile = getLoggingProfile(occurrence)]
 
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData", "AppData", "Encryption", "SSHKey" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+    [#local kmsKeyId = baselineComponentIds["Encryption"] ]
+
     [#-- Flag that the flowlog configuration needs to be updated if enabled via flags --]
     [#if deploymentSubsetRequired(NETWORK_COMPONENT_TYPE, true) &&
         (
@@ -73,6 +78,7 @@
                 logGroupId=flowLogLogGroupId
                 logGroupName=flowLogLogGroupName
                 loggingProfile=loggingProfile
+                kmsKeyId=kmsKeyId
                 retention=((segmentObject.Operations.FlowLogs.Expiration) !
                                 (segmentObject.Operations.Expiration) !
                                 (environmentObject.Operations.FlowLogs.Expiration) !
@@ -141,6 +147,7 @@
                 logGroupId=dnsQueryLogGroupId
                 logGroupName=dnsQueryLogGroupName
                 loggingProfile=loggingProfile
+                kmsKeyId=kmsKeyId
             /]
 
             [#local destinationArn = dnsQueryLogGroupId ]

--- a/aws/extensions/cmk_logs_access/extension.ftl
+++ b/aws/extensions/cmk_logs_access/extension.ftl
@@ -1,0 +1,64 @@
+[#ftl]
+
+[@addExtension
+    id="cmk_logs_access"
+    aliases=[
+        "_cmk_logs_access"
+    ]
+    description=[
+        "Grants access to a CMK from the CloudWatch Logs Service"
+    ]
+    supportedTypes=[
+        BASELINE_KEY_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_cmk_logs_access_deployment_setup occurrence ]
+
+    [@Policy
+        [
+            getPolicyStatement(
+                [
+                    "kms:Encrypt*",
+                    "kms:Decrypt*",
+                    "kms:ReEncrypt*",
+                    "kms:GenerateDataKey*",
+                    "kms:Describe*"
+                ],
+                "*"
+                {
+                    "Service" : {
+                        "Fn::Sub" : [
+                            r'logs.${Region}.amazonaws.com',
+                            {
+                                "Region" : {
+                                    "Ref" : "AWS::Region"
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "ArnLike": {
+                        "kms:EncryptionContext:aws:logs:arn":  {
+                            "Fn::Sub" : [
+                                r'arn:aws:logs:${Region}:${AWSAccountId}:*',
+                                {
+                                    "Region" : {
+                                        "Ref" : "AWS::Region"
+                                    },
+                                    "AWSAccountId" : {
+                                        "Ref" : "AWS::AccountId"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                true,
+                "CloudWatch Logs access to KMS for log storage"
+            )
+        ]
+    /]
+
+[/#macro]

--- a/aws/modules/log_encryption/README.md
+++ b/aws/modules/log_encryption/README.md
@@ -1,0 +1,30 @@
+# log_encryption Hamlet Module
+
+This is a Hamlet Deploy module.
+
+See docs.hamlet.io for more information.
+
+## Description
+
+Provides a deployment Profile and Logging Profile to enable at-rest encryption of log storage for CloudWatch
+
+## Requirements
+
+- AWS Provider Plugin
+
+## Usage
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "$id": "",
+  "definitions": {
+    "log_encryption": {
+      "type": "object"
+    }
+  }
+}
+```
+
+Note: This module does not accept parameters.

--- a/aws/modules/log_encryption/module.ftl
+++ b/aws/modules/log_encryption/module.ftl
@@ -1,0 +1,33 @@
+[#ftl]
+
+[@addModule
+    name="log_encryption"
+    description="Enables at-rest log encryption across all components using CloudWatch Logs"
+    provider=AWS_PROVIDER
+    properties=[]
+/]
+
+[#macro aws_module_log_encryption ]
+    [@loadModule
+        blueprint={
+            "DeploymentProfiles" : {
+                "kms_key_logs" : {
+                    "Modes" : {
+                        "*" : {
+                            "baselinekey" : {
+                                "Extensions" : [ "cmk_logs_access" ]
+                            }
+                        }
+                    }
+                }
+            },
+            "LoggingProfiles" : {
+                "default" : {
+                    "Encryption" : {
+                        "Enabled" : true
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/aws/services/cw/policy.ftl
+++ b/aws/services/cw/policy.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#function cwLogsProducePermission logGroupName=""]
+[#function cwLogsProducePermission logGroupName="" ]
     [#local logGroupArn = logGroupName?has_content?then(
                     formatRegionalArn(
                             "logs",
@@ -16,7 +16,8 @@
                     "logs:DescribeLogGroups",
                     "logs:DescribeLogStreams"
                 ],
-                logGroupArn)
+                logGroupArn
+            )
         ]
     ]
 [/#function]

--- a/aws/services/kinesis/resource.ftl
+++ b/aws/services/kinesis/resource.ftl
@@ -120,6 +120,7 @@
     bucketPrefix
     componentSubset
     cloudwatchEnabled=true
+    loggingProfile={}
     processorId=""
     cmkKeyId=""
     dependencies=""
@@ -244,20 +245,23 @@
 
         [/#switch]
 
-        [#if cloudwatchEnabled &&
-                deploymentSubsetRequired("lg", true) &&
-                isPartOfCurrentDeploymentUnit(resourceDetails["lg"].Id) ]
-            [@createLogGroup
-                id=resourceDetails["lg"].Id
-                name=resourceDetails["lg"].Name
+        [#if cloudwatchEnabled ]
+            [@setupLogGroup
+                occurrence=occurrence
+                logGroupId=resourceDetails["lg"].Id
+                logGroupName=resourceDetails["lg"].Name
+                loggingProfile=loggingProfile
+                kmsKeyId=cmkKeyId
             /]
 
-            [@createLogStream
-                id=resourceDetails["lgStream"].Id
-                name=resourceDetails["lgStream"].Name
-                logGroup=resourceDetails["lg"].Name
-                dependencies=resourceDetails["lg"].Id
-            /]
+            [#if deploymentSubsetRequired("lg", true) && isPartOfCurrentDeploymentUnit(resourceDetails["lg"].Id)]
+                [@createLogStream
+                    id=resourceDetails["lgStream"].Id
+                    name=resourceDetails["lgStream"].Name
+                    logGroup=resourceDetails["lg"].Name
+                    dependencies=resourceDetails["lg"].Id
+                /]
+            [/#if]
         [/#if]
 
         [#if deploymentSubsetRequired("iam", true)  &&

--- a/aws/tasks/aws_encrypt_kms_ciphertext/id.ftl
+++ b/aws/tasks/aws_encrypt_kms_ciphertext/id.ftl
@@ -5,19 +5,19 @@
     properties=[
             {
                 "Type"  : "Description",
-                "Value" : "Given an encrypted KMS ciphertext object decrypt it and return the plaintext result as a string"
+                "Value" : "Given a value return the KMS encrypted ciphertext as the result"
             }
         ]
     attributes=[
         {
-            "Names" : "Ciphertext",
-            "Description" : "The ciphertext value",
+            "Names" : "Value",
+            "Description" : "The value that needs to be encrypted",
             "Types" : STRING_TYPE,
             "Mandatory" : true
         },
         {
             "Names" : "Base64Encode",
-            "Description" : "Is the Ciphertext base64 encoded",
+            "Description" : "Return the ciphertext as a base64 encoded string",
             "Types" : BOOLEAN_TYPE,
             "Default" : true
         },

--- a/aws/tasks/aws_encrypt_kms_ciphertext/id.ftl
+++ b/aws/tasks/aws_encrypt_kms_ciphertext/id.ftl
@@ -1,0 +1,45 @@
+[#ftl]
+
+[@addTask
+    type=AWS_KMS_ENCRYPT_VALUE_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Given an encrypted KMS ciphertext object decrypt it and return the plaintext result as a string"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "Ciphertext",
+            "Description" : "The ciphertext value",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Base64Encode",
+            "Description" : "Is the Ciphertext base64 encoded",
+            "Types" : BOOLEAN_TYPE,
+            "Default" : true
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        }
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/task.ftl
+++ b/aws/tasks/task.ftl
@@ -4,3 +4,4 @@
 [#assign AWS_ECS_SELECT_TASK_TASK_TYPE = "aws_ecs_select_task" ]
 [#assign AWS_ECS_RUN_COMMAND_TASK_TYPE = "aws_ecs_run_command" ]
 [#assign AWS_EC2_SELECT_INSTANCE_TASK_TYPE = "aws_ec2_select_instance" ]
+[#assign AWS_KMS_ENCRYPT_VALUE_TASK_TYPE = "aws_kms_encrypt_value" ]


### PR DESCRIPTION


## Intent of Change
<!-- Delete all that do not apply                      -->
- Documentation (new or update to existing)
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
- Adds support accross all components for at-rest encryption of logs stored in CloudWatch Logs
- Adds an extension for the baselinekey component to add the required KMS policy for Cloudwatch to encrypt logs. This is not included by default 
- Adds a module to highlight the configuration required for enabling logging encryption
- Uses the logging profile assigned to the component to control the service
- Adds a task to encrypt a value using AWS KMS 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This is a common security requirement and ensures we meet compliance requirements for deployments

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1915

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

