### PR TITLE
feat(directory): log forwarding support

### DIFF
--- a/aws/components/directory/setup.ftl
+++ b/aws/components/directory/setup.ftl
@@ -30,6 +30,8 @@
     [#local engine = solution.Engine]
     [#local enableSSO = solution["aws:EnableSSO"]]
 
+    [#local loggingProfile = getLoggingProfile(occurrence)]
+
     [#local networkProfile = getNetworkProfile(occurrence)]
     [#local hibernate = solution.Hibernate.Enabled && isOccurrenceDeployed(occurrence)]
 
@@ -173,6 +175,20 @@
 
         [#switch engine ]
             [#case "ActiveDirectory"]
+
+                [#if solution.Logging.Enabled ]
+                    [#local lgId = resources["lg"].Id ]
+                    [#local lgName = resources["lg"].Name ]
+
+                    [@setupLogGroup
+                        occurrence=occurrence
+                        logGroupId=lgId
+                        logGroupName=lgName
+                        loggingProfile=loggingProfile
+                        kmsKeyId=cmkKeyId
+                    /]
+                [/#if]
+
             [#case "Simple"]
                 [#if !hibernate]
 
@@ -344,6 +360,57 @@
                 [#break]
         [/#switch]
 
+        [#local directoryLoggingScript = []]
+
+        [#if solution.Logging.Enabled]
+
+            [#switch engine ]
+
+                [#case "ActiveDirectory"]
+
+                    [#local lgId = resources["lg"].Id ]
+                    [#local lgName = resources["lg"].Name ]
+
+                    [#local directoryLoggingScript = [
+                        r'case ${STACK_OPERATION} in',
+                        r'  create|update)'
+                        r'      info "enabling log forwarding"',
+                        r'      if [[ -z "$(aws --region ' + getRegion() + r' ds list-log-subscriptions --query "LogSubscriptions[?DirectoryId==' + r"'${ds_id}'" + r'].LogGroupName" --output text)" ]]; then',
+                        r'          aws --region ' + getRegion() + r' ds create-log-subscription --directory-id "${ds_id}" --log-group-name "' + lgName + '" || return $?',
+                        r'      fi',
+                        r'   ;;',
+                        r'esac'
+                    ]]
+                    [#break]
+
+                    [#default]
+                        [@fatal
+                            message="Logging not available for this engine"
+                            detail={
+                                "Id" : core.RawId
+                                "Engine" : engine
+                            }
+                        /]
+            [/#switch]
+        [#else]
+
+            [#switch engine ]
+
+                [#case "ActiveDirectory"]
+
+                    [#local directoryLoggingScript = [
+                        r'case ${STACK_OPERATION} in',
+                        r'  create|update)'
+                        r'      info "removing log forwarding"',
+                        r'      if [[ -n "$(aws --region ' + getRegion() + r' ds list-log-subscriptions --query "LogSubscriptions[?DirectoryId==' + r"'${ds_id}'" + r'].LogGroupName" --output text)" ]]; then',
+                        r'          aws --region ' + getRegion() + r' ds delete-log-subscription --directory-id "${ds_id}" || return $?',
+                        r'      fi',
+                        r'   ;;',
+                        r'esac'
+                    ]]
+                    [#break]
+            [/#switch]
+        [/#if]
 
         [#local secgrp_lockdown=[]]
 
@@ -410,6 +477,7 @@
         [@addToDefaultBashScriptOutput
             content=
                 directoryIdScript +
+                directoryLoggingScript +
                 secgrp_lockdown
         /]
     [/#if]

--- a/aws/components/directory/setup.ftl
+++ b/aws/components/directory/setup.ftl
@@ -387,7 +387,7 @@
                         [@fatal
                             message="Logging not available for this engine"
                             detail={
-                                "Id" : core.RawId
+                                "Id" : core.RawId,
                                 "Engine" : engine
                             }
                         /]

--- a/aws/components/directory/state.ftl
+++ b/aws/components/directory/state.ftl
@@ -70,6 +70,22 @@
 
     [#switch solution.Engine ]
         [#case "ActiveDirectory"]
+
+            [#if solution.Logging.Enabled ]
+                [#local lgName = formatAbsolutePath("aws", "directoryservice", core.FullName)]
+                [#local resources = mergeObjects(
+                    resources,
+                    {
+                        "lg" : {
+                            "Id" : formatLogGroupId(core.Id),
+                            "Name" : lgName,
+                            "Type" : AWS_CLOUDWATCH_LOG_GROUP_RESOURCE_TYPE,
+                            "IncludeInDeploymentState" : false
+                        }
+                    }
+                )]
+            [/#if]
+
         [#case "Simple"]
 
             [#local id = formatResourceId(AWS_DIRECTORY_RESOURCE_TYPE, core.Id) ]

--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -1404,6 +1404,11 @@
                     "deployment:Priority" : 100,
                     "GroupDeploymentUnit" : false
                 },
+                "directory" : {
+                    "deployment:Unit" : "directory",
+                    "deployment:Priority" : 100,
+                    "GroupDeploymentUnit" : false
+                },
                 "ecs" : {
                     "deployment:Unit" : "ecs",
                     "deployment:Priority" : 100,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for forwarding logs from a managed AD directory service to CloudWatch
- Adds directory deployment to aws masterdata for legacy deployment support

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for capturing and auditing security events occurring in the managed ad environment

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally and on test deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

