### PR TITLE
fix(ecs): ensure subnets are always treated as an array

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -714,7 +714,7 @@
 
         [#local subnets = solution.MultiAZ?then(
                 getSubnets(core.Tier, networkResources),
-                getSubnets(core.Tier, networkResources)[0]
+                [ getSubnets(core.Tier, networkResources)[0] ]
             )]
 
         [#local networkProfile = getNetworkProfile(subOccurrence)]
@@ -743,7 +743,7 @@
                 {
                     "AwsvpcConfiguration" : {
                         "SecurityGroups" : getReferences(ecsSecurityGroupId),
-                        "Subnets" : asArray(subnets),
+                        "Subnets" : subnets,
                         "AssignPublicIp" : publicRouteTable?then("ENABLED", "DISABLED" )
                     }
                 }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
When using singleAZ make sure that the subnets returned are a list

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Template generation failing when in single AZ mode

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

