### PR TITLE
fix(backupstore): tag based conditions

### DIFF
--- a/aws/components/backupstore/setup.ftl
+++ b/aws/components/backupstore/setup.ftl
@@ -181,20 +181,26 @@
             [#-- Check if store matches are required --]
             [#local conditions = {} ]
             [#if isPresent(subSolution.Conditions.MatchesStore) ]
+
                 [#list ["Product","Environment","Segment","Tier"] as tag]
                     [#if subSolution.Conditions.MatchesStore[tag]!false]
                         [#local conditionValue = "HamletFatal: Unknown backup condition tag" ]
+                        [#local tagValue = "HamletFatal: Unknown backup condition tag"]
                         [#switch tag]
                             [#case "Product"]
+                                [#local tagValue = "cot:product" ]
                                 [#local conditionValue = productName ]
                                 [#break]
                             [#case "Environment"]
+                                [#local tagValue = "cot:environment" ]
                                 [#local conditionValue = environmentName ]
                                 [#break]
                             [#case "Segment"]
+                                [#local tagValue = "cot:segment" ]
                                 [#local conditionValue = segmentName ]
                                 [#break]
                             [#case "Tier"]
+                                [#local tagValue = "cot:tier" ]
                                 [#local conditionValue = getTierName(core.Tier) ]
                                 [#break]
                         [/#switch]
@@ -202,8 +208,9 @@
                         [#local conditions =
                             addBackupSelectionCondition(
                                 conditions,
-                                tag,
-                                conditionValue
+                                tagValue,
+                                conditionValue,
+                                "tag"
                             )
                         ]
                     [/#if]

--- a/aws/services/backup/resource.ftl
+++ b/aws/services/backup/resource.ftl
@@ -255,7 +255,14 @@
     /]
 [/#macro]
 
-[#function addBackupSelectionCondition conditions key value type="StringEquals" ]
+[#function addBackupSelectionCondition conditions key value keyType type="StringEquals" ]
+
+    [#switch keyType ]
+        [#case "tag"]
+            [#local key = key?ensure_starts_with("aws:ResourceTag/")]
+            [#break]
+    [/#switch]
+
     [#return
         combineEntities(
             conditions,

--- a/awstest/modules/backup/module.ftl
+++ b/awstest/modules/backup/module.ftl
@@ -132,4 +132,104 @@
             }
         ]
     /]
+
+
+    [#-- Tag Condition selection --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "mgmt" : {
+                    "Components" : {
+                        "backupstoretags" : {
+                            "Type" : "backupstore",
+                            "deployment:Unit" : "aws-backupstore-tags",
+                            "Profiles" : {
+                                "Testing" : [ "backupstoretags" ]
+                            },
+                            "Regimes": {
+                                "dailysegment": {
+                                    "Targets": {
+                                        "All": {
+                                            "Enabled": true
+                                        }
+                                    },
+                                    "Rules": {
+                                        "daily": {
+                                            "PointInTimeSupport": true,
+                                            "Expression": "rate(1 day)"
+                                        }
+                                    },
+                                    "Conditions": {
+                                        "MatchesStore": {
+                                            "Tier": false,
+                                            "Enabled": true,
+                                            "Product": true,
+                                            "Environment": true,
+                                            "Segment": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "backupstoretags" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "vault" : {
+                                    "Name" : "backupvaultXmgmtXbackupstoretags",
+                                    "Type" : "AWS::Backup::BackupVault"
+                                }
+                            },
+                            "Output" : [
+                                "backupvaultXmgmtXbackupstoretagsXname"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "ConditionTagNaming" : {
+                                    "Path"  : "Resources.backupselectionXmgmtXbackupstoretagsXdailysegment.Properties.BackupSelection.Conditions.StringEquals[0].ConditionKey",
+                                    "Value" : "aws:ResourceTag/cot:product"
+                                }
+                            },
+                            "Length" : {
+                                "TagConditions" : {
+                                    "Path": "Resources.backupselectionXmgmtXbackupstoretagsXdailysegment.Properties.BackupSelection.Conditions.StringEquals",
+                                    "Count": 3
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "backupstoretags" : {
+                    "backupstore" : {
+                        "TestCases" : [ "backupstoretags" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
+                    }
+                }
+            }
+        }
+        stackOutputs=[
+            {
+                "Account" : "0123456789",
+                "Region" : "mock-region-1",
+                "DeploymentUnit" : "aws-backupstore-tags",
+                "backupvaultXmgmtXbackupstoretags": "mockedup-integration-management-backupstoretags"
+            },
+            {
+                "Account" : "0123456789",
+                "Region" : "mock-region-1",
+                "DeploymentUnit" : "aws-backupstore-tags",
+                "backupplanXmgmtXbackupstoretagsXdailysegment": "mockedup-integration-management-backupstoretags-dailysegment"
+            }
+        ]
+    /]
 [/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds the required resource tag to selection conditions
- Fixes the tag value used to align with our current standard tags

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Deployment fails when using tag based conditions as the values aren't quite right. 
Cloudformation doco doesn't reference the format but an error is raised and it is outlined in 
https://docs.aws.amazon.com/aws-backup/latest/devguide/assigning-resources.html 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and added test suite

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

