### PR TITLE
fix(task): kms encrypt parameters

### DIFF
--- a/aws/tasks/aws_encrypt_kms_ciphertext/id.ftl
+++ b/aws/tasks/aws_encrypt_kms_ciphertext/id.ftl
@@ -10,16 +10,16 @@
         ]
     attributes=[
         {
+            "Names" : "KeyArn",
+            "Description" : "The Arn of the of the KMS key to encrypt the value",
+            "Types" : STRING_TYPE,
+            "Default" : true
+        },
+        {
             "Names" : "Value",
             "Description" : "The value that needs to be encrypted",
             "Types" : STRING_TYPE,
             "Mandatory" : true
-        },
-        {
-            "Names" : "Base64Encode",
-            "Description" : "Return the ciphertext as a base64 encoded string",
-            "Types" : BOOLEAN_TYPE,
-            "Default" : true
         },
         {
             "Names" : "Region",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- fixes the required paramters for encrypting values with kms as a task

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The implementation in runbooks and the python cli were expecting different parameters to what was used in the privder.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

