### PR TITLE
feat(globaldb): cloudwatch alarms

### DIFF
--- a/aws/components/globaldb/state.ftl
+++ b/aws/components/globaldb/state.ftl
@@ -20,6 +20,7 @@
                     "Id" : id,
                     "Name" : core.FullName,
                     "Key" : key,
+                    "Monitored": true,
                     "Type" : AWS_DYNAMODB_TABLE_RESOURCE_TYPE
                 } +
                 attributeIfContent(


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Add support for monitoring dynamodb tables with cloudwatch alarms

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for monitoring tables 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

