### PR TITLE
fix(sns): add support for encrypted topics

### DIFF
--- a/aws/services/sns/policy.ftl
+++ b/aws/services/sns/policy.ftl
@@ -121,3 +121,20 @@
         ]
     ]
 [/#function]
+
+[#function snsEncryptionStatement actions keyId topicRegion ]
+    [#return
+        [
+            getPolicyStatement(
+                asArray(actions),
+                getArn(keyId, false, topicRegion),
+                "",
+                {
+                    "StringEquals" : {
+                        "kms:ViaService" : formatDomainName( "sns", topicRegion, "amazonaws.com" )
+                    }
+                }
+            )
+        ]
+    ]
+[/#function]

--- a/aws/services/sns/resource.ftl
+++ b/aws/services/sns/resource.ftl
@@ -10,6 +10,9 @@
         },
         NAME_ATTRIBUTE_TYPE : {
             "Attribute" : "TopicName"
+        },
+        REGION_ATTRIBUTE_TYPE: {
+            "Value" : { "Ref" : "AWS::Region" }
         }
     }
 ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds role policy support for encrypted topics which require the caller to have KMS access to the key used to encrypt the topic

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Publish actions failing when a component attempted to publish to a queue with at rest encryption enabled

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

