### PR TITLE
feat: add SES SMTP user module

### DIFF
--- a/aws/extensions/user_ses_smtp_permissions/extension.ftl
+++ b/aws/extensions/user_ses_smtp_permissions/extension.ftl
@@ -1,0 +1,25 @@
+[#ftl]
+
+[@addExtension
+    id="user_ses_smtp_permissions"
+    aliases=[
+        "_user_ses_smtp_permissions"
+    ]
+    description=[
+        "Provide a user with the permissions to send emails using SMTP"
+    ]
+    supportedTypes=[
+        USER_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_runbook_user_ses_smtp_permissions_runbook_setup occurrence ]
+
+    [@includeServicesConfiguration
+        provider=AWS_PROVIDER
+        services=AWS_SIMPLE_EMAIL_SERVICE
+        deploymentFramework=CLOUD_FORMATION_DEPLOYMENT_FRAMEWORK
+    /]
+
+    [@Policy getSESSendStatement() /]
+[/#macro]

--- a/aws/modules/ses_smtp_user/module.ftl
+++ b/aws/modules/ses_smtp_user/module.ftl
@@ -1,0 +1,181 @@
+[#ftl]
+
+[@addModule
+    name="ses_smtp_user"
+    description="Fixed user credentials that can be used for SMTP access to SES"
+    provider=AWS_PROVIDER
+    properties=[
+        {
+            "Names" : "tier",
+            "Type" : STRING_TYPE,
+            "Description" : "The tier the user will be part of",
+            "Default" : "app"
+        },
+        {
+            "Names" : "component",
+            "Type" : STRING_TYPE,
+            "Description" : "The name of the smtp user component",
+            "Default" : "smtp_user"
+        },
+        {
+            "Names" : "deploymentUnit",
+            "Type" : STRING_TYPE,
+            "Description" : "The deployment unit for the private bastion",
+            "Default" : "smtp-user"
+        },
+        {
+            "Names": "sesRegion",
+            "Type" : STRING_TYPE,
+            "Description" : "The SES region that will be used for sending emails",
+            "Default" : "us-east-1"
+        }
+    ]
+/]
+
+[#macro aws_module_ses_smtp_user
+            tier
+            component
+            deploymentUnit
+            sesRegion ]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                tier : {
+                    "Components" : {
+                        component: {
+                            "Type" : "user",
+                            "deployment:Unit": deploymentUnit,
+                            "GenerateCredentials" : {
+                                "EncryptionScheme" : "",
+                                "Formats" : [ "system" ]
+                            },
+                            "Permissions" : {
+                                "Decrypt": false,
+                                "AppData": false,
+                                "AppPublic": false,
+                                "AsFile": false
+                            }
+                        },
+                        "${component}_ses-password" : {
+                            "Description" : "Generate a sig4 password for use with SES",
+                            "Type" : "runbook",
+                            "Engine" : "hamlet",
+                            "Inputs" : {
+                                "sesRegion" : {
+                                    "Types" : "string",
+                                    "Default" : sesRegion,
+                                    "Values" : [
+                                        "us-east-2",
+                                        "us-east-1",
+                                        "us-west-1",
+                                        "us-west-2",
+                                        "ap-south-1",
+                                        "ap-northeast-3",
+                                        "ap-northeast-2",
+                                        "ap-southeast-1",
+                                        "ap-southeast-2",
+                                        "ap-northeast-1",
+                                        "ca-central-1",
+                                        "eu-central-1",
+                                        "eu-west-1",
+                                        "eu-west-2",
+                                        "eu-west-3",
+                                        "eu-north-1",
+                                        "sa-east-1",
+                                        "us-gov-west-1"
+                                    ]
+                                }
+                            },
+                            "Steps" : {
+                                "aws_login" : {
+                                    "Priority" : 5,
+                                    "Extensions" : [ "_runbook_get_provider_id" ],
+                                    "Task" : {
+                                        "Type" : "set_provider_credentials",
+                                        "Parameters" : {
+                                            "AccountId" : {
+                                                "Value" : "__setting:ACCOUNT__"
+                                            }
+                                        }
+                                    }
+                                },
+                                "decrypt_user_password" : {
+                                    "Priority" : 10,
+                                    "Extensions" : [ "_runbook_get_region" ],
+                                    "Task" : {
+                                        "Type" : "aws_kms_decrypt_ciphertext",
+                                        "Parameters" : {
+                                            "Ciphertext" : {
+                                                "Value" : "__attribute:user:SECRET_KEY__"
+                                            },
+                                            "EncryptionScheme" : {
+                                                "Value" : ""
+                                            },
+                                            "AWSAccessKeyId" : {
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Value" : "__output:aws_login:aws_session_token__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "user" : {
+                                            "Tier" : tier,
+                                            "Component" : component,
+                                            "Type" : "user"
+                                        }
+                                    }
+                                },
+                                "ses_password" : {
+                                    "Priority" : 50,
+                                    "Task" : {
+                                        "Type" : "aws_ses_smtp_password",
+                                        "Parameters" : {
+                                            "SESRegion" : {
+                                                "Value" : "__input:sesRegion__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:decrypt_user_password:result__"
+                                            }
+                                        }
+                                    }
+                                },
+                                "output_echo" : {
+                                    "Priority" : 100,
+                                    "Task": {
+                                        "Type" : "output_echo",
+                                        "Parameters" : {
+                                            "Format": {
+                                                "Value": "json"
+                                            },
+                                            "Value" : {
+                                                "Value" : getJSON({
+                                                    "host" : "email-smtp.__input:sesRegion__.amazonaws.com",
+                                                    "port" : 587,
+                                                    "username" : "__attribute:user:ACCESS_KEY__",
+                                                    "password" : "__output:ses_password:smtp_password__"
+                                                })
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "user" : {
+                                            "Tier" : tier,
+                                            "Component" : component,
+                                            "Type" : "user"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a module to define a standard SES SMTP
- Includes extension for setting SMTP email permissions
- Includes runbook for getting the SES SMTP password

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
With updates to the way that SES handles authentication for SMTP the process is now a bit more complicated. This module helps to reduce the complication and make a standardised way to manage SMTP based mail users for SES

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

