### PR TITLE
feat: add baseline encryption module

### DIFF
--- a/aws/modules/baseline/module.ftl
+++ b/aws/modules/baseline/module.ftl
@@ -1,0 +1,258 @@
+[#ftl]
+
+[@addModule
+    name="baseline"
+    description="The baseline module for AWS which controls the base level resources required for all deployments"
+    provider=AWS_PROVIDER
+    properties=[]
+/]
+
+[#macro aws_module_baseline]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "mgmt": {
+                    "Components" : {
+                        "baseline": {
+                            "baseline": {
+                                "deployment:Unit": "baseline",
+                                "DataBuckets": {
+                                    "opsdata": {
+                                        "Role": "operations",
+                                        "Encryption": {
+                                            "EncryptionSource": "LocalService"
+                                        },
+                                        "Lifecycles": {
+                                            "flowlogs": {
+                                                "Prefix": "VPCFlowLogs",
+                                                "Expiration": "_flowlogs",
+                                                "Offline": "_flowlogs"
+                                            },
+                                            "awslogs": {
+                                                "Prefix": "AWSLogs",
+                                                "Expiration": "_operations",
+                                                "Offline": "_operations"
+                                            },
+                                            "cloudfront": {
+                                                "Prefix": "CLOUDFRONTLogs",
+                                                "Expiration": "_operations",
+                                                "Offline": "_operations"
+                                            },
+                                            "docker": {
+                                                "Prefix": "DOCKERLogs",
+                                                "Expiration": "_operations",
+                                                "Offline": "_operations"
+                                            },
+                                            "waf": {
+                                                "Prefix": "WAF",
+                                                "Expiration": "_operations",
+                                                "Offline": "_operations"
+                                            }
+                                        },
+                                        "Links": {
+                                            "cf_key": {
+                                                "Tier": "mgmt",
+                                                "Component": "baseline",
+                                                "Instance": "",
+                                                "Version": "",
+                                                "Key": "oai"
+                                            }
+                                        }
+                                    },
+                                    "appdata": {
+                                        "Role": "appdata",
+                                        "Lifecycles": {
+                                            "global": {
+                                                "Expiration": "_data",
+                                                "Offline": "_data"
+                                            }
+                                        }
+                                    }
+                                },
+                                "Keys": {
+                                    "ssh": {
+                                        "Engine": "ssh"
+                                    },
+                                    "cmk": {
+                                        "Engine": "cmk",
+                                        "Extensions": [
+                                            "_cmk_s3_access",
+                                            "_cmk_ses_access",
+                                            "_cmk_cloudfront_access"
+                                        ]
+                                    },
+                                    "oai": {
+                                        "Engine": "oai"
+                                    }
+                                }
+                            }
+                        },
+                        "baseline_kms-encrypt" : {
+                            "Description" : "Encrypt a string or filepath with the baseline kms key",
+                            "Type" : "runbook",
+                            "Engine" : "hamlet",
+                            "Inputs" : {
+                                "Value" : {
+                                    "Description" : "The value to encrypt",
+                                    "Types" : [ "string" ],
+                                    "Mandatory" : true
+                                },
+                                "EncryptionScheme" : {
+                                    "Description" : "A scheme prefix to added to the result",
+                                    "Types" : [ "string" ],
+                                    "Default" : ""
+                                }
+                            },
+                            "Steps" : {
+                                "aws_login" : {
+                                    "Priority" : 5,
+                                    "Extensions" : [ "_runbook_get_provider_id" ],
+                                    "Task" : {
+                                        "Type" : "set_provider_credentials",
+                                        "Parameters" : {
+                                            "AccountId" : {
+                                                "Value" : "__setting:ACCOUNT__"
+                                            }
+                                        }
+                                    }
+                                },
+                                "kms_encrypt" : {
+                                    "Priority" : 100,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Task" : {
+                                        "Type" : "aws_kms_encrypt_value",
+                                        "Parameters" : {
+                                            "KeyArn" : {
+                                                "Value" : "__attribute:key:ARN__"
+                                            },
+                                            "Value" : {
+                                                "Value" : "__input:Value__"
+                                            },
+                                            "EncryptionScheme" : {
+                                                "Value" : "__input:EncryptionScheme__"
+                                            },
+                                            "AWSAccessKeyId" : {
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Value" : "__output:aws_login:aws_session_token__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "key" : {
+                                            "Tier" : "mgmt",
+                                            "Component" : "baseline",
+                                            "SubComponent" : "cmk",
+                                            "Type" : "baselinekey"
+                                        }
+                                    }
+                                },
+                                "output" : {
+                                    "Priority" : 120,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Task" : {
+                                        "Type" : "output_echo",
+                                        "Parameters" : {
+                                            "Value" : {
+                                                "Value" : "__output:kms_encrypt:result__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "key" : {
+                                            "Tier" : "mgmt",
+                                            "Component" : "baseline",
+                                            "SubComponent" : "cmk",
+                                            "Type" : "baselinekey"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "baseline_kms-decrypt" : {
+                            "Description" : "Decrypt a base64 encoded kms ciphertext object",
+                            "Type" : "runbook",
+                            "Engine" : "hamlet",
+                            "Inputs" : {
+                                "Value" : {
+                                    "Description" : "The base64 encoded kms ciphertext",
+                                    "Types" : [ "string" ],
+                                    "Mandatory" : true
+                                },
+                                "EncryptionScheme" : {
+                                    "Description" : "If the value included an encryption scheme the scheme that has been used",
+                                    "Types" : [ "string" ],
+                                    "Default" : ""
+                                }
+                            },
+                            "Steps" : {
+                                "aws_login" : {
+                                    "Priority" : 5,
+                                    "Extensions" : [ "_runbook_get_provider_id" ],
+                                    "Task" : {
+                                        "Type" : "set_provider_credentials",
+                                        "Parameters" : {
+                                            "AccountId" : {
+                                                "Value" : "__setting:ACCOUNT__"
+                                            }
+                                        }
+                                    }
+                                },
+                                "kms_decrypt" : {
+                                    "Priority" : 100,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Task" : {
+                                        "Type" : "aws_kms_decrypt_ciphertext",
+                                        "Parameters" : {
+                                            "Ciphertext" : {
+                                                "Value" : "__input:Value__"
+                                            },
+                                            "EncryptionScheme" : {
+                                                "Value" : "__input:EncryptionScheme__"
+                                            },
+                                            "AWSAccessKeyId" : {
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Value" : "__output:aws_login:aws_session_token__"
+                                            }
+                                        }
+                                    }
+                                },
+                                "output" : {
+                                    "Priority" : 120,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Task" : {
+                                        "Type" : "output_echo",
+                                        "Parameters" : {
+                                            "Value" : {
+                                                "Value" : "__output:kms_decrypt:result__"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "BaselineProfiles": {
+                "default": {
+                    "OpsData": "opsdata",
+                    "AppData": "appdata",
+                    "Encryption": "cmk",
+                    "SSHKey": "ssh",
+                    "CDNOriginKey": "oai"
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/aws/modules/runbook_rds_pgdump/module.ftl
+++ b/aws/modules/runbook_rds_pgdump/module.ftl
@@ -57,7 +57,7 @@
                                     "Priority" : 10,
                                     "Extensions" : [ "_runbook_get_region" ],
                                     "Task" : {
-                                        "Type" : "aws_decrypt_kms_ciphertext",
+                                        "Type" : "aws_kms_decrypt_ciphertext",
                                         "Parameters" : {
                                             "Ciphertext" : {
                                                 "Value" : "__attribute:ssh_key:PRIVATE_KEY__"
@@ -89,7 +89,7 @@
                                     "Priority" : 10,
                                     "Extensions" : [ "_runbook_get_region" ],
                                     "Task" : {
-                                        "Type" : "aws_decrypt_kms_ciphertext",
+                                        "Type" : "aws_kms_decrypt_ciphertext",
                                         "Parameters" : {
                                             "Ciphertext" : {
                                                 "Value" : "__attribute:db:URL__"

--- a/aws/modules/ssh_bastion/module.ftl
+++ b/aws/modules/ssh_bastion/module.ftl
@@ -74,7 +74,7 @@
                                     "Extensions" : [ "_runbook_get_provider_id" ],
                                     "Task" : {
                                         "Type" : "set_provider_credentials",
-                                        "Properties" : {
+                                        "Parameters" : {
                                             "AccountId" : {
                                                 "Value" : "__setting:ACCOUNT__"
                                             }
@@ -85,7 +85,7 @@
                                     "Priority" : 10,
                                     "Extensions" : [ "_runbook_get_region" ],
                                     "Task" : {
-                                        "Type" : "aws_decrypt_kms_ciphertext",
+                                        "Type" : "aws_kms_decrypt_ciphertext",
                                         "Parameters" : {
                                             "Ciphertext" : {
                                                 "Value" : "__attribute:ssh_key:PRIVATE_KEY__"
@@ -162,7 +162,7 @@
                                     "Priority" : 10,
                                     "Extensions" : [ "_runbook_get_region" ],
                                     "Task" : {
-                                        "Type" : "aws_decrypt_kms_ciphertext",
+                                        "Type" : "aws_kms_decrypt_ciphertext",
                                         "Parameters" : {
                                             "Ciphertext" : {
                                                 "Value" : "__attribute:ssh_key:PRIVATE_KEY__"

--- a/aws/tasks/aws_kms_decrypt_ciphertext/id.ftl
+++ b/aws/tasks/aws_kms_decrypt_ciphertext/id.ftl
@@ -1,7 +1,7 @@
 [#ftl]
 
 [@addTask
-    type=AWS_DECRYPT_KMS_CIPHERTEXT_TASK_TYPE
+    type=AWS_KMS_DECRYPT_CIPHERTEXT_TASK_TYPE
     properties=[
             {
                 "Type"  : "Description",
@@ -14,12 +14,6 @@
             "Description" : "The ciphertext value",
             "Types" : STRING_TYPE,
             "Mandatory" : true
-        },
-        {
-            "Names" : "Base64Encoded",
-            "Description" : "Is the Ciphertext base64 encoded",
-            "Types" : BOOLEAN_TYPE,
-            "Default" : true
         },
         {
             "Names" : "EncryptionScheme",

--- a/aws/tasks/aws_kms_encrypt_value/id.ftl
+++ b/aws/tasks/aws_kms_encrypt_value/id.ftl
@@ -1,0 +1,51 @@
+[#ftl]
+
+[@addTask
+    type=AWS_KMS_ENCRYPT_VALUE_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Given a value return the a base64 encoded string of the KMS Symetric encrypted ciphertext"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "KeyArn",
+            "Description" : "The Arn of the kms key or alias to encrypt the value with",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Value",
+            "Description" : "The value that needs to be encrypted",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "EncryptionScheme",
+            "Description" : "A scheme style prefix to add to the base64 encoded value",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        }
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/task.ftl
+++ b/aws/tasks/task.ftl
@@ -1,6 +1,7 @@
 [#ftl]
 
-[#assign AWS_DECRYPT_KMS_CIPHERTEXT_TASK_TYPE = "aws_decrypt_kms_ciphertext" ]
 [#assign AWS_ECS_SELECT_TASK_TASK_TYPE = "aws_ecs_select_task" ]
 [#assign AWS_ECS_RUN_COMMAND_TASK_TYPE = "aws_ecs_run_command" ]
 [#assign AWS_EC2_SELECT_INSTANCE_TASK_TYPE = "aws_ec2_select_instance" ]
+[#assign AWS_KMS_ENCRYPT_VALUE_TASK_TYPE = "aws_kms_encrypt_value" ]
+[#assign AWS_KMS_DECRYPT_CIPHERTEXT_TASK_TYPE = "aws_kms_decrypt_ciphertext" ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a baseline module that includes runbooks for encrypting and decrypting secrets using the kms key generated as part of the baseline
- fixes some typos in existing runbook modules
- renames the encrypt runbook task to include the service before the action

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for migrating the way that operational tasks are performed to runbooks instead of external scripts and allows for these tasks to be used for other purposes in runbooks

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

