### PR TITLE
feat: ec2 resource outputs and replace updates

### DIFF
--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -28,6 +28,20 @@
     mappings=AWS_EC2_EBS_VOLUME_OUTPUT_MAPPINGS
 /]
 
+[#assign AWS_EC2_INSTANCE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_EC2_INSTANCE_RESOURCE_TYPE
+    mappings=AWS_EC2_INSTANCE_OUTPUT_MAPPINGS
+/]
+
 [#function getCFNInitFromComputeTasks computeTaskConfig ]
 
     [#local configSetName = ""]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Add ref output for ec2 instance id when using ec2 component
- Don't replace network interfaces when running replace1/replace2

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The ec2 Id can be used in management tasks that are part of other deployments to manage the instance 
Removing the eni from the replacement process preserves the IP addresses used for a given ec2 instance in a zone.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

