### PR TITLE
fix(cdn): missing logging profile for waf logging

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -28,6 +28,7 @@
     [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]!"") ]
 
     [#local securityProfile = getSecurityProfile(occurrence, core.Type)]
+    [#local loggingProfile = getLoggingProfile(occurrence)]
 
     [#local certificateObject = getCertificateObject(solution.Certificate) ]
     [#local hostName = getHostName(certificateObject, occurrence) ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds logging profile to support setting up logging for waf to cloudwatch

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Template generation failing when cloudwatch logging used for WAF

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

