### PR TITLE
feat(spa): force max-age for config

### DIFF
--- a/aws/components/spa/setup.ftl
+++ b/aws/components/spa/setup.ftl
@@ -137,6 +137,12 @@
                     "$\{CONFIG}",
                     "config.json"
                 ) +
+                [#-- Ensure config.json is not cached for too long --]
+                [#-- as it can contain version ids that need to be --]
+                [#-- refetched when the code changes.              --]
+                [#-- Otherwise it is not obvious that new code has --]
+                [#-- been loaded becuase the version info doesn't  --]
+                [#-- change.                                       --]
                 syncFilesToBucketScript(
                     "configFiles",
                     getRegion(),
@@ -144,7 +150,10 @@
                     formatRelativePath(
                         getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
                         solution.ConfigPath
-                    )
+                    ),
+                    true,
+                    [],
+                    60
                 ) /]
     [/#if]
 


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
In order to ensure browsers don't excessively cache the spa config.json file, give it a max-age in s3 which will
flow through CloudFront to the browser.

## Motivation and Context
Because the config.json typically contains the version information displayed by the spa, it needs to be fetched
when new code is loaded to avoid the appearance that no update has ocurr.

## How Has This Been Tested?
- Local template generation to confirm additional switches are added to the script that sync's the config.json.
- Customer deployment once merged

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- https://github.com/hamlet-io/engine/pull/1953

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

