### PR TITLE
refactor(backup): Configuration options

### DIFF
--- a/aws/components/backupstore/setup.ftl
+++ b/aws/components/backupstore/setup.ftl
@@ -180,9 +180,9 @@
 
             [#-- Check if store matches are required --]
             [#local conditions = {} ]
-            [#if isPresent(subSolution.Targets.MatchesStore) ]
+            [#if isPresent(subSolution.Conditions.MatchesStore) ]
                 [#list ["Product","Environment","Segment","Tier"] as tag]
-                    [#if subSolution.Targets.MatchesStore[tag]!false]
+                    [#if subSolution.Conditions.MatchesStore[tag]!false]
                         [#local conditionValue = "HamletFatal: Unknown backup condition tag" ]
                         [#switch tag]
                             [#case "Product"]
@@ -210,8 +210,13 @@
                 [/#list]
             [/#if]
 
-            [#-- Check for any specific resources to be included --]
+            [#-- Check if all resource should be considered --]
             [#local includedResources = [] ]
+            [#if isPresent(subSolution.Targets.All) ]
+                [#local includedResources = ["*"] ]
+            [/#if]
+
+            [#-- Check for any specific resources to be included --]
             [#list subSolution.Targets.Components.Inclusions?values as link]
                 [#if link?is_hash]
 

--- a/aws/components/backupstore/state.ftl
+++ b/aws/components/backupstore/state.ftl
@@ -24,7 +24,12 @@
                 "ARN" : getExistingReference(vaultId, ARN_ATTRIBUTE_TYPE)
             },
             "Roles" : {
-                "Inbound" : {},
+                "Inbound" : {
+                    "invoke" : {
+                        "Principal" : "backup.amazonaws.com",
+                        "SourceArn" : getReference(vaultId, ARN_ATTRIBUTE_TYPE)
+                    }
+                },
                 "Outbound" : {}
             }
         }

--- a/aws/services/backup/resource.ftl
+++ b/aws/services/backup/resource.ftl
@@ -205,17 +205,18 @@
 
 [#macro createBackupSelection id name planId roleId tags=[] resources=[] conditions={} exclusions=[] dependencies=""]
 
-    [#-- Treat everything as a potential target by default (likely limited by conditions) --]
-    [#local requiredResources = [ "*" ] ]
 
     [#-- If explicit targets have been provided, use those --]
-    [#if tags?has_content || resources?has_content]
-        [#local requiredResources = [] ]
-        [#list resources as resource]
+    [#local requiredResources = [] ]
+    [#list resources as resource]
+        [#if resource == "*" ]
+            [#-- If the resource wildcard, then just include everything --]
+            [#local requiredResources = [ resource ] ]
+            [#break]
+        [#else]
             [#local requiredResources += [ getArn(resource) ] ]
-        [/#list]
-    [/#if]
-
+        [/#if]
+    [/#list]
 
     [#local requiredExclusions = [] ]
     [#list exclusions as exclusion]


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
- separate out conditions from targets
- add an "All" target option to support the use case where everything in a solution should be considered as a candidate target.
- remove the specific logic in the AWS Backup service support for adding the resource wildcard so it can be applied in a broader range of cases, and move control of it to the backupstore component.

## Motivation and Context
When adding backup to the baseline module for a customer, the need for more flexibility in the configuration options was exposed.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- https://github.com/hamlet-io/engine/pull/1926

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

