### PR TITLE
refactor(datavolumes: zone based control and remove backups

### DIFF
--- a/aws/components/datavolume/setup.ftl
+++ b/aws/components/datavolume/setup.ftl
@@ -13,25 +13,11 @@
     [#local manualSnapshotId = resources["manualSnapshot"].Id]
     [#local manualSnapshotName = getExistingReference(manualSnapshotId, NAME_ATTRIBUTE_TYPE)]
 
-
     [#-- Baseline component lookup --]
     [#local baselineLinks = getBaselineLinks(occurrence, [ "Encryption"] )]
     [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
 
     [#local cmkKeyId = baselineComponentIds["Encryption" ]]
-
-    [#local backupEnabled = solution.Backup.Enabled ]
-    [#if backupEnabled ]
-        [#local maintenanceWindowId = resources["maintenanceWindow"].Id ]
-        [#local maintenanceWindowName = resources["maintenanceWindow"].Name ]
-        [#local windowTargetId = resources["windowTarget"].Id]
-        [#local windowTargetName = resources["windowTarget"].Name]
-
-        [#local maintenanceServiceRoleId = resources["maintenanceServiceRole"].Id]
-        [#local maintenanceLambdaRoleId = resources["maintenanceLambdaRole"].Id]
-
-        [#local ssmWindowTargets = getSSMWindowTargets( [],[],true )]
-    [/#if]
 
     [#list resources["Zones"] as zoneId, zoneResources ]
         [#local volumeId = zoneResources["ebsVolume"].Id ]
@@ -43,146 +29,21 @@
                                     "",
                                     false)]
 
-        [#local resourceZone = {}]
-        [#list getZones() as zone ]
-            [#if zoneId == zone.Id ]
-                [#local resourceZone = zone ]
-            [/#if]
-        [/#list]
-
         [#if deploymentSubsetRequired(DATAVOLUME_COMPONENT_TYPE, true)]
             [@createEBSVolume
                 id=volumeId
                 tags=volumeTags
                 size=solution.Size
-                volumeType=solution.VolumeType
+                volumeType=solution.VolumeType?remove_beginning("aws:")
                 encrypted=solution.Encrypted
                 kmsKeyId=cmkKeyId
                 provisionedIops=solution.ProvisionedIops
-                zone=resourceZone
+                zone=getZones()?filter(zone -> zone.Id == zoneId)[0]
                 snapshotId=manualSnapshotName
             /]
-
-            [#if backupEnabled ]
-
-                [#local snapshotCreateTaskId = zoneResources["taskCreateSnapshot"].Id ]
-                [#local snapshotCreateTaskName = zoneResources["taskCreateSnapshot"].Name ]
-
-                [@createSSMMaintenanceWindowTask
-                    id=snapshotCreateTaskId
-                    name=snapshotCreateTaskName
-                    targets=ssmWindowTargets
-                    priority=10
-                    serviceRoleId=maintenanceServiceRoleId
-                    windowId=maintenanceWindowId
-                    taskId="AWS-CreateSnapshot"
-                    taskType="Automation"
-                    taskParameters=getSSMWindowAutomationTaskParameters(
-                                        {
-                                            "AutomationAssumeRole" : asArray(getReference(maintenanceServiceRoleId,ARN_ATTRIBUTE_TYPE)),
-                                            "VolumeId" : asArray(getReference(volumeId))
-                                        }
-                    )
-                    priority=10
-                /]
-
-                [#local snapshotDeleteTaskId = zoneResources["taskDeleteSnapshot"].Id ]
-                [#local snapshotDeleteTaskName = zoneResources["taskDeleteSnapshot"].Name ]
-
-                [@createSSMMaintenanceWindowTask
-                    id=snapshotDeleteTaskId
-                    name=snapshotDeleteTaskName
-                    targets=ssmWindowTargets
-                    priority=20
-                    serviceRoleId=maintenanceServiceRoleId
-                    windowId=maintenanceWindowId
-                    taskId="AWS-DeleteEbsVolumeSnapshots"
-                    taskType="Automation"
-                    taskParameters=getSSMWindowAutomationTaskParameters(
-                                        {
-                                            "AutomationAssumeRole" : asArray(getReference(maintenanceServiceRoleId, ARN_ATTRIBUTE_TYPE)),
-                                            "LambdaAssumeRole" : asArray(getReference(maintenanceLambdaRoleId, ARN_ATTRIBUTE_TYPE)),
-                                            "VolumeId" : asArray(getReference(volumeId)),
-                                            "RetentionDays" : asArray(solution.Backup.RetentionPeriod),
-                                            "RetentionCount" : asArray("")
-                                        }
-                    )
-                    priority=10
-                /]
-            [/#if]
         [/#if]
     [/#list]
 
-    [#if deploymentSubsetRequired(DATAVOLUME_COMPONENT_TYPE, true) && backupEnabled ]
-        [#local maintenanceWindowTags = getOccurrenceCoreTags(
-                                            occurrence,
-                                            maintenanceWindowName,
-                                            "",
-                                            false)]
-        [@createSSMMaintenanceWindow
-            id=maintenanceWindowId
-            name=maintenanceWindowName
-            schedule=solution.Backup.Schedule
-            durationHours=3
-            cutoffHours=0
-            tags=maintenanceWindowTags
-            scheduleTimezone=solution.Backup.ScheduleTimeZone
-        /]
-
-        [@createSSMMaintenanceWindowTarget
-            id=windowTargetId
-            name=windowTargetName
-            windowId=maintenanceWindowId
-            targets=ssmWindowTargets
-        /]
-    [/#if]
-
-    [#if deploymentSubsetRequired("iam", true) ]
-
-        [#if backupEnabled ]
-            [#if isPartOfCurrentDeploymentUnit(maintenanceServiceRoleId) ]
-                [@createRole
-                    id=maintenanceServiceRoleId
-                    trustedServices=[
-                        "ec2.amazonaws.com",
-                        "ssm.amazonaws.com"
-                    ]
-                    managedArns=["arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole"]
-                    tags=getOccurrenceCoreTags(occurrence)
-                /]
-
-                [#local policyId = formatDependentPolicyId(maintenanceServiceRoleId, "passRole")]
-                [@createPolicy
-                    id=policyId
-                    name="passRole"
-                    statements=iamPassRolePermission(
-                                    [
-                                        getReference(maintenanceLambdaRoleId, ARN_ATTRIBUTE_TYPE),
-                                        getReference(maintenanceServiceRoleId, ARN_ATTRIBUTE_TYPE)
-                                    ]
-                                ) +
-                                ec2EBSVolumeSnapshotAllPermission() +
-                                lambdaSSMAutomationPermission()
-                    roles=maintenanceServiceRoleId
-                /]
-            [/#if]
-            [#if isPartOfCurrentDeploymentUnit(maintenanceLambdaRoleId) ]
-                [@createRole
-                    id=maintenanceLambdaRoleId
-                    trustedServices=[
-                            "lambda.amazonaws.com"
-                        ]
-                    policies=
-                        [
-                            getPolicyDocument(
-                                ec2EBSVolumeSnapshotAllPermission(),
-                                "snapshot")
-                        ]
-                    tags=getOccurrenceCoreTags(occurrence)
-                /]
-            [/#if]
-        [/#if]
-    [/#if]
     [#if deploymentSubsetRequired("epilogue", false)]
         [@addToDefaultBashScriptOutput
             content=

--- a/aws/components/datavolume/state.ftl
+++ b/aws/components/datavolume/state.ftl
@@ -4,40 +4,19 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 
-    [#if multiAZ!false ]
-        [#local resourceZones = getZones() ]
-    [#else]
-        [#local resourceZones = [ getZones()[0] ] ]
-    [/#if]
-
     [#local zoneResources = {} ]
 
-    [#list resourceZones as zone ]
-        [#local dataVolumeId = formatResourceId(AWS_EC2_EBS_RESOURCE_TYPE, core.Id, zone.Id )]
+    [#local zones = getZones()?filter(zone -> solution.Zones?seq_contains(zone.Id) || solution.Zones?seq_contains("_all")) ]
+    [#list multiAZ?then(zones, [zones[0]]) as zone ]
         [#local zoneResources +=
             {
                 zone.Id : {
                     "ebsVolume" : {
-                        "Id" : dataVolumeId,
+                        "Id" :  formatResourceId(AWS_EC2_EBS_RESOURCE_TYPE, core.Id, zone.Id ),
                         "Name" : core.FullName,
                         "Type" : AWS_EC2_EBS_RESOURCE_TYPE
                     }
-                } +
-                (solution.Backup.Enabled)?then(
-                    {
-                        "taskCreateSnapshot" : {
-                            "Id" : formatResourceId( AWS_SSM_MAINTENANCE_WINDOW_TASK_RESOURCE_TYPE, core.Id, "create", zone.Id),
-                            "Name" : formatName(core.FullName, "create", zone.Name),
-                            "Type" : AWS_SSM_MAINTENANCE_WINDOW_TASK_RESOURCE_TYPE
-                        },
-                        "taskDeleteSnapshot" : {
-                            "Id" : formatResourceId( AWS_SSM_MAINTENANCE_WINDOW_TASK_RESOURCE_TYPE, core.Id, "delete", zone.Id),
-                            "Name" : formatName(core.FullName, "delete", zone.Name),
-                            "Type" : AWS_SSM_MAINTENANCE_WINDOW_TASK_RESOURCE_TYPE
-                        }
-                    },
-                    {}
-                )
+                }
             }
         ]
     [/#list]
@@ -50,32 +29,7 @@
                     "Type" : AWS_EC2_EBS_MANUAL_SNAPSHOT_RESOURCE_TYPE
                 },
                 "Zones" : zoneResources
-            } +
-            (solution.Backup.Enabled)?then(
-                {
-                    "maintenanceWindow" : {
-                        "Id" : formatResourceId(AWS_SSM_MAINTENANCE_WINDOW_RESOURCE_TYPE, core.Id ),
-                        "Name" : core.FullName,
-                        "Type" : AWS_SSM_MAINTENANCE_WINDOW_RESOURCE_TYPE
-                    },
-                    "windowTarget" : {
-                        "Id" : formatResourceId(AWS_SSM_MAINTENANCE_WINDOW_TARGET_RESOURCE_TYPE, core.Id),
-                        "Name" : core.FullName,
-                        "Type" : AWS_SSM_MAINTENANCE_WINDOW_TARGET_RESOURCE_TYPE
-                    },
-                    "maintenanceServiceRole" : {
-                        "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, "service", core.Id  ),
-                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
-                        "IncludeInDeploymentState" : false
-                    },
-                    "maintenanceLambdaRole" : {
-                        "Id" : formatResourceId( AWS_IAM_ROLE_RESOURCE_TYPE, "lambda", core.Id ),
-                        "Type" : AWS_IAM_ROLE_RESOURCE_TYPE,
-                        "IncludeInDeploymentState" : false
-                    }
-                },
-                {}
-            ),
+            },
             "Attributes" : {
                 "VOLUME_NAME" : core.FullName,
                 "ENGINE" : solution.Engine

--- a/aws/extensions/computetask_linux_volumemount/extension.ftl
+++ b/aws/extensions/computetask_linux_volumemount/extension.ftl
@@ -35,41 +35,50 @@
 
         [#-- These volumes are provided through DataVolumes which are an indepdent component --]
         [#-- These are attached to instances through links and VolumeMount macro which applies the extra configuration required --]
-        [#local zoneResources = occurrence.State.Resources.Zones]
-        [#list getZones() as zone]
-            [#if multiAZ || (getZones()[0].Id = zone.Id)]
-                [#local zoneEc2InstanceId = zoneResources[zone.Id]["ec2Instance"].Id ]
-                [#list (_context.VolumeMounts)![] as mountId,volumeMount ]
-                    [#local dataVolume = _context.DataVolumes[mountId]!{} ]
-                    [#if dataVolume?has_content ]
-                        [#local zoneVolume = (dataVolume[zone.Id].VolumeId)!"" ]
-                        [#if zoneVolume?has_content ]
-                            [#if ! ( getCLODeploymentUnitAlternative() == "replace1" ) ]
-                                [@createEBSVolumeAttachment
-                                    id=formatDependentResourceId(
-                                        AWS_EC2_EBS_ATTACHMENT_RESOURCE_TYPE,
-                                        zoneEc2InstanceId,
-                                        mountId
-                                    )
-                                    device=volumeMount.DeviceId
-                                    instanceId=zoneEc2InstanceId
-                                    volumeId=zoneVolume
-                                /]
-                            [/#if]
 
-                            [#local volumes += {
-                                mountId : {
-                                    "Enabled" : true,
-                                    "MountPath" : volumeMount.MountPath,
-                                    "Device" : volumeMount.DeviceId,
-                                    "DataVolume" : true
-                                }
-                            }]
+        [#list occurrence.State.Resources.Zones as zone, resources]
+            [#local instanceId = resources["ec2Instance"].Id]
 
-                        [/#if]
+            [#list (_context.VolumeMounts)![] as mountId,volumeMount ]
+
+                [#local dataVolume = _context.DataVolumes[mountId]!{} ]
+                [#if dataVolume?has_content]
+
+                    [#if ! ((dataVolume[zone].VolumeId)!"")?has_content ]
+
+                        [@fatal
+                            message="Data Volume missing for Zone ${zone}"
+                            context={
+                                "Component" : occurrence.Core.RawName,
+                                "DataVolume" : dataVolume
+                            }
+                        /]
+                        [#continue]
                     [/#if]
-                [/#list]
-            [/#if]
+
+                    [#if ( getCLODeploymentUnitAlternative() != "replace1" ) ]
+                        [@createEBSVolumeAttachment
+                            id=formatDependentResourceId(
+                                AWS_EC2_EBS_ATTACHMENT_RESOURCE_TYPE,
+                                zoneEc2InstanceId,
+                                dataVolume.Id
+                            )
+                            device=volumeMount.DeviceId
+                            instanceId=zoneEc2InstanceId
+                            volumeId=zoneVolume
+                        /]
+                    [/#if]
+
+                    [#local volumes += {
+                        dataVolume.Id : {
+                            "Enabled" : true,
+                            "MountPath" : volumeMount.MountPath,
+                            "Device" : volumeMount.DeviceId,
+                            "DataVolume" : true
+                        }
+                    }]
+                [/#if]
+            [/#list]
         [/#list]
     [/#if]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
- Removes support for creating SSM based snapshots of datavolumes 
- Supports zone based filtering defined in https://github.com/hamlet-io/engine/pull/1966
- Updates the compute extensions for ec2 components using datavolumes to allow for zone based filtering

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Simplifies the datavolume implementation, and standardises the backup process to align with the backup component

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

