### PR TITLE
feat: add s3 runbook tasks

### DIFF
--- a/aws/tasks/aws_s3_download_bucket/id.ftl
+++ b/aws/tasks/aws_s3_download_bucket/id.ftl
@@ -1,0 +1,51 @@
+[#ftl]
+
+[@addTask
+    type=AWS_S3_DOWNLOAD_BUCKET_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Download the contents of an S3 bucket to a local directory"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "BucketName",
+            "Description" : "The name of the S3 Bucket",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names": "Prefix",
+            "Description" : "A prefix required for all items to download",
+            "Types" : STRING_TYPE,
+            "Default": ""
+        },
+        {
+            "Names": "LocalPath",
+            "Description" : "A local directory path to store the objects in",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        }
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/aws_s3_empty_bucket/id.ftl
+++ b/aws/tasks/aws_s3_empty_bucket/id.ftl
@@ -1,0 +1,45 @@
+[#ftl]
+
+[@addTask
+    type=AWS_S3_EMPTY_BUCKET_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Delete all versions of objects in an S3 Bucket"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "BucketName",
+            "Description" : "The name of the S3 Bucket",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names": "Prefix",
+            "Description" : "A prefix required for all items to download",
+            "Types" : STRING_TYPE,
+            "Default": ""
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        }
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/task.ftl
+++ b/aws/tasks/task.ftl
@@ -8,3 +8,5 @@
 [#assign AWS_KMS_ENCRYPT_VALUE_TASK_TYPE = "aws_kms_encrypt_value" ]
 [#assign AWS_KMS_DECRYPT_CIPHERTEXT_TASK_TYPE = "aws_kms_decrypt_ciphertext" ]
 [#assign AWS_LAMBDA_INVOKE_FUNCTION_TASK_TYPE = "aws_lambda_invoke_function"]
+[#assign AWS_S3_DOWNLOAD_BUCKET_TASK_TYPE = "aws_s3_download_bucket"]
+[#assign AWS_S3_EMPTY_BUCKET_TASK_TYPE = "aws_s3_empty_bucket"]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for s3 based runbook tasks for backup and emtpying

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Adds standard tasks that can be used in runbooks for backing up and emptying s3 buckets

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

