### PR TITLE
feat(apigateway): mutual TLS attribute

### DIFF
--- a/aws/components/apigateway/state.ftl
+++ b/aws/components/apigateway/state.ftl
@@ -405,6 +405,11 @@ created in either case.
                 "DOCS_URL",
                 docsPrimaryFqdn != "",
                 "http://" + docsPrimaryFqdn
+            ) +
+            attributeIfTrue(
+                "TLS_MUTUAL",
+                (solution.MutualTLS.Enabled)!false,
+                true
             ),
             "Roles" : {
                 "Inbound" : {


### PR DESCRIPTION

## Intent of Change
<!-- Delete all that do not apply                      -->
- Documentation (new or update to existing)
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
If mutual TLS is required for the api, add an attribute to this effect to the state. 

## Motivation and Context
Consumers can use this attribute to drive the logic to facilitate mutual TLS connections.

## How Has This Been Tested?
`hamlet describe-occurrence` requests with and without mutual TLS enabled.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

