### PR TITLE
fix: format json content for run task module

### DIFF
--- a/aws/modules/runbook_run_task/module.ftl
+++ b/aws/modules/runbook_run_task/module.ftl
@@ -153,6 +153,9 @@
                                     "Task": {
                                         "Type": "output_echo",
                                         "Parameters" : {
+                                            "Format": {
+                                                "Value" : "json"
+                                            },
                                             "Value" : {
                                                 "Value" : "__output:run_task:run_status__"
                                             }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Make it easier to read the outcome of the task

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When running the task runbook the JSON output provided by the ecs task was hard to read as it was a compressed JSON output

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

