### PR TITLE
refactor(apigateway): authorization models

### DIFF
--- a/aws/components/apigateway/id.ftl
+++ b/aws/components/apigateway/id.ftl
@@ -57,3 +57,15 @@
         ]
     prefixed=false
 /]
+
+[@addResourceGroupAttributeValues
+    type=APIGATEWAY_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names": "AuthorisationModel",
+            "Types" : STRING_TYPE,
+            "Values" : [ "aws:SIG4_OR_IP", "aws:SIG4_AND_IP" ]
+        }
+    ]
+/]

--- a/aws/components/apigateway/id.ftl
+++ b/aws/components/apigateway/id.ftl
@@ -65,7 +65,7 @@
         {
             "Names": "AuthorisationModel",
             "Types" : STRING_TYPE,
-            "Values" : [ "aws:SIG4_OR_IP", "aws:SIG4_AND_IP" ]
+            "Values" : [ "shared:SIG4ORIP", "SIG4_OR_IP", "shared:SIG4ANDIP", "SIG4_AND_IP" ]
         }
     ]
 /]

--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -281,7 +281,7 @@
                 [#break]
 
             [#case "SIG4ORIP" ]
-            [#case "SIG4_OR_IP" ]
+            [#case "aws:SIG4_OR_IP" ]
             [#case "AUTHORIZER_OR_IP" ]
             [#case "AUTHORISER_OR_IP" ]
                 [#-- Resource policy provides ALLOW on IP --]
@@ -300,7 +300,7 @@
                 [#break]
 
             [#case "SIG4ANDIP" ]
-            [#case "SIG4_AND_IP" ]
+            [#case "aws:SIG4_AND_IP" ]
             [#case "AUTHORIZER_AND_IP" ]
             [#case "AUTHORISER_AND_IP" ]
                 [#-- If IP doesn't match, EXPLICIT DENY regardless of SIG4 --]

--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -241,16 +241,18 @@
         [#-- If lambda authorizers are in use, and the default AuthorisationModel is --]
         [#-- effect, warn and force the model to a valid value                       --]
         [#if lambdaAuthorizers?has_content && !apiPolicyAuth?starts_with("AUTHORI") ]
-            [@warn
-                message="Authorization model of \"" + apiPolicyAuth + "\" is not compatible with the use of lambda authorizers. Forcing to \"AUTHORISER_AND_IP\"."
+            [@fatal
+                message="Authorization model of \"" + apiPolicyAuth + "\" is not compatible with the use of lambda authorizers"
+                detail="Use one of the AUTHORISER models"
             /]
             [#local apiPolicyAuth = "AUTHORISER_AND_IP" ]
         [/#if]
 
         [#-- If cognito authorizers are in use, the AuthorisationModel must be IP --]
         [#if cognitoPools?has_content && (apiPolicyAuth != "IP") ]
-            [@warn
-                message="Authorization model of \"" + apiPolicyAuth + "\" is not compatible with the use of cognito authorizers. Forcing to \"IP\"."
+            [@fatal
+                message="Authorization model of \"" + apiPolicyAuth + "\" is not compatible with the use of cognito authorizers"
+                detail="Use the IP model"
             /]
             [#local apiPolicyAuth = "IP" ]
         [/#if]


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Support additional model values for the case of IP filtering in combination with a lambda authorizer. Also rename the config attribute to more correctly reflect its purpose in controlling authorization rather than authentication.

## Motivation and Context
When used with a lambda authorizer, the default value of "IP" incorrectly provides an explicit ALLOW rather than relying on it to come from the policy provided by the authorizer. By providing explicit values to be used with the authorizer, the configuration can be validated as appropriate.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- https://github.com/hamlet-io/engine/pull/1995

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

