### PR TITLE
feat(s3): backup support

### DIFF
--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -38,6 +38,7 @@
     [#local replicationDestinationAccountId = "" ]
     [#local replicationExternalPolicy = []]
 
+    [#local backupTags = [] ]
 
     [#-- Baseline component lookup --]
     [#local baselineLinks = getBaselineLinks(occurrence, [ "CDNOriginKey", "Encryption" ])]
@@ -314,6 +315,25 @@
                             [#break]
                     [/#switch]
                     [#break]
+
+                [#case BACKUPSTORE_REGIME_COMPONENT_TYPE]
+                    [#if linkTargetAttributes["TAG_NAME"]?has_content]
+                        [#local backupTags +=
+                            [
+                                {
+                                    "Key" : linkTargetAttributes["TAG_NAME"],
+                                    "Value" : linkTargetAttributes["TAG_VALUE"]
+                                }
+                            ]
+                        ]
+                    [#else]
+                        [@warn
+                            message="Ignoring linked backup regime \"${linkTargetCore.SubComponent.Name}\" that does not support tag based inclusion"
+                            context=linkTargetCore
+                        /]
+                    [/#if]
+                    [#break]
+
             [/#switch]
         [/#if]
     [/#list]
@@ -494,6 +514,7 @@
             kmsKeyId=kmsKeyId
             inventoryReports=inventoryReports
             dependencies=dependencies
+            tags=backupTags
         /]
     [/#if]
 [/#macro]

--- a/aws/services/s3/resource.ftl
+++ b/aws/services/s3/resource.ftl
@@ -376,7 +376,9 @@
                         CORSBehaviours=[]
                         inventoryReports=[]
                         dependencies=""
-                        outputId=""]
+                        outputId=""
+                        tags=[]
+                        ]
 
     [#local loggingConfiguration = {} ]
 
@@ -519,7 +521,7 @@
                 "InventoryConfigurations",
                 inventoryReports
             )
-        tags=getCfTemplateCoreTags("", tier, component, "", false, false, 7)
+        tags=getCfTemplateCoreTags() + tags
         outputs=S3_OUTPUT_MAPPINGS
         outputId=outputId
         dependencies=dependencies


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
- add ability for an S3 bucket to be included in backups via a link to a backup regime. This results in it receiving the tag associated with the regime.
- remove the limitation on the tags per bucket. There is a limit of 10 tags per bucket object, but a bucket itself can have
up to 50 tags (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html).


## Motivation and Context
Allow backups to cover S3 buckets in cases where components affected by backups are explicitly targetted.

## How Has This Been Tested?
Local template generation.

The ability to add more than 10 tags per bucket was tested through the console.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

