### PR TITLE
refactor: iam standard policies and ecs container migration

### DIFF
--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -112,7 +112,7 @@
             "DefaultEnvironmentVariables" : true,
             "DefaultBaselineVariables" : true,
             "DefaultLinkVariables" : true,
-            "Policy" : standardPolicies(occurrence, baselineComponentIds),
+            "Policy" : iamStandardPolicies(occurrence, baselineComponentIds),
             "ManagedPolicy" : [],
             "ComputeTasks" : [],
             "Files" : {},

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -153,7 +153,7 @@
             "DefaultEnvironmentVariables" : true,
             "DefaultLinkVariables" : true,
             "DefaultBaselineVariables" : true,
-            "Policy" : standardPolicies(occurrence, baselineComponentIds),
+            "Policy" : iamStandardPolicies(occurrence, baselineComponentIds),
             "ManagedPolicy" : [],
             "ComputeTasks" : [],
             "Files" : {},

--- a/aws/components/datapipeline/setup.ftl
+++ b/aws/components/datapipeline/setup.ftl
@@ -114,7 +114,7 @@
             "Environment" : {},
             "Links" : contextLinks,
             "BaselineLinks" : baselineLinks,
-            "Policy" : standardPolicies(occurrence, baselineComponentIds),
+            "Policy" : iamStandardPolicies(occurrence, baselineComponentIds),
             "DefaultCoreVariables" : true,
             "DefaultEnvironmentVariables" : true,
             "DefaultLinkVariables" : true,

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -108,7 +108,7 @@
             "DefaultEnvironmentVariables" : false,
             "DefaultLinkVariables" : true,
             "DefaultBaselineVariables" : true,
-            "Policy" : standardPolicies(occurrence, baselineComponentIds),
+            "Policy" : iamStandardPolicies(occurrence, baselineComponentIds),
             "ManagedPolicy" : [],
             "ComputeTasks" : [],
             "Files" : {},

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -101,7 +101,7 @@
             "DefaultEnvironmentVariables" : true,
             "DefaultLinkVariables" : true,
             "DefaultBaselineVariables" : true,
-            "Policy" : standardPolicies(occurrence, baselineComponentIds),
+            "Policy" : iamStandardPolicies(occurrence, baselineComponentIds),
             "ManagedPolicy" : [],
             "ComputeTasks" : [],
             "Files" : {},
@@ -668,7 +668,7 @@
 
         [#local taskId = resources["task"].Id ]
         [#local taskName = resources["task"].Name ]
-        [#local containers = getTaskContainers(occurrence, subOccurrence) ]
+        [#local containers = getECSTaskContainers(occurrence, subOccurrence) ]
 
         [#local networkMode = solution.NetworkMode]
         [#if solution.NetworkMode == "aws:awsvpc"]

--- a/aws/components/federatedrole/setup.ftl
+++ b/aws/components/federatedrole/setup.ftl
@@ -91,7 +91,7 @@
         [#local _context =
             {
                 "Links" : contextLinks,
-                "Policy" : standardPolicies(subOccurrence, baselineComponentIds),
+                "Policy" : iamStandardPolicies(subOccurrence, baselineComponentIds),
                 "ManagedPolicy" : [],
                 "Assignment" : subCore.SubComponent.Id,
                 "DefaultCoreVariables" : false,

--- a/aws/components/healthcheck/setup.ftl
+++ b/aws/components/healthcheck/setup.ftl
@@ -220,7 +220,7 @@
                     "DefaultEnvironmentVariables" : false,
                     "DefaultLinkVariables" : false,
                     "DefaultBaselineVariables" : false,
-                    "Policy" : standardPolicies(occurrence, baselineComponentIds),
+                    "Policy" : iamStandardPolicies(occurrence, baselineComponentIds),
                     "ManagedPolicy" : [],
                     "Script" : []
                 }

--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -131,7 +131,7 @@
             "DefaultEnvironmentVariables" : true,
             "DefaultLinkVariables" : true,
             "DefaultBaselineVariables" : true,
-            "Policy" : standardPolicies(fn, baselineComponentIds),
+            "Policy" : iamStandardPolicies(fn, baselineComponentIds),
             "ManagedPolicy" : [],
             "CodeHash" : solution.FixedCodeVersion.CodeHash,
             "VersionDependencies" : [],

--- a/aws/components/user/setup.ftl
+++ b/aws/components/user/setup.ftl
@@ -64,7 +64,7 @@
             "DefaultCoreVariables" : false,
             "DefaultEnvironmentVariables" : false,
             "DefaultLinkVariables" : false,
-            "Policy" : standardPolicies(occurrence, baselineComponentIds),
+            "Policy" : iamStandardPolicies(occurrence, baselineComponentIds),
             "TransferMounts" : {}
         }
     ]

--- a/aws/services/ecs/resource.ftl
+++ b/aws/services/ecs/resource.ftl
@@ -778,3 +778,482 @@
             dependencies=dependencies
         /]
 [/#macro]
+
+[#assign ECS_DEFAULT_MEMORY_LIMIT_MULTIPLIER=1.5 ]
+
+[#function getECSTaskContainers ecs task]
+
+    [#local core = task.Core ]
+    [#local solution = task.Configuration.Solution ]
+
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(task, [ "OpsData", "AppData", "Encryption" ] )]
+    [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+
+    [#local operationsBucket = getExistingReference(baselineComponentIds["OpsData"]) ]
+    [#local dataBucket = getExistingReference(baselineComponentIds["AppData"])]
+
+    [#local tier = core.Tier ]
+    [#local component = core.Component ]
+
+    [#local containers = [] ]
+
+    [#list solution.Containers as containerId, container]
+        [#local containerPortMappings = [] ]
+        [#local containerLinks = mergeObjects( solution.Links, container.Links) ]
+        [#local inboundPorts = []]
+        [#local ingressRules = []]
+        [#local egressRules = []]
+
+        [#list container.Ports?values as port]
+
+            [#local containerPortMapping =
+                {
+                    "ContainerPort" :
+                        contentIfContent(
+                            port.Container!"",
+                            port.Name
+                        ),
+                    "HostPort" : port.Name,
+                    "DynamicHostPort" : port.DynamicHostPort
+                } ]
+
+            [#if port.LB.Configured]
+                [#local lbLink = getLBLink( task, port )]
+
+                [#if isDuplicateLink(containerLinks, lbLink) ]
+                    [@fatal
+                        message="Duplicate Link Name"
+                        context=containerLinks
+                        detail=lbLink /]
+                    [#continue]
+                [/#if]
+
+                [#-- Treat the LB link like any other - this will also detect --]
+                [#-- if the target is missing                                 --]
+                [#local containerLinks += lbLink]
+
+                [#-- Ports should only be defined if connecting to a load balancer --]
+                [#list lbLink as key,loadBalancer]
+                    [#local containerPortMapping +=
+                        {
+                            "LoadBalancer" :
+                                {
+                                    "Link" : loadBalancer.Name
+                                }
+                        }
+                    ]
+
+                [/#list]
+
+            [/#if]
+
+            [#if port.Registry.Configured]
+                [#local registryLink = getRegistryLink(task, port)]
+
+                [#if isDuplicateLink(containerLinks, registryLink) ]
+                    [@fatal
+                        message="Duplicate Link Name"
+                        context=containerLinks
+                        detail=RegistryLink /]
+                    [#continue]
+                [/#if]
+
+                [#-- Add to normal container links --]
+
+                [#local containerLinks += registryLink]
+
+                [#list registryLink as key,serviceRegistry]
+                    [#local containerPortMapping +=
+                        {
+                            "ServiceRegistry" :
+                                {
+                                    "Link" : serviceRegistry.Name
+                                }
+                        }
+                    ]
+
+                [/#list]
+            [/#if]
+
+            [#if port.IPAddressGroups?has_content]
+                [#if solution.NetworkMode == "awsvpc" || !port.LB.Configured ]
+                    [#list getGroupCIDRs(port.IPAddressGroups, true, task ) as cidr]
+                        [#local ingressRules += [ {
+                            "port" : port.DynamicHostPort?then(0,contentIfContent(
+                                                                            port.Container!"",
+                                                                            port.Name )),
+                            "cidr" : cidr
+                        }]]
+                    [/#list]
+                [#else]
+                    [@fatal
+                        message="Port IP Address Groups not supported for port configuration"
+                        context=container
+                        detail=port /]
+                    [#continue]
+                [/#if]
+            [/#if]
+
+            [#local containerPortMappings += [containerPortMapping] ]
+            [#local inboundPorts += [ port.Name ]]
+        [/#list]
+
+        [#local logDriver =
+            valueIfTrue(
+                "json-file",
+                container.LocalLogging,
+                container.LogDriver
+            ) ]
+
+        [#if logDriver != "awslogs" && solution.Engine == "fargate" ]
+            [@fatal
+                message="The fargate engine only supports the awslogs logging driver"
+                context=solution
+                /]
+            [#break]
+        [/#if]
+
+        [#local containerLgId =
+            formatDependentLogGroupId(core.Id,  container.Id?split("-")) ]
+        [#local containerLgName =
+            formatAbsolutePath(core.FullAbsolutePath, container.Name?split("-")) ]
+        [#local containerLogGroup =
+            valueIfTrue(
+                {
+                    "Id" : containerLgId,
+                    "Name" : containerLgName
+                },
+                container.ContainerLogGroup
+            ) ]
+
+        [#local logGroupId =
+            valueIfTrue(
+                containerLgId,
+                container.ContainerLogGroup,
+                valueIfTrue(
+                    task.State.Resources["lg"].Id!"",
+                    solution.TaskLogGroup,
+                    valueIfTrue(
+                        ecs.State.Resources["lg"].Id!"",
+                        ecs.Configuration.Solution.ClusterLogGroup,
+                        "HamletFatal: Logs type is awslogs but no group defined"
+                    )
+                )
+            ) ]
+
+        [#local logOptions =
+            logDriver?switch(
+                "fluentd",
+                {
+                    "tag" : concatenate(
+                                [
+                                    "docker",
+                                    productId,
+                                    segmentId,
+                                    tier.Id,
+                                    component.Id,
+                                    container.Id
+                                ],
+                                "."
+                            )
+                },
+                "awslogs",
+                {
+                    "awslogs-group" : getReference(logGroupId),
+                    "awslogs-region" : getRegion(),
+                    "awslogs-stream-prefix" : core.Name
+                },
+                {}
+            )]
+
+        [#local contextLinks = getLinkTargets(task, containerLinks) ]
+
+        [#local containerDetails = {
+            "Id" : contentIfContent(
+                    (container.Extensions[0])!"",
+                    getContainerId(container)
+            ),
+            "Name" : getContainerName(container)
+        }]
+
+        [#-- Add in extension specifics including override of defaults --]
+        [#-- Extensions are based on occurrences so we need to create a fake occurrence --]
+
+        [#-- add an extra setting namespace which is used to find the container build refernces when images --]
+        [#-- are manged by a container registry --]
+        [#local containerSettingNamespaces = combineEntities(
+            task.Configuration.SettingNamespaces,
+            [
+                {
+                    "Key" : formatName(task.Core.RawName, containerId)?lower_case,
+                    "Match" : "partial"
+                }
+            ],
+            APPEND_COMBINE_BEHAVIOUR
+        )]
+        [#local containerBuildSettings = getAdditionalBuildSettings(containerSettingNamespaces)]
+
+        [#local containerOccurrence = mergeObjects(
+            task,
+            {
+                "Configuration" : {
+                    "SettingNamespaces" : containerSettingNamespaces
+                }
+            }
+        )]
+        [#local containerOccurrence = mergeObjects(
+            containerOccurrence,
+            {
+                "Configuration" : {
+                    "Settings" : {
+                        "Build" : containerBuildSettings
+                    },
+                    "Environment" : {
+                        "Build" : getSettingsAsEnvironment(containerBuildSettings)
+                    }
+                }
+            }
+        )]
+
+        [#local _context =
+            containerDetails +
+            {
+                "Essential" : true,
+                "RegistryEndPoint" : getRegistryEndPoint("docker", task),
+                "Image" : formatRelativePath(
+                    formatName(
+                        getOccurrenceBuildProduct(task, productName),
+                        getOccurrenceBuildScopeExtension(task)
+                    ),
+                    formatName(
+                        getOccurrenceBuildUnit(task),
+                        getOccurrenceBuildReference(task)
+                    )
+                ),
+                "MemoryReservation" : container.MemoryReservation,
+                "Mode" : getContainerMode(container),
+                "LogDriver" : logDriver,
+                "LogOptions" : logOptions,
+                "DefaultEnvironment" : defaultEnvironment(containerOccurrence, contextLinks, baselineLinks),
+                "Environment" :
+                    {
+                        "APP_RUN_MODE" : getContainerMode(container),
+                        "AWS_REGION" : getRegion(),
+                        "AWS_DEFAULT_REGION" : getRegion()
+                    },
+                "Links" : contextLinks,
+                "BaselineLinks" : baselineLinks,
+                "DefaultCoreVariables" : true,
+                "DefaultEnvironmentVariables" : true,
+                "DefaultBaselineVariables" : true,
+                "DefaultLinkVariables" : true,
+                "Policy" : iamStandardPolicies(task, baselineComponentIds),
+                "Privileged" : container.Privileged,
+                "LogMetrics" : container.LogMetrics,
+                "Alerts" : container.Alerts,
+                "Container" : container,
+                "InitProcess" : container.InitProcess
+            } +
+            attributeIfContent("LogGroup", containerLogGroup) +
+            attributeIfContent("ImageVersion", container.Version) +
+            attributeIfContent("Cpu", container.Cpu) +
+            attributeIfContent("Gpu", container.Gpu) +
+            attributeIfTrue(
+                "MaximumMemory",
+                container.MaximumMemory?has_content &&
+                    container.MaximumMemory?is_number &&
+                    container.MaximumMemory > 0,
+                container.MaximumMemory!""
+            ) +
+            attributeIfTrue(
+                "MaximumMemory",
+                !container.MaximumMemory??,
+                container.MemoryReservation*ECS_DEFAULT_MEMORY_LIMIT_MULTIPLIER
+            ) +
+            attributeIfContent("PortMappings", containerPortMappings) +
+            attributeIfContent("IngressRules", ingressRules) +
+            attributeIfContent("InboundPorts", inboundPorts) +
+            attributeIfContent("RunCapabilities", container.RunCapabilities) +
+            attributeIfContent("ContainerNetworkLinks", container.ContainerNetworkLinks) +
+            attributeIfContent("PlacementConstraints", container.PlacementConstraints![] ) +
+            attributeIfContent("Ulimits", container.Ulimits )
+        ]
+
+        [#if container.Image.Source == "containerregistry" ]
+            [#local _context += { "Image" : container.Image["Source:containerregistry"].Image }]
+            [@debug message="SourceImage" context=container.Image["Source:containerregistry"].Image enabled=true /]
+        [/#if]
+
+        [#local linkIngressRules = [] ]
+        [#list _context.Links as linkId,linkTarget]
+            [#local linkTargetCore = linkTarget.Core ]
+            [#local linkTargetConfiguration = linkTarget.Configuration ]
+            [#local linkTargetResources = linkTarget.State.Resources ]
+            [#local linkTargetAttributes = linkTarget.State.Attributes ]
+            [#local linkTargetRoles = linkTarget.State.Roles ]
+
+            [#if (linkTargetRoles.Outbound["networkacl"]!{})?has_content ]
+                [#local egressRules += [ linkTargetRoles.Outbound["networkacl"] ]]
+            [/#if]
+
+            [#if linkTarget.Direction?lower_case == "Inbound" && linkTarget.Role == "networkacl" ]
+                [#local linkIngressRules += [  mergeObjects( linkTargetRoles.Inbound["networkacl"],  { "Ports" : inboundPorts } ) ] ]]
+            [/#if]
+
+            [#switch linkTargetCore.Type]
+                [#case DATAVOLUME_COMPONENT_TYPE]
+
+                    [#local dataVolumeEngine = linkTargetAttributes["ENGINE"] ]
+
+                    [#if ! ( ecs.Configuration.Solution.VolumeDrivers?seq_contains(dataVolumeEngine)) ]
+                            [@fatal
+                                message="Volume driver for this data volume not configured for ECS Cluster"
+                                context=ecs.Configuration.Solution.VolumeDrivers
+                                detail=ecs /]
+                    [/#if]
+
+                    [#local _context +=
+                        {
+                            "DataVolumes" :
+                                (_context.DataVolumes!{}) +
+                                {
+                                    linkId : {
+                                        "Name" : linkTargetAttributes["VOLUME_NAME"],
+                                        "Engine" : linkTargetAttributes["ENGINE"]
+                                    }
+                                }
+                        }]
+                    [#break]
+                [#case FILESHARE_COMPONENT_TYPE]
+                [#case FILESHARE_MOUNT_COMPONENT_TYPE]
+                    [#local _context +=
+                        {
+                            "DataVolumes" :
+                                (_context.DataVolumes!{}) +
+                                {
+                                    linkId : {
+                                        "Name" : formatName("efs", linkTargetAttributes["EFS"], linkTargetAttributes["ACCESS_POINT_ID"]!""),
+                                        "Engine" : "efs",
+                                        "EFS" : {
+                                            "FileSystemId" : linkTargetAttributes["EFS"]
+                                        } +
+                                        attributeIfContent(
+                                            "AccessPointId",
+                                            (linkTargetAttributes["ACCESS_POINT_ID"]!"")
+                                        )
+                                    }
+                                }
+                        }
+
+                    ]
+                    [#break]
+                [#case SECRETSTORE_SECRET_COMPONENT_TYPE ]
+                    [#local _context = mergeObjects(
+                        _context,
+                        {
+                            "Secrets" : {
+                                linkId : {
+                                    "Provider" : linkTargetAttributes["ENGINE"],
+                                    "Ref" : linkTargetResources["secret"].Id,
+                                    "EncryptionKeyId" : linkTargetResources["secret"].cmkKeyId
+                                }
+                            }
+                        })]
+                    [#break]
+
+                [#case DB_COMPONENT_TYPE]
+                    [#if ((linkTargetAttributes["SECRET_ARN"])!"")?has_content ]
+                        [#local _context = mergeObjects(
+                            _context,
+                            {
+                                "Secrets" : {
+                                    linkId : {
+                                        "Provider" : linkTargetResources["rootCredentials"]["secret"].Provider,
+                                        "Ref" : linkTargetResources["rootCredentials"]["secret"].Id,
+                                        "EncryptionKeyId" : linkTargetResources["rootCredentials"]["secret"].cmkKeyId
+                                    }
+                                }
+                            }
+                        )]
+                    [/#if]
+                    [#break]
+            [/#switch]
+        [/#list]
+
+        [#-- Add link based sec rules --]
+        [#local _context += { "EgressRules" : egressRules }]
+        [#local _context += { "LinkIngressRules" : linkIngressRules }]
+
+        [#-- Add in extension specifics including override of defaults --]
+        [#-- Extensions are based on occurrences so we need to create a fake occurrence --]
+        [#local containerOccurrence = mergeObjects(
+            containerOccurrence,
+            {
+                "Core" : {
+                    "Component" : containerDetails
+                },
+                "Configuration" : {
+                    "Solution" : container
+                }
+            }
+        )]
+        [#local _context = invokeExtensions(task, _context, containerOccurrence, [ container.Extensions ] )]
+        [#local _context += containerDetails ]
+        [#local _context += getFinalEnvironment(task, _context) ]
+
+        [#-- validate fargate requirements from container context --]
+        [#if solution.Engine == "fargate" ]
+            [#local fargateInvalidConfig = false ]
+            [#local fargateInvalidConfigMessage = [] ]
+
+            [#if !( [ 256, 512, 1024, 2048, 4096 ]?seq_contains(_context.Cpu) )  ]
+                [#local fargateInvalidConfig = true ]
+                [#local fargateInvalidConfigMessage += [ "CPU quota is not valid ( must be divisible by 256 )" ] ]
+            [/#if]
+
+            [#if !( _context.MaximumMemory?has_content )  ]
+                [#local fargateInvalidConfig = true ]
+                [#local fargateInvalidConfigMessage += [ "Maximum memory must be assigned" ]]
+            [/#if]
+
+            [#if (_context.Privileged )]
+                [#local fargateInvalidConfig = true ]
+                [#local fargateInvalidConfigMessage += [ "Cannot run in priviledged mode" ] ]
+            [/#if]
+
+            [#if _context.ContainerNetworkLinks!{}?has_content ]
+                [#local fargateInvalidConfig = true ]
+                [#local fargateInvalidConfigMessage += [ "Cannot use Network Links" ] ]
+            [/#if]
+
+            [#if (_context.Hosts!{})?has_content ]
+                [#local fargateInvalidConfig = true ]
+                [#local fargateInvalidConfigMessage += [ "Cannot add host entries" ] ]
+            [/#if]
+
+            [#list _context.Volumes!{} as name,volume ]
+                [#if volume.hostPath?has_content || volume.PersistVolume || ( volume.Driver != "local" && volume.Driver != "efs" ) ]
+                    [#local fargateInvalidConfig = true ]
+                    [#local fargateInvalidConfigMessage += [ "Can only use the local or efs driver and cannot reference host - volume ${name}" ] ]
+                [/#if]
+            [/#list]
+
+            [#if fargateInvalidConfig ]
+                [@fatal
+                    message="Invalid Fargate configuration"
+                    context=
+                        {
+                            "Description" : "Fargate containers only support the awsvpc network mode",
+                            "ValidationErrors" : fargateInvalidConfigMessage
+                        }
+                    detail=solution
+                /]
+            [/#if]
+        [/#if]
+
+        [#local containers += [_context] ]
+    [/#list]
+
+    [#return containers]
+[/#function]

--- a/aws/services/iam/policy.ftl
+++ b/aws/services/iam/policy.ftl
@@ -1,16 +1,5 @@
 [#ftl]
 
-[#function globalAdministratorAccess ]
-    [#return
-        [
-            getPolicyStatement(
-                [
-                    "*"
-                ]
-            )
-        ]
-    ]
-[/#function]
 
 [#function iamPassRolePermission role ]
     [#return
@@ -23,5 +12,60 @@
                 role
             )
         ]
+    ]
+[/#function]
+
+[#function iamStandardPolicies occurrence baselineIds ]
+    [#local permissions = occurrence.Configuration.Solution.Permissions ]
+    [#return
+        valueIfTrue(
+            cmkDecryptPermission(baselineIds["Encryption"]),
+            permissions.Decrypt,
+            []
+        ) +
+        valueIfTrue(
+            s3ReadPermission(baselineIds["OpsData"], getSettingsFilePrefix(occurrence)) +
+            s3ListPermission(baselineIds["OpsData"], getSettingsFilePrefix(occurrence)) +
+            s3EncryptionReadPermission(
+                baselineIds["Encryption"],
+                getExistingReference(baselineIds["OpsData"], NAME_ATTRIBUTE_TYPE),
+                getSettingsFilePrefix(occurrence),
+                getExistingReference(baselineIds["OpsData"], REGION_ATTRIBUTE_TYPE)
+            ) +
+
+            [#-- Support transition between FullRelativePath and FullRelativeRawPath --]
+            s3ReadPermission(baselineIds["OpsData"], occurrence.Core.FullRelativePath) +
+            s3ListPermission(baselineIds["OpsData"], occurrence.Core.FullRelativePath) +
+            s3EncryptionReadPermission(
+                baselineIds["Encryption"],
+                getExistingReference(baselineIds["OpsData"], NAME_ATTRIBUTE_TYPE),
+                occurrence.Core.FullRelativePath,
+                getExistingReference(baselineIds["OpsData"], REGION_ATTRIBUTE_TYPE)
+            ),
+            permissions.AsFile,
+            []
+        ) +
+        valueIfTrue(
+            s3AllPermission(baselineIds["AppData"], getAppDataFilePrefix(occurrence)) +
+            s3EncryptionAllPermission(
+                baselineIds["Encryption"],
+                getExistingReference(baselineIds["AppData"], NAME_ATTRIBUTE_TYPE),
+                getAppDataFilePrefix(occurrence),
+                getExistingReference(baselineIds["AppData"], REGION_ATTRIBUTE_TYPE)
+            ),
+            permissions.AppData,
+            []
+        ) +
+        valueIfTrue(
+            s3AllPermission(baselineIds["AppData"], getAppDataPublicFilePrefix(occurrence)) +
+            s3EncryptionAllPermission(
+                baselineIds["Encryption"],
+                getExistingReference(baselineIds["AppData"], NAME_ATTRIBUTE_TYPE),
+                getAppDataPublicFilePrefix(occurrence),
+                getExistingReference(baselineIds["AppData"], REGION_ATTRIBUTE_TYPE)
+            ),
+            permissions.AppPublic && getAppDataPublicFilePrefix(occurrence)?has_content,
+            []
+        )
     ]
 [/#function]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Documentation (new or update to existing)
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
- Moves the standard IAM policies from the shared provider to aws
- Adds support for the FullRelativePath and the FullRawRelativePath to handle the move of asFile settings
- Removes the globalAdministratorAccess permission as it shouldn't be used and isn't used in the plugin
- Updates the standardPolices function to use the standard naming for policy resources
- Move ecs container setup from commonApplication to the aws ecs provider

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This aligns with the changes made in https://github.com/hamlet-io/engine/pull/1949 and separates the shared provider from the aws specific implementation

## How Has This Been Tested? 
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

