### PR TITLE
feat: add additional runbook tasks and modules

### DIFF
--- a/aws/modules/runbook_rds_snapshot/module.ftl
+++ b/aws/modules/runbook_rds_snapshot/module.ftl
@@ -1,0 +1,151 @@
+[#ftl]
+
+[@addModule
+    name="runbook_rds_snapshot"
+    description="Create a native snapshot of an RDS cluster or instance"
+    provider=AWS_PROVIDER
+    properties=[
+        {
+            "Names" : "dbLink",
+            "Description" : "A link to the db component running postgres that the dump will be created from",
+            "Mandatory" : true,
+            "AttributeSet" : LINK_ATTRIBUTESET_TYPE
+        }
+    ]
+/]
+
+[#macro aws_module_runbook_rds_snapshot dbLink ]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                dbLink.Tier : {
+                    "Components" : {
+                        "${dbLink.Component}_snpashot" : {
+                            "Description" : "Creates an rds native snapshot of the database",
+                            "Type" : "runbook",
+                            "Engine" : "hamlet",
+                            "Inputs" : {
+                                "SnapshotName" : {
+                                    "Type" : STRING_TYPE,
+                                    "Description" : "The name of the snapshot",
+                                    "Mandatory" : true
+                                },
+                                "IncludeDateSuffix" : {
+                                    "Type" : BOOLEAN_TYPE,
+                                    "Description" : "Include a date based suffix to the snapshot name -YYYMMDD-HHMM",
+                                    "Default" : true
+                                }
+                            },
+                            "Steps" : {
+                                "aws_login" : {
+                                    "Priority" : 5,
+                                    "Extensions" : [ "_runbook_get_provider_id" ],
+                                    "Task" : {
+                                        "Type" : "set_provider_credentials",
+                                        "Parameters" : {
+                                            "Account" : {
+                                                "Value" : "__setting:ACCOUNT__"
+                                            }
+                                        }
+                                    }
+                                },
+                                "cluster_snapshot" : {
+                                    "Priority" : 10,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Conditions" :{
+                                        "isCluster" : {
+                                            "Value" : "__attribute:db:TYPE__",
+                                            "Test" : "cluster",
+                                            "Match" : "Equals"
+                                        }
+                                    },
+                                    "Task" : {
+                                        "Type" : "aws_rds_create_snapshot",
+                                        "Parameters" : {
+                                            "DbId" : {
+                                                "Value" : "__attribute:db:INSTANCEID__"
+                                            },
+                                            "SnapshotName" : {
+                                                "Value" : "__input:SnapshotName__"
+                                            },
+                                            "Cluster" : {
+                                                "Value" : true
+                                            },
+                                            "IncludeDateSuffix" : {
+                                                "Value" : "__input:IncludeDateSuffix__"
+                                            },
+                                            "AWSAccessKeyId" : {
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Value" : "__output:aws_login:aws_session_token__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "db" : dbLink
+                                    }
+                                },
+                                "instance_snapshot" : {
+                                    "Priority" : 10,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Conditions" :{
+                                        "isCluster" : {
+                                            "Value" : "__attribute:db:TYPE__",
+                                            "Test" : "instance",
+                                            "Match" : "Equals"
+                                        }
+                                    },
+                                    "Task" : {
+                                        "Type" : "aws_rds_create_snapshot",
+                                        "Parameters" : {
+                                            "DbId" : {
+                                                "Value" : "__attribute:db:INSTANCEID__"
+                                            },
+                                            "SnapshotName" : {
+                                                "Value" : "__input:SnapshotName__"
+                                            },
+                                            "Cluster" : {
+                                                "Value" : false
+                                            },
+                                            "IncludeDateSuffix" : {
+                                                "Value" : "__input:IncludeDateSuffix__"
+                                            },
+                                            "AWSAccessKeyId" : {
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Value" : "__output:aws_login:aws_session_token__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "db" : dbLink
+                                    }
+                                },
+                                "echo_snapshot_arn" : {
+                                    "Priority" : 120,
+                                    "Task" : {
+                                        "Type" : "output_echo",
+                                        "Parameters" : {
+                                            "Value" : {
+                                                "Value" : "__output:cluster_snapshot:SnapshotArn____output:instance_snapshot:SnapshotArn__"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]

--- a/aws/tasks/aws_ecs_run_task/id.ftl
+++ b/aws/tasks/aws_ecs_run_task/id.ftl
@@ -22,6 +22,12 @@
             "Mandatory" : true
         },
         {
+            "Names" : "ContainerName",
+            "Description" : "The name of the container to apply overrrides and watch for exit status",
+            "Mandatory" : true,
+            "Types" : STRING_TYPE
+        },
+        {
             "Names" : "CapacityProvider",
             "Description" : "The capacity provider used to host the task",
             "Types" : STRING_TYPE
@@ -42,25 +48,6 @@
             "Types" : [ BOOLEAN_TYPE, STRING_TYPE],
             "Values" : [ "true", "false"],
             "Default" : false
-        },
-        {
-            "Names" : "ShowStatus",
-            "Description" : "Show the status of running the task",
-            "Types" : [ BOOLEAN_TYPE, STRING_TYPE],
-            "Values" : [ "true", "false"],
-            "Default" : true
-        },
-        {
-            "Names" : "WaitToStop",
-            "Description" : "Wait for the task to stop",
-            "Types" : [ BOOLEAN_TYPE, STRING_TYPE],
-            "Values" : [ "true", "false"],
-            "Default" : true
-        },
-        {
-            "Names" : "OverrideContainerName",
-            "Description" : "The name of the container to apply overrides to",
-            "Types" : STRING_TYPE
         },
         {
             "Names" : "CommandOverride",

--- a/aws/tasks/aws_lambda_invoke_function/id.ftl
+++ b/aws/tasks/aws_lambda_invoke_function/id.ftl
@@ -1,0 +1,43 @@
+[#ftl]
+
+[@addTask
+    type=AWS_LAMBDA_INVOKE_FUNCTION_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Invoke a lambda function with a payload and return the returned payload"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "FunctionArn",
+            "Description" : "The ARN of the lambda function",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Payload",
+            "Description" : "A json encoded string with the lambda payload",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        }
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/aws_rds_create_snapshot/id.ftl
+++ b/aws/tasks/aws_rds_create_snapshot/id.ftl
@@ -1,0 +1,57 @@
+[#ftl]
+
+[@addTask
+    type=AWS_RDS_CREATE_SNAPSHOT_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Create an rds native snapshot for either an instance or cluster, wait for it to become available and then return the arn"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "DbId",
+            "Description" : "The Arn or Id of the rds instance or cluster",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names": "Cluster",
+            "Description" : "If the database is a cluster or instance",
+            "Types" : [ STRING_TYPE, BOOLEAN_TYPE ],
+            "Mandatory" : true
+        },
+        {
+            "Names": "SnapshotName",
+            "Description" : "The name of the snapshot",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "IncludeDateSuffix",
+            "Description" : "Include a date based suffix in the snapshot name",
+            "Types" : [ STRING_TYPE, BOOLEAN_TYPE ],
+            "Default" : true
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        }
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/task.ftl
+++ b/aws/tasks/task.ftl
@@ -1,8 +1,10 @@
 [#ftl]
 
+[#assign AWS_RDS_CREATE_SNAPSHOT_TASK_TYPE = "aws_rds_create_snapshot" ]
 [#assign AWS_ECS_SELECT_TASK_TASK_TYPE = "aws_ecs_select_task" ]
 [#assign AWS_ECS_RUN_COMMAND_TASK_TYPE = "aws_ecs_run_command" ]
 [#assign AWS_ECS_RUN_TASK_TASK_TYPE = "aws_ecs_run_task" ]
 [#assign AWS_EC2_SELECT_INSTANCE_TASK_TYPE = "aws_ec2_select_instance" ]
 [#assign AWS_KMS_ENCRYPT_VALUE_TASK_TYPE = "aws_kms_encrypt_value" ]
 [#assign AWS_KMS_DECRYPT_CIPHERTEXT_TASK_TYPE = "aws_kms_decrypt_ciphertext" ]
+[#assign AWS_LAMBDA_INVOKE_FUNCTION_TASK_TYPE = "aws_lambda_invoke_function"]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds invoke lambda function task
- Adds rds snapshot task
- Adds module for rds snapshot to create a snapshot of a linked instance

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Continues the migration of run* bash executor scripts into a more standard contract and cmdb based approach

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

