### PR TITLE
feat(ec2): support IPAddress groups and LB on same port

### DIFF
--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -87,7 +87,9 @@
                 [#continue]
             [/#if]
             [#local links += lbLink]
-        [#else]
+        [/#if]
+
+        [#if port.IPAddressGroups?has_content ]
             [#local ingressRules +=
                 [{
                     "Ports" : port.Name,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Support both the Port and LB configuration options on a port

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
- allows for multiple access methods to a given port depending on the service requirements

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

