### PR TITLE
fix(ec2): fix ordering for cfn init commands

### DIFF
--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -88,8 +88,20 @@
             {
                 "AWS::CloudFormation::Init" : {
                     "configSets" : {
-                        configSetName : configSetTaskList?sort,
-                        formatName(configSetName, "wait") : waitConfigSetTaskList?sort
+                        configSetName : configSetTaskList?map(
+                            x -> { "priority" : x?keep_before("_")?number, "value": x }
+                        )?sort_by(
+                            "priority"
+                        )?map(
+                            x -> x["value"]
+                        ),
+                        formatName(configSetName, "wait") : waitConfigSetTaskList?map(
+                            x -> { "priority" : x?keep_before("_")?number, "value": x }
+                        )?sort_by(
+                            "priority"
+                        )?map(
+                            x -> x["value"]
+                        )
                     }
                 } + cfnInitTasks
             }]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Uses a list map to get the actual priority as a number

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When using CFN init scripts the ordering of tasks was determined by sorting on strings.  This meant that the ordering was based on same values rather than the number order of the priority. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

