### PR TITLE
feat(secretsmanager): add read write support fo secrets

### DIFF
--- a/aws/components/secretstore/state.ftl
+++ b/aws/components/secretstore/state.ftl
@@ -79,7 +79,9 @@
                 {
                     "Outbound" : {
                         "default" : "read",
-                        "read" : secretsManagerReadPermission(secretId, cmkKeyId)
+                        "read" : secretsManagerReadPermission(secretId, cmkKeyId),
+                        "readwrite" : secretsManagerWritePermission(secretId, cmkKeyId)+
+                                        secretsManagerReadPermission(secretId, cmkKeyId)
                     }
                 }
             )]

--- a/aws/services/kms/policy.ftl
+++ b/aws/services/kms/policy.ftl
@@ -86,3 +86,26 @@
         ]
     ]
 [/#function]
+
+[#function secretsManagerKMSStatement actions keyId secretId secretRegion ]
+
+    [#-- Handle empty region value if attribute is not set --]
+    [#if ! secretRegion?has_content ]
+        [#local secretRegion = getRegion()]
+    [/#if]
+
+    [#return
+        [
+            getPolicyStatement(
+                asArray(actions),
+                getArn(keyId, false, secretRegion),
+                "",
+                {
+                    "StringEquals" : {
+                        "kms:ViaService" : { "Fn::Join" : [ ".", [ "secretsmanager", secretRegion, "amazonaws.com"] ] }
+                    }
+                }
+            )
+        ]
+    ]
+[/#function]

--- a/aws/services/secretsmanager/policy.ftl
+++ b/aws/services/secretsmanager/policy.ftl
@@ -27,6 +27,31 @@
             allow,
             sid
         ) +
-        cmkDecryptPermission(kmsKeyId)
+        secretsManagerKMSStatement(["kms:Decrypt"], kmsKeyId, id, getReference(id, REGION_ATTRIBUTE_TYPE))
+    ]
+[/#function]
+
+[#function secretsManagerWritePermission id kmsKeyId principals="" conditions={} allow=true sid="" ]
+    [#return
+        getSecretsManagerStatement(
+            [
+                "secretsmanager:PutSecretValue",
+                "secretsmanager:UpdateSecret"
+            ],
+            id,
+            principals,
+            conditions,
+            allow,
+            sid
+        ) +
+        secretsManagerKMSStatement(["kms:GenerateDataKey"], kmsKeyId, id, getReference(id, REGION_ATTRIBUTE_TYPE)) +
+        [
+            getPolicyStatement(
+                [
+                    "secretsmanager:GetRandomPassword"
+                ],
+                "*"
+            )
         ]
+    ]
 [/#function]

--- a/aws/services/secretsmanager/resource.ftl
+++ b/aws/services/secretsmanager/resource.ftl
@@ -7,6 +7,9 @@
         },
         ARN_ATTRIBUTE_TYPE : {
             "UseRef" : true
+        },
+        REGION_ATTRIBUTE_TYPE: {
+            "Value" : { "Ref" : "AWS::Region" }
         }
     }
 ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds readwrite role for secrets manager secrets
- Adds additional access restriction on the use of the KMS key for encryption and decryption when using secrets manager
- Adds region to resource to allow for cross region secrets

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Read write role to allow for automated access to secrets from components that need to write generated secrets or content

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

