### PR TITLE
fix: efs mount script formatting

### DIFF
--- a/aws/extensions/computetask_awslinux_efsmount/extension.ftl
+++ b/aws/extensions/computetask_awslinux_efsmount/extension.ftl
@@ -64,10 +64,10 @@
                     [#local script += [
                         r'# Create mount dir in EFS',
                         r'temp_dir="$(mktemp -d -t efs.XXXXXXXX)"',
-                        r'mount -t efs "${efsId}:/" ${temp_dir} || exit $?',
-                        r'if [[ ! -d "${temp_dir}/' + directory + r' ]]; then',
+                        r'mount -t efs ' + '"${efsId}:/"' + r' ${temp_dir} || exit $?',
+                        r'if [[ ! -d "${temp_dir}/' + directory + r'" ]]; then',
                         r'  mkdir -p "${temp_dir}/' + directory + r'"',
-                        r'  # Allow Full Access to volume (Allows for unkown container access )',
+                        r'  # Allow Full Access to volume (Allows for unknown container access )',
                         r'  chmod -R ugo+rwx "${temp_dir}/' + directory + r'"',
                         r'fi',
                         r'umount ${temp_dir}'


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- escaping and freemarker formatting for the efsId that was provided as part of the template script

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Script was failing to run on ec2 instances

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

