### PR TITLE
refactor(s3): use references for bucket policy

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -380,9 +380,8 @@
                 [#if bucketPolicy?has_content ]
                     [@createBucketPolicy
                         id=bucketPolicyId
-                        bucket=bucketName
+                        bucketId=bucketId
                         statements=bucketPolicy
-                        dependencies=bucketId
                     /]
                 [/#if]
             [/#if]

--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -485,9 +485,8 @@
         [#if policyStatements?has_content ]
             [@createBucketPolicy
                 id=bucketPolicyId
-                bucket=s3Name
+                bucketId=s3Id
                 statements=policyStatements
-                dependencies=s3Id
             /]
         [/#if]
 

--- a/aws/services/s3/resource.ftl
+++ b/aws/services/s3/resource.ftl
@@ -528,13 +528,13 @@
     /]
 [/#macro]
 
-[#macro createBucketPolicy id bucket statements dependencies=[] ]
+[#macro createBucketPolicy id bucketId statements dependencies=[] ]
     [@cfResource
         id=id
         type="AWS::S3::BucketPolicy"
         properties=
             {
-                "Bucket" : (getExistingReference(bucket)?has_content)?then(getExistingReference(bucket),bucket)
+                "Bucket" : getReference(bucketId)
             } +
             getPolicyDocument(statements)
         outputs={}


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- uses getReference to get the bucket name for bucket policies

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
A complicated process was being used to find the bucket name along with a fixed dependency. Using the reference ensures the dependency is met and that cfn_lint is happy

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

