### PR TITLE
feat(task): add ses smtp password generation task

### DIFF
--- a/aws/tasks/aws_ses_smtp_password/id.ftl
+++ b/aws/tasks/aws_ses_smtp_password/id.ftl
@@ -17,7 +17,7 @@
         },
         {
             "Names" : "AWSSecretAccessKey",
-            "Description" : "The secret key of the access key pair that will be used to send emails via SMPT",
+            "Description" : "The secret key of the access key pair that will be used to send emails via SMTP",
             "Types" : STRING_TYPE,
             "Mandatory" : true
         }

--- a/aws/tasks/aws_ses_smtp_password/id.ftl
+++ b/aws/tasks/aws_ses_smtp_password/id.ftl
@@ -1,0 +1,25 @@
+[#ftl]
+
+[@addTask
+    type=AWS_SES_SMTP_PASSWORD_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Generate a Sig4 based SMTP credential that is used to authenciate with ses via SMTP"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "SESRegion",
+            "Description" : "The name of the region that the SMTP endpoint will be used",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The secret key of the access key pair that will be used to send emails via SMPT",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        }
+    ]
+/]

--- a/aws/tasks/task.ftl
+++ b/aws/tasks/task.ftl
@@ -10,3 +10,4 @@
 [#assign AWS_LAMBDA_INVOKE_FUNCTION_TASK_TYPE = "aws_lambda_invoke_function"]
 [#assign AWS_S3_DOWNLOAD_BUCKET_TASK_TYPE = "aws_s3_download_bucket"]
 [#assign AWS_S3_EMPTY_BUCKET_TASK_TYPE = "aws_s3_empty_bucket"]
+[#assign AWS_SES_SMTP_PASSWORD_TASK_TYPE = "aws_ses_smtp_password" ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Defines a task that generates the required Sig4 signed password used by the SES smtp service

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The new password required for SES smtp services is a hash encoded sig4 signature. This is much more complex than the original approach and AWS guidance requires the use of a script like python to handle this. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally with cli.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

