### PR TITLE
feat(cdn): add error for wrong logging region

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -508,6 +508,17 @@
 
     [#if wafPresent ]
         [#if solution.WAF.Logging.Enabled]
+
+            [#if getRegion() != "us-east-1" ]
+                [@fatal
+                    message="To enable fireshose based logging for WAF on CDN the deployment must be run from us-east-1"
+                    context={
+                        "CDNId" : occurrence.Core.Id,
+                        "Region" : getRegion()
+                    }
+                /]
+            [/#if]
+
             [#local wafFirehoseStreamId =
                 formatResourceId(AWS_KINESIS_FIREHOSE_STREAM_RESOURCE_TYPE, wafAclId)]
 

--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -511,7 +511,7 @@
 
             [#if getRegion() != "us-east-1" ]
                 [@fatal
-                    message="To enable fireshose based logging for WAF on CDN the deployment must be run from us-east-1"
+                    message="To enable firehose based logging for WAF on CDN the deployment must be run from us-east-1"
                     context={
                         "CDNId" : occurrence.Core.Id,
                         "Region" : getRegion()


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a fatal exception to outline that logging can only be enabled if the CDN is deployed to us-east-1. the firehose stream must be in us-east-1


## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Stops from deployments happening where logs are required but the CDN has already been deployed

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

