### PR TITLE
feat(lb): add support for alb as a network target

### DIFF
--- a/aws/components/lb/id.ftl
+++ b/aws/components/lb/id.ftl
@@ -28,3 +28,19 @@
             AWS_CERTIFICATE_MANAGER_SERVICE
         ]
 /]
+
+[@addResourceGroupAttributeValues
+    type=LB_PORT_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names" : "Forward",
+            "Children" : [
+                {
+                    "Names" : "TargetType",
+                    "Values" : [ "shared:ip", "shared:instance", "alb"]
+                }
+            ]
+        }
+    ]
+/]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for using an application load balancer as a network load balancer fixed target
- Updates healthchecks to support using HTTP or HTTPS protocol when using TCP as the target protocol

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This is an awsism for load balancing and is useful when you need some advanced networking features such as 
- Private Link sharing of applications between VPCS 
- Static IP Addresses for application load balancers ( NLB gets fixed IP's assigned to them ) 

See details on why here https://docs.aws.amazon.com/elasticloadbalancing/latest/network/application-load-balancer-target.html 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

