### PR TITLE
feat(lambda): versioned lambda retention policy

### DIFF
--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -390,7 +390,7 @@
                 codeHash=_context.CodeHash!""
                 outputId=versionId
                 deletionPolicy=(solution.FixedCodeVersion.NewVersionOnDeploy)?then(
-                    "Retain",
+                    solution.FixedCodeVersion.DeletionPolicy,
                     ""
                 )
                 provisionedExecutions=solution.ProvisionedExecutions


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
When a new version is created on each deploy, provide control over whether the old versions are deleted or retained.

The default is to retain in line with the previous hard coded value.

## Motivation and Context
The need to delete has become more relevant as versioned lambdas are needed to preprovision lambda instances.

## How Has This Been Tested?
Local template generation. Customer deployments.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- https://github.com/hamlet-io/engine/pull/1989

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

