### PR TITLE
fix(healthcheck): add more entropy to naming of health checks

### DIFF
--- a/aws/components/healthcheck/state.ftl
+++ b/aws/components/healthcheck/state.ftl
@@ -34,8 +34,13 @@
                 "canary" : {
                     "Id" : formatResourceId(AWS_CLOUDWATCH_CANARY_RESOURCE_TYPE, core.Id),
                     [#-- Name must be less than 21 chars --]
-                    "Name" : concatenate([ core.Component.RawName, segmentSeed], "_")
-                                ?truncate_c(21, "")
+                    "Name" : concatenate([
+                                    segmentSeed?truncate_c(5, ""),
+                                    (core.Version.Name)?split("")?reverse?join("")?truncate_c(5, "")?split("")?reverse?join(""),
+                                    (core.Instance.Name)?split("")?reverse?join("")?truncate_c(5, "")?split("")?reverse?join(""),
+                                    (core.Component.Name)?split("")?reverse?join("")?truncate_c(5, "")?split("")?reverse?join("")
+                                ],
+                                "_")
                                 ?lower_case,
                     "TagName" : core.FullName,
                     "Type" : AWS_CLOUDWATCH_CANARY_RESOURCE_TYPE,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Changes the name used for the health check to always include the segment seed and use snippets of each section of the occurrence

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When creating instances of the same healthcheck the naming was conflicting between the instances due to using the truncated name

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

