### PR TITLE
feat(lambda): sqs batch control

### DIFF
--- a/aws/components/lambda/id.ftl
+++ b/aws/components/lambda/id.ftl
@@ -26,3 +26,41 @@
             AWS_SIMPLE_NOTIFICATION_SERVICE
         ]
 /]
+
+
+[@addResourceGroupAttributeValues
+    type=LAMBDA_FUNCTION_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names" : "EventSources",
+            "Description": "Control how event sources are processed for AWS specific services",
+            "Children" : [
+                {
+                    "Names" : "SQS",
+                    "Description" : "SQS specific controls",
+                    "Children" : [
+                        {
+                            "Names" : "BatchSize",
+                            "Description" : "How many messages to pull from the queue in a batch",
+                            "Types" : NUMBER_TYPE,
+                            "Default" : 1
+                        },
+                        {
+                            "Names" : "ReportBatchItemFailures",
+                            "Description" : "Report the status of particular items that failed in the batch",
+                            "Types" : BOOLEAN_TYPE,
+                            "Default": false
+                        },
+                        {
+                            "Names" : "MaximumBatchingWindow",
+                            "Description" : "How long to gather records for batch processing",
+                            "Types": NUMBER_TYPE,
+                            "Default": 0
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+/]

--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -225,7 +225,12 @@
                                             id=formatLambdaEventSourceId(fn, "link", linkName)
                                             targetId=fnId
                                             source=linkTargetAttributes["ARN"]
-                                            batchSize=1
+                                            batchSize=solution["aws:EventSources"].SQS.BatchSize
+                                            functionResponseTypes=(solution["aws:EventSources"].SQS.ReportBatchItemFailures)?then(
+                                                ["ReportBatchItemFailures"],
+                                                []
+                                            )
+                                            maximumBatchingWindow=solution["aws:EventSources"].SQS.MaximumBatchingWindow
                                         /]
                                     [/#if]
                                     [#break]

--- a/aws/services/lambda/resource.ftl
+++ b/aws/services/lambda/resource.ftl
@@ -199,7 +199,16 @@
     /]
 [/#macro]
 
-[#macro createLambdaEventSource id targetId source enabled=true batchSize="" startingPosition="" dependencies=""]
+[#macro createLambdaEventSource
+        id
+        targetId
+        source
+        enabled=true
+        batchSize=""
+        startingPosition=""
+        functionResponseTypes=[]
+        maximumBatchingWindow=0
+        dependencies=[]]
 
     [@cfResource
         id=id
@@ -211,7 +220,9 @@
                 "FunctionName" : getReference(targetId)
             } +
             attributeIfContent("BatchSize", batchSize) +
-            attributeIfContent("StartingPosition", startingPosition)
+            attributeIfContent("StartingPosition", startingPosition) +
+            attributeIfContent("FunctionResponseTypes", asArray(functionResponseTypes)) +
+            attributeIfTrue("MaximumBatchingWindowInSeconds", maximumBatchingWindow > 0, maximumBatchingWindow)
         outputs=LAMBDA_EVENT_SOURCE_MAPPINGS
         dependencies=dependencies
     /]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for controlling the message batches for sqs when using lambda event sources

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Adds support for controlling the message size, batch maximum wait time and handling individual record failures

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

