### PR TITLE
feat(dnszone): add support for private vpc zones

### DIFF
--- a/aws/components/dnszone/id.ftl
+++ b/aws/components/dnszone/id.ftl
@@ -8,11 +8,4 @@
     services=[
         AWS_ROUTE53_SERVICE
     ]
-    locations={
-        DEFAULT_RESOURCE_GROUP : {
-            "TargetComponentTypes" : [
-                SUBSCRIPTION_COMPONENT_TYPE
-            ]
-        }
-    }
 /]

--- a/aws/components/dnszone/setup.ftl
+++ b/aws/components/dnszone/setup.ftl
@@ -1,0 +1,38 @@
+[#ftl]
+[#macro aws_dnszone_cf_deployment_generationcontract_solution occurrence ]
+    [@addDefaultGenerationContract
+        subsets=["template"]
+    /]
+[/#macro]
+
+[#macro aws_dnszone_cf_deployment_solution occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core ]
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local resources = occurrence.State.Resources ]
+    [#local attributes = occurrence.State.Attributes ]
+
+    [#local vpcIds = []]
+
+    [#if (solution.Profiles.Network)?has_content]
+
+        [#local networkLink = getOccurrenceNetwork(occurrence).Link!{} ]
+        [#local networkLinkTarget = getLinkTarget(occurrence, networkLink ) ]
+        [#if ! networkLinkTarget?has_content ]
+            [@fatal message="Network could not be found" context=networkLink /]
+            [#return]
+        [/#if]
+        [#local networkConfiguration = networkLinkTarget.Configuration.Solution]
+        [#local networkResources = networkLinkTarget.State.Resources ]
+        [#local vpcIds = combineEntities(vpcIds, [ networkResources["vpc"].Id ], UNIQUE_COMBINE_BEHAVIOUR)]
+
+    [/#if]
+
+    [@createRoute53HostedZone
+        id=resources["zone"].Id
+        name=resources["zone"].Name
+        tags=getOccurrenceCoreTags(occurrence, occurrence.Core.FullName)
+        vpcIds=vpcIds
+    /]
+[/#macro]

--- a/aws/components/dnszone/state.ftl
+++ b/aws/components/dnszone/state.ftl
@@ -5,36 +5,76 @@
     [#local solution = getOccurrenceSolution(occurrence) ]
     [#local locations = getOccurrenceLocations(occurrence) ]
 
-    [#-- Combine any placement attributes with explicitly provided values --]
-    [#local attributes =
-        {
-            "REGION" : "us-east-1"
-        } +
-        ((locations[DEFAULT_RESOURCE_GROUP].Attributes)!{}) +
-        attributeIfContent(
-            "ZONE",
-            solution["external:ProviderId"]!""
-        )
-    ]
+    [#local privateZone = (solution.Profiles.Network)?has_content]
+
+    [#local resources = {}]
+    [#local attributes = {}]
+    [#local roles = {
+        "Inbound" : {},
+        "Outbound" : {}
+    }]
+
+    [#if privateZone]
+
+        [#local zoneId = formatResourceId(AWS_ROUTE53_HOSTED_ZONE_RESOURCE_TYPE, core.Id) ]
+
+        [#local domainObject = getCertificateObject(
+            {} +
+            attributeIfContent(
+                "Domain",
+                (solution.Domain)!""
+            ) +
+            attributeIfTrue(
+                "IncludeInDomain",
+                solution.IncludeInDomain.Configured
+            )
+        )]
+        [#local domainName = getCertificatePrimaryDomain(domainObject).Name ]
+
+        [#local resources = {
+            "zone" : {
+                "Id": zoneId,
+                "Name" : domainName,
+                "Type": AWS_ROUTE53_HOSTED_ZONE_RESOURCE_TYPE
+            }
+        }]
+
+        [#local attributes = {
+            "DOMAIN" : domainName,
+            "ZONE" : getExistingReference(zoneId)
+        }]
+
+    [#else]
+        [#-- Combine any placement attributes with explicitly provided values --]
+        [#local attributes =
+            {
+                "REGION" : "us-east-1"
+            } +
+            ((locations[DEFAULT_RESOURCE_GROUP].Attributes)!{}) +
+            attributeIfContent(
+                "ZONE",
+                solution["external:ProviderId"]!""
+            )
+        ]
+
+        [#local resources = {
+            "external" : {
+                "Id" : formatResourceId(AWS_ROUTE53_HOSTED_ZONE_RESOURCE_TYPE, core.Id),
+                "Type" : AWS_ROUTE53_HOSTED_ZONE_RESOURCE_TYPE,
+                "Deployed" :
+                    attributes["PROVIDER"]?has_content &&
+                    attributes["ACCOUNT"]?has_content &&
+                    attributes["ZONE"]?has_content
+            }
+        }]
+
+    [/#if]
 
     [#assign componentState =
         {
-            "Resources" : {
-                "external" : {
-                    "Id" : formatResourceId(AWS_ROUTE53_DNS_ZONE_RESOURCE_TYPE, core.Id),
-                    "Type" : AWS_ROUTE53_DNS_ZONE_RESOURCE_TYPE,
-                    "Deployed" :
-                        attributes["PROVIDER"]?has_content &&
-                        attributes["ACCOUNT"]?has_content &&
-                        attributes["ZONE"]?has_content
-                }
-            },
-            "Attributes" : attributes,
-            "Roles" : {
-                "Inbound" : {},
-                "Outbound" : {}
-            }
+            "Resources": resources,
+            "Attributes": attributes,
+            "Roles": roles
         }
     ]
-
 [/#macro]

--- a/aws/services/route53/id.ftl
+++ b/aws/services/route53/id.ftl
@@ -21,11 +21,11 @@
     resource=AWS_ROUTE53_HEALTHCHECK_RESOURCE_TYPE
 /]
 
-[#assign AWS_ROUTE53_DNS_ZONE_RESOURCE_TYPE = "route53dnszone" ]
+[#assign AWS_ROUTE53_HOSTED_ZONE_RESOURCE_TYPE = "route53hostedzone" ]
 [@addServiceResource
     provider=AWS_PROVIDER
     service=AWS_ROUTE53_SERVICE
-    resource=AWS_ROUTE53_DNS_ZONE_RESOURCE_TYPE
+    resource=AWS_ROUTE53_HOSTED_ZONE_RESOURCE_TYPE
 /]
 
 [#assign AWS_ROUTE53_RESOLVER_ENDPOINT_RESOURCE_TYPE = "route53ResolverEndpoint" ]

--- a/aws/services/vpc/resource.ftl
+++ b/aws/services/vpc/resource.ftl
@@ -431,6 +431,9 @@
         REFERENCE_ATTRIBUTE_TYPE : {
             "UseRef" : true,
             "Export" : true
+        },
+        REGION_ATTRIBUTE_TYPE : {
+            "Value" : { "Ref" : "AWS::Region" }
         }
     }
 ]

--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -117,6 +117,10 @@
                                 "Provider" : "awstest",
                                 "Name" : "dataset"
                             },
+                            "dnszone" : {
+                                "Provider" : "awstest",
+                                "Name" : "dnszone"
+                            },
                             "ec2" : {
                                 "Provider" : "awstest",
                                 "Name" : "ec2"

--- a/awstest/modules/dnszone/module.ftl
+++ b/awstest/modules/dnszone/module.ftl
@@ -1,0 +1,71 @@
+[#ftl]
+
+[@addModule
+    name="dnszone"
+    description="Testing module for the aws dnszone component"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_dnszone  ]
+
+    [#-- Base --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "mgmt" : {
+                    "Components" : {
+                        "dnszonebase_private":{
+                            "Type": "dnszone",
+                            "deployment:Unit": "aws-dnszone",
+                            "Profiles" : {
+                                "Network" : "default",
+                                "Testing" : [ "dnszonebase_private" ]
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "dnszonebase_private" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "privateZone" : {
+                                    "Name" : "route53hostedzoneXmgmtXdnszonebaseXprivate",
+                                    "Type" : "AWS::Route53::HostedZone"
+                                }
+                            },
+                            "Output" : [
+                                "route53hostedzoneXmgmtXdnszonebaseXprivate"
+                            ]
+                        },
+                        "JSON" : {
+                            "VPCDefined" : {
+                                "Exists" : "Resources.route53hostedzoneXmgmtXdnszonebaseXprivate.VPCs"
+                            },
+                            "LocalVPCDefined" : {
+                                "Match" : {
+                                    "Path" : "Resources.route53hostedzoneXmgmtXdnszonebaseXprivate.VPCs[0].VpcId",
+                                    "Value" : "vpc-123456789abcdef12"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "dnszonebase_private" : {
+                    "dnszone" : {
+                        "TestCases" : [ "dnszonebase_private" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
+                    }
+                }
+            }
+        }
+    /]
+
+[/#macro]

--- a/awstest/modules/segment/module.ftl
+++ b/awstest/modules/segment/module.ftl
@@ -47,6 +47,7 @@
                 "DeploymentUnit" : "vpc",
 
                 "vpcXmgmtXvpc": "vpc-123456789abcdef12",
+                "vpcXmgmtXvpcXregion": "mock-region-1",
 
                 "routeTableXmgmtXvpcXinternalXa": "rtb-123456789abcdef11",
                 "routeTableXmgmtXvpcXinternalXb": "rtb-21fedcba987654321",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for creating Route53 Hosted zones
- Updates dnszone to support network profile configuration to enable vpc based zones
- Adds testing for private hosting
- Adds region attribute to VPC 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for creating private DNS zones within route53 to support split DNS zones

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1979

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

