### PR TITLE
fix(s3): handle notifications for endpoints already deployed

### DIFF
--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -66,7 +66,7 @@
 
                     [#if ! getExistingReference(s3Id)?has_content ]
                         [@warn
-                            message="Notification persmissions requried before enabling notifications"
+                            message="Notification permissions required before enabling notifications"
                             detail="Update the notificaton destination and rerun this deployment"
                             context={
                                 "S3_Bucket" : {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Fixes an issue where s3 can't validate a notification endpoint because the resource policy isn't applied on the notification endpoint

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Handles adding 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

