### PR TITLE
feat(certificateauthority): intial support with ACMPCA

### DIFF
--- a/aws/components/certificateauthority/id.ftl
+++ b/aws/components/certificateauthority/id.ftl
@@ -1,0 +1,12 @@
+[#ftl]
+
+[@addResourceGroupInformation
+    type=CERTIFICATEAUTHORITY_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_CERTIFICATE_MANAGER_PRIVATE_CA_SERVICE
+        ]
+/]

--- a/aws/components/certificateauthority/setup.ftl
+++ b/aws/components/certificateauthority/setup.ftl
@@ -1,0 +1,86 @@
+[#ftl]
+[#macro aws_certificateauthority_cf_deployment_generationcontract occurrence ]
+    [@addDefaultGenerationContract subsets=["template" ] /]
+[/#macro]
+
+[#macro aws_certificateauthority_cf_deployment_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core ]
+    [#local resources = occurrence.State.Resources]
+    [#local solution = occurrence.Configuration.Solution ]
+
+    [#local authorityId = resources["authority"].Id ]
+    [#local authorityName = resources["authority"].Name ]
+    [#local authoritySerialNumber = resources["authority"].SerialNumber ]
+
+    [#local certificateId = resources["certificate"].Id]
+
+    [#local certificateObject = getCertificateObject(solution.Subject.CommonName) ]
+    [#local commonName = getHostName(certificateObject, occurrence) ]
+
+    [#local certificateSubject = getACMPCACertificateSubject(
+        commonName, authoritySerialNumber
+    )]
+
+    [#if deploymentSubsetRequired(CERTIFICATEAUTHORITY_COMPONENT_TYPE, true)]
+
+        [#switch (solution.Level)?lower_case ]
+            [#case "root"]
+                [#local activiationAuthorityId = authorityId]
+                [#local activationCertificateChain = ""]
+                [#local certificateTemplateArn = "arn:aws:acm-pca:::template/RootCACertificate/V1"]
+                [#break]
+
+            [#case "subordinate"]
+
+                [#local parentAuthorityLink = getLinkTarget(occurrence, solution["level:Subordinate"].ParentAuthority.Link, true, true)]
+
+                [#local activiationAuthorityId = (parentAuthorityLink.State.Attributes.ARN)!"" ]
+                [#local activationCertificateChain = (parentAuthorityLink.State.Attributes.CERTIFICATE_CHAIN)!"" ]
+                [#local certificateTemplateArn = "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen${solution['level:Subordinate'].MaxLevels}/V1" ]
+                [#break]
+        [/#switch]
+
+        [@createACMPCAAuthority
+            id=authorityId
+            type=solution.Level
+            keyAlgorithm=solution.KeyAlgorithm
+            signingAlgorithm=solution.SigningAlgorithm
+            subject=certificateSubject
+            tags=getOccurrenceCoreTags(occurrence, authorityName)
+        /]
+
+        [@createACMPCACertificate
+            id=certificateId
+            certificateSigningRequest={
+                "Fn::GetAtt" : [
+                    authorityId,
+                    "CertificateSigningRequest"
+                ]
+            }
+            signingAlgorithm=solution.SigningAlgorithm
+            validityDays=solution.Validity.Length
+            templateArn=certificateTemplateArn
+            certificateAuthorityId=activiationAuthorityId
+        /]
+
+        [@createACMPCACAActivation
+            id=resources["activation"].Id
+            certificate=getReference(certificateId, CERTIFICATE_ATTRIBUTE_TYPE)
+            certificateAuthorityId=authorityId
+            certificateChain=activationCertificateChain
+        /]
+
+        [@createACMPCAPermission
+            id=resources["authorityPermission"].Id
+            actions=[
+                "issue",
+                "get",
+                "list"
+            ]
+            certificateAuthorityId=authorityId
+        /]
+
+    [/#if]
+[/#macro]

--- a/aws/components/certificateauthority/state.ftl
+++ b/aws/components/certificateauthority/state.ftl
@@ -1,0 +1,42 @@
+[#ftl]
+
+[#macro aws_certificateauthority_cf_state occurrence parent={} ]
+    [#local core = getOccurrenceCore(occurrence) ]
+    [#local solution = getOccurrenceSolution(occurrence) ]
+
+    [#local authorityId = formatResourceId(AWS_ACMPCA_AUTHORITY_RESOURCE_TYPE, occurrence.Core.Id)]
+    [#local rootCertificateId = formatResourceId(AWS_ACMPCA_CERTIFICATE_RESOURCE_TYPE, occurrence.Core.Id)]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "authority" : {
+                    "Id" : authorityId,
+                    "Name": occurrence.Core.RawFullName,
+                    "SerialNumber": getSegmentSeed(),
+                    "Type" : AWS_ACMPCA_AUTHORITY_RESOURCE_TYPE
+                },
+                "activation" : {
+                    "Id" : formatResourceId(AWS_ACMPCA_CA_ACTIVATION_RESOURCE_TYPE, occurrence.Core.Id),
+                    "Type" : AWS_ACMPCA_CA_ACTIVATION_RESOURCE_TYPE
+                },
+                "certificate" : {
+                    "Id" : rootCertificateId,
+                    "Type" : AWS_ACMPCA_CERTIFICATE_RESOURCE_TYPE
+                },
+                "authorityPermission" : {
+                    "Id" : formatResourceId(AWS_ACMPCA_PERMISSION_RESOURCE_TYPE, occurrence.Core.Id),
+                    "Type" : AWS_ACMPCA_PERMISSION_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : {
+                "ARN" : getExistingReference(authorityId),
+                "CERTIFICATE_CHAIN": getExistingReference(rootCertificateId, CERTIFICATE_ATTRIBUTE_TYPE)
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+[/#macro]

--- a/aws/services/acm/resource.ftl
+++ b/aws/services/acm/resource.ftl
@@ -11,7 +11,7 @@
     }
 ]
 
-[@addOutputMapping 
+[@addOutputMapping
     provider=AWS_PROVIDER
     resourceType=AWS_CERTIFICATE_RESOURCE_TYPE
     mappings=CERTIFICATE_OUTPUT_MAPPINGS

--- a/aws/services/acmpca/id.ftl
+++ b/aws/services/acmpca/id.ftl
@@ -1,0 +1,30 @@
+[#ftl]
+
+[#-- Resources --]
+[#assign AWS_ACMPCA_AUTHORITY_RESOURCE_TYPE = "ACMPCAAuthority" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_CERTIFICATE_MANAGER_PRIVATE_CA_SERVICE
+    resource=AWS_ACMPCA_AUTHORITY_RESOURCE_TYPE
+/]
+
+[#assign AWS_ACMPCA_CA_ACTIVATION_RESOURCE_TYPE = "ACMPCActivation" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_CERTIFICATE_MANAGER_PRIVATE_CA_SERVICE
+    resource=AWS_ACMPCA_CA_ACTIVATION_RESOURCE_TYPE
+/]
+
+[#assign AWS_ACMPCA_CERTIFICATE_RESOURCE_TYPE = "ACMPCACertificate" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_CERTIFICATE_MANAGER_PRIVATE_CA_SERVICE
+    resource=AWS_ACMPCA_CERTIFICATE_RESOURCE_TYPE
+/]
+
+[#assign AWS_ACMPCA_PERMISSION_RESOURCE_TYPE = "ACMPCAPermission" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_CERTIFICATE_MANAGER_PRIVATE_CA_SERVICE
+    resource=AWS_ACMPCA_PERMISSION_RESOURCE_TYPE
+/]

--- a/aws/services/acmpca/resource.ftl
+++ b/aws/services/acmpca/resource.ftl
@@ -1,0 +1,293 @@
+[#ftl]
+
+[#function getACMPCACertificateSubject
+    commonName=""
+    serialNumber=""
+    country=""
+    customAttributes=[]
+    distinguishedNameQualifier=""
+    generationQualifier=""
+    givenName=""
+    initials=""
+    locality=""
+    organization=""
+    organizationUnit=""
+    pseudonym=""
+    state=""
+    surname=""
+    title=""
+]
+
+    [#return
+        {} +
+        attributeIfContent(
+            "CommonName",
+            commonName
+        ) +
+        attributeIfContent(
+            "Country",
+            country
+        ) +
+        attributeIfContent(
+            "CustomAttributes",
+            customAttributes
+        ) +
+        attributeIfContent(
+            "DistinguishedNameQualifier",
+            distinguishedNameQualifier
+        ) +
+        attributeIfContent(
+            "GenerationQualifier",
+            generationQualifier
+        ) +
+        attributeIfContent(
+            "GivenName",
+            givenName
+        ) +
+        attributeIfContent(
+            "Initials",
+            initials
+        ) +
+        attributeIfContent(
+            "Locality",
+            locality
+        ) +
+        attributeIfContent(
+            "Organization",
+            organization
+        ) +
+        attributeIfContent(
+            "OrganizationalUnit",
+            organizationUnit
+        ) +
+        attributeIfContent(
+            "Pseudonym",
+            pseudonym
+        ) +
+        attributeIfContent(
+            "SerialNumber",
+            serialNumber
+        ) +
+        attributeIfContent(
+            "State",
+            state
+        ) +
+        attributeIfContent(
+            "Surname",
+            surname
+        ) +
+        attributeIfContent(
+            "Title",
+            title
+        )
+    ]
+[/#function]
+
+[#assign AWS_ACMPCA_AUTHORITY_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : {
+            "Attribute" : "Arn"
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_ACMPCA_AUTHORITY_RESOURCE_TYPE
+    mappings=AWS_ACMPCA_AUTHORITY_OUTPUT_MAPPINGS
+/]
+
+[#macro createACMPCAAuthority id type
+            keyAlgorithm
+            signingAlgorithm
+            subject
+            revocationConfiguration={}
+            csrExtensions={}
+            tags=[]
+            dependencies=[]]
+
+    [@cfResource
+        id=id
+        type="AWS::ACMPCA::CertificateAuthority"
+        properties=
+            {
+                "Type": type?upper_case,
+                "KeyAlgorithm": keyAlgorithm,
+                "SigningAlgorithm": signingAlgorithm,
+                "Subject": subject
+            } +
+            attributeIfContent(
+                "CsrExtensions",
+                csrExtensions
+            ) +
+            attributeIfContent(
+                "RevocationConfiguration",
+                revocationConfiguration
+            )
+        tags=tags
+        outputs=AWS_ACMPCA_AUTHORITY_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#assign AWS_ACMPCA_CA_ACTIVATION_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        CERTIFICATE_ATTRIBUTE_TYPE: {
+            "Attribute": "CompleteCertificateChain"
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_ACMPCA_CA_ACTIVATION_RESOURCE_TYPE
+    mappings=AWS_ACMPCA_CA_ACTIVATION_OUTPUT_MAPPINGS
+/]
+
+[#macro createACMPCACAActivation id
+            certificate
+            certificateAuthorityId
+            certificateChain=""
+            status="Active"
+            dependencies=[]]
+
+    [@cfResource
+        id=id
+        type="AWS::ACMPCA::CertificateAuthorityActivation"
+        properties=
+            {
+                "Certificate": certificate,
+                "CertificateAuthorityArn": getArn(certificateAuthorityId),
+                "Status": status?upper_case
+            } +
+            attributeIfContent(
+                "CertificateChain",
+                certificateChain
+            )
+        outputs=AWS_ACMPCA_CA_ACTIVATION_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#macro createACMPCAPermission id
+            actions
+            certificateAuthorityId
+            sourceAccount={"Ref": "AWS::AccountId"}
+            dependencies=[]]
+
+    [#local cleanedActions = []]
+    [#list actions as action ]
+        [#switch action?lower_case]
+            [#case "list"]
+            [#case "listpermissions"]
+                [#local cleanedActions = combineEntities(
+                    cleanedActions,
+                    [ "ListPermissions"],
+                    UNIQUE_COMBINE_BEHAVIOUR
+                )]
+                [#break]
+
+            [#case "get"]
+            [#case "getcertificate"]
+                [#local cleanedActions = combineEntities(
+                    cleanedActions,
+                    [ "GetCertificate"],
+                    UNIQUE_COMBINE_BEHAVIOUR
+                )]
+                [#break]
+
+            [#case "issue"]
+            [#case "issuecertificate"]
+                [#local cleanedActions = combineEntities(
+                    cleanedActions,
+                    [ "IssueCertificate"],
+                    UNIQUE_COMBINE_BEHAVIOUR
+                )]
+                [#break]
+
+            [#default]
+                [@fatal message="Invalid ACMPCA Permission action" context={ "id": id, "Action": action} /]
+        [/#switch]
+    [/#list]
+
+    [@cfResource
+        id=id
+        type="AWS::ACMPCA::Permission"
+        properties=
+            {
+                "Actions": cleanedActions,
+                "CertificateAuthorityArn": getArn(certificateAuthorityId),
+                "Principal": "acm.amazonaws.com",
+                "SourceAccount" : sourceAccount
+            }
+        outputs={}
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#assign AWS_ACMPCA_CERTIFICATE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "Attribute" : "Arn"
+        },
+        ARN_ATTRIBUTE_TYPE : {
+            "Attribute" : "Arn"
+        },
+        CERTIFICATE_ATTRIBUTE_TYPE: {
+            "Attribute": "Certificate"
+        }
+    }
+]
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_ACMPCA_CERTIFICATE_RESOURCE_TYPE
+    mappings=AWS_ACMPCA_CERTIFICATE_OUTPUT_MAPPINGS
+/]
+
+[#macro createACMPCACertificate id
+            certificateSigningRequest
+            signingAlgorithm
+            validityDays
+            templateArn
+            certificateAuthorityId
+            validityNotBeforeDate=""
+            apiPassthrough={}
+            dependencies=[]]
+
+    [@cfResource
+        id=id
+        type="AWS::ACMPCA::Certificate"
+        properties=
+            {
+                "CertificateAuthorityArn": getArn(certificateAuthorityId),
+                "CertificateSigningRequest": certificateSigningRequest,
+                "SigningAlgorithm": signingAlgorithm,
+                "TemplateArn": templateArn,
+                "Validity" : {
+                    "Type": "DAYS",
+                    "Value": validityDays
+                }
+            } +
+            attributeIfContent(
+                "ApiPassthrough",
+                apiPassthrough
+            ) +
+            attributeIfContent(
+                "ValidityNotBefore",
+                validityNotBeforeDate
+                {
+                    "Type": "ABSOLUTE",
+                    "Value": validityNotBeforeDate
+                }
+            )
+        outputs=AWS_ACMPCA_CERTIFICATE_OUTPUT_MAPPINGS
+        dependencies=dependencies
+    /]
+[/#macro]

--- a/aws/services/service.ftl
+++ b/aws/services/service.ftl
@@ -16,6 +16,9 @@
 [#assign AWS_CERTIFICATE_MANAGER_SERVICE = "acm"]
 [@addService provider=AWS_PROVIDER service=AWS_CERTIFICATE_MANAGER_SERVICE /]
 
+[#assign AWS_CERTIFICATE_MANAGER_PRIVATE_CA_SERVICE = "acmpca"]
+[@addService provider=AWS_PROVIDER service=AWS_CERTIFICATE_MANAGER_PRIVATE_CA_SERVICE /]
+
 [#assign AWS_CLIENTVPN_SERVICE = "clientvpn"]
 [@addService provider=AWS_PROVIDER service=AWS_CLIENTVPN_SERVICE /]
 

--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -89,6 +89,10 @@
                                 "Provider" : "awstest",
                                 "Name" : "cdn"
                             },
+                            "certificateauthority": {
+                                "Provider": "awstest",
+                                "Name": "certificateauthority"
+                            },
                             "computecluster" : {
                                 "Provider" : "awstest",
                                 "Name" : "computecluster"

--- a/awstest/modules/certificateauthority/module.ftl
+++ b/awstest/modules/certificateauthority/module.ftl
@@ -1,0 +1,153 @@
+[#ftl]
+
+[@addModule
+    name="certificateauthority"
+    description="Testing module for the aws certificateauthority component"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_certificateauthority ]
+
+    [#-- Base certificateauthority setup --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "dir" : {
+                    "Components" : {
+                        "certificateauthoritybase": {
+                            "Type": "certificateauthority",
+                            "Level": "Root",
+                            "deployment:Unit": "aws-certificateauthority",
+                            "Profiles" : {
+                                "Testing" : [ "certificateauthoritybase" ]
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "certificateauthoritybase" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "ACMPCAAuthorityXdirXcertificateauthoritybase" : {
+                                    "Name" : "ACMPCAAuthorityXdirXcertificateauthoritybase",
+                                    "Type" : "AWS::ACMPCA::CertificateAuthority"
+                                }
+                            },
+                            "Output" : [
+                                "ACMPCAAuthorityXdirXcertificateauthoritybase"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "CAType" : {
+                                    "Path"  : "Resources.ACMPCAAuthorityXdirXcertificateauthoritybase.Properties.Type",
+                                    "Value" : "ROOT"
+                                },
+                                "CAType" : {
+                                    "Path"  : "Resources.ACMPCAAuthorityXdirXcertificateauthoritybase.Properties.Subject.CommonName",
+                                    "Value" : "certificateauthoritybase-integration"
+                                },
+                                "ValidityFormat": {
+                                    "Path": "Resources.ACMPCACertificateXdirXcertificateauthoritybase.Properties.Validity.Type",
+                                    "Value": "DAYS"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "certificateauthoritybase" : {
+                    "certificateauthority" : {
+                        "TestCases" : [ "certificateauthoritybase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
+                    }
+                }
+            }
+        }
+    /]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "dir" : {
+                    "Components" : {
+                        "certificateauthorityrootsub_root": {
+                            "Type": "certificateauthority",
+                            "deployment:Unit": "aws-certificateauthority",
+                            "Level": "Root"
+                        },
+                        "certificateauthorityrootsub_sub": {
+                            "Type": "certificateauthority",
+                            "deployment:Unit": "aws-certificateauthority",
+                            "Level": "Subordinate",
+                            "level:Subordinate": {
+                                "ParentAuthority": {
+                                    "Link": {
+                                        "Tier": "dir",
+                                        "Component": "certificateauthorityrootsub_root"
+                                    }
+                                }
+                            },
+                            "Profiles" : {
+                                "Testing" : [ "certificateauthorityrootsub" ]
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "certificateauthorityrootsub" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "ACMPCAAuthorityXdirXcertificateauthorityrootsubXroot" : {
+                                    "Name" : "ACMPCAAuthorityXdirXcertificateauthorityrootsubXroot",
+                                    "Type" : "AWS::ACMPCA::CertificateAuthority"
+                                },
+                                "ACMPCAAuthorityXdirXcertificateauthorityrootsubXsub" : {
+                                    "Name" : "ACMPCAAuthorityXdirXcertificateauthorityrootsubXsub",
+                                    "Type" : "AWS::ACMPCA::CertificateAuthority"
+                                }
+                            },
+                            "Output" : [
+                                "ACMPCAAuthorityXdirXcertificateauthorityrootsubXroot",
+                                "ACMPCAAuthorityXdirXcertificateauthorityrootsubXsub"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "RootCAType" : {
+                                    "Path"  : "Resources.ACMPCAAuthorityXdirXcertificateauthorityrootsubXroot.Properties.Type",
+                                    "Value" : "ROOT"
+                                },
+                                "SubCAType" : {
+                                    "Path"  : "Resources.ACMPCAAuthorityXdirXcertificateauthorityrootsubXsub.Properties.Type",
+                                    "Value" : "SUBORDINATE"
+                                },
+                                "SubSignedByRoot" : {
+                                    "Path": "Resources.ACMPCACertificateXdirXcertificateauthorityrootsubXsub.Properties.CertificateAuthorityArn",
+                                    "Value": "arn:aws:iam::123456789012:mock/##MockOutputXACMPCAAuthorityXdirXcertificateauthorityrootsubXrootX##Xarn"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "certificateauthorityrootsub" : {
+                    "certificateauthority" : {
+                        "TestCases" : [ "certificateauthorityrootsub" ]
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds service and resources for ACMPCA
- Adds component implementation of the certificate authority using the ACMPCA services

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Implementation of https://github.com/hamlet-io/engine/pull/1970 
Creates a managed PKI chain that provides access to the private certificates and the ability to control the full authority chain

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with test suite

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1970

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

