### PR TITLE
fix(lb): use suboccurrence for static forwardning

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -769,7 +769,7 @@
 
         [#list solution.Forward.StaticEndpoints.Links as id,link ]
             [#if link?is_hash]
-                [#local linkTarget = getLinkTarget(occurrence, link) ]
+                [#local linkTarget = getLinkTarget(subOccurrence, link) ]
 
                 [@debug message="Link Target" context=linkTarget enabled=false /]
 
@@ -808,7 +808,7 @@
                         [/#list]
 
                         [#list endpointAddresses as endpointAddress ]
-                            [#local staticTargets += getTargetGroupTarget("ip", endpointAddress, endpointPort, true)]
+                            [#local staticTargets += getTargetGroupTarget("ip", endpointAddress, endpointPort, solution.Forward.StaticEndpoints.External)]
                         [/#list]
                         [#break]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- ensures the appropriate occurrence is used when linking to static targets
- Adds external configuration check to allow  for forwarding to static targets within the VPC

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Template generation failing when using links from subcomponent instances and relying on the local instance for link behaviour 
Using static target forwarding is helpful in situations where you might have fixed IP's but changing instances or multiple target groups are required for a particular service. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1981

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

