### PR TITLE
feat(alertslack): allow setting runtime with param

### DIFF
--- a/aws/modules/cloudwatchslack/module.ftl
+++ b/aws/modules/cloudwatchslack/module.ftl
@@ -48,6 +48,16 @@
             "Default" : "8f194db4f6ed2b826387112df144f188451ba6db"
         },
         {
+            "Names" : "lambdaRuntime",
+            "Type" : STRING_TYPE,
+            "Description" : "runtime engine for lambda",
+            "Values" : [
+                "python3.6",
+                "python3.9"
+            ],
+            "Default" : "python3.6"
+        },
+        {
             "Names" : "namePrefix",
             "Type" : STRING_TYPE,
             "Description" : "A prefix appended to component names and deployment units to ensure uniquness",
@@ -68,6 +78,7 @@
             kmsPrefix
             lambdaSourceUrl
             lambdaSourceHash
+            lambdaRuntime
             namePrefix
             tier
             alertSeverity
@@ -123,7 +134,7 @@
                             "Functions" : {
                                 "send" : {
                                     "Handler" : "cloudwatch-slack/lambda_function.lambda_handler",
-                                    "RunTime" : "python3.6",
+                                    "RunTime" : lambdaRuntime,
                                     "MemorySize" : 128,
                                     "Timeout" : 15,
                                     "VPCAccess" : false,

--- a/aws/modules/cloudwatchslack/module.ftl
+++ b/aws/modules/cloudwatchslack/module.ftl
@@ -48,16 +48,6 @@
             "Default" : "8f194db4f6ed2b826387112df144f188451ba6db"
         },
         {
-            "Names" : "lambdaRuntime",
-            "Type" : STRING_TYPE,
-            "Description" : "runtime engine for lambda",
-            "Values" : [
-                "python3.6",
-                "python3.9"
-            ],
-            "Default" : "python3.6"
-        },
-        {
             "Names" : "namePrefix",
             "Type" : STRING_TYPE,
             "Description" : "A prefix appended to component names and deployment units to ensure uniquness",
@@ -78,7 +68,6 @@
             kmsPrefix
             lambdaSourceUrl
             lambdaSourceHash
-            lambdaRuntime
             namePrefix
             tier
             alertSeverity
@@ -134,7 +123,7 @@
                             "Functions" : {
                                 "send" : {
                                     "Handler" : "cloudwatch-slack/lambda_function.lambda_handler",
-                                    "RunTime" : lambdaRuntime,
+                                    "RunTime" : "python3.9",
                                     "MemorySize" : 128,
                                     "Timeout" : 15,
                                     "VPCAccess" : false,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
Allow for lambda runtime to be set with a parameter for alertslack

## Motivation and Context
alertslack v1.2.0 has changes for python3.9 as the runtime. This is to allow it to be controlled via parameters

## How Has This Been Tested?
Locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

