### PR TITLE
fix(iam): inline policy creation from policy set

### DIFF
--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -337,7 +337,7 @@
 
         [#-- Create any required managed policies --]
         [#-- They may result when policies are split to keep below AWS limits --]
-        [@createCustomerManagedPoliciesFromSet policySet /]
+        [@createCustomerManagedPoliciesFromSet policies=policySet /]
 
         [#-- Create a role under which the function will run and attach required policies --]
         [#-- The role is mandatory though there may be no policies attached to it --]
@@ -357,7 +357,7 @@
         /]
 
         [#-- Create any inline policies that attach to the role --]
-        [@createInlinePoliciesFromSet policySet /]
+        [@createInlinePoliciesFromSet policies=policySet roles=roleId /]
     [/#if]
 
     [#if deploymentType == "REGIONAL" &&

--- a/aws/services/iam/resource.ftl
+++ b/aws/services/iam/resource.ftl
@@ -199,30 +199,30 @@
     [#return policies]
 [/#function]
 
-[#macro createInlinePoliciesFromSet policies ]
+[#macro createInlinePoliciesFromSet policies roles="" users="" groups="" dependencies=[] ]
     [#list policies.Inline![] as entry]
         [@createPolicy
             id=entry.Id
             name=entry.Name
             statements=entry.Statements
-            roles=entry.Roles
-            users=entry.Users
-            groups=entry.Groups
-            dependencies=entry.Dependencies
+            roles=roles
+            users=users
+            groups=groups
+            dependencies=dependencies
         /]
     [/#list]
 [/#macro]
 
-[#macro createCustomerManagedPoliciesFromSet policies ]
+[#macro createCustomerManagedPoliciesFromSet policies roles="" users="" groups="" dependencies=[] ]
     [#list policies.CustomerManaged![] as entry]
         [@createManagedPolicy
             id=entry.Id
             name=entry.Name
             statements=entry.Statements
-            roles=entry.Roles
-            users=entry.Users
-            groups=entry.Groups
-            dependencies=entry.Dependencies
+            roles=roles
+            users=users
+            groups=groups
+            dependencies=dependencies
         /]
     [/#list]
 [/#macro]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Any role, user or group association should be provided when requesting the creation of the policy rather than being derived from (now removed) information in the policy set.

## Motivation and Context
Inline policies were not being associated with a role.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

