### PR TITLE
feat(datafeed): add support for data streams as a source

### DIFF
--- a/aws/components/datafeed/id.ftl
+++ b/aws/components/datafeed/id.ftl
@@ -37,6 +37,23 @@
                     ]
                 }
             ]
+        },
+        {
+            "Names" : "DataStreamSource",
+            "Description" : "Use a data stream as the source of data for the feed",
+            "Children" : [
+                {
+                    "Names" : "Enabled",
+                    "Description": "Require the use of a data stream as the data source",
+                    "Types" : BOOLEAN_TYPE,
+                    "Default" : false
+                },
+                {
+                    "Names" : "Link",
+                    "Description" : "A link to the datastream to use as the source",
+                    "AttributeSet": LINK_ATTRIBUTESET_TYPE
+                }
+            ]
         }
     ]
     provider=AWS_PROVIDER

--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -265,7 +265,7 @@
                                                 streamBackupLoggingConfiguration )]
 
         [#local includeOrder = solution.Bucket.Include.Order ]
-        [#switch destinationLink.Core.Type ]
+        [#switch (destinationLink.Core.Type)!"" ]
 
             [#case BASELINE_DATA_COMPONENT_TYPE]
                 [#if !(includeOrder?seq_contains("ComponentPath")) || !(solution.Bucket.Include.ComponentPath) ]

--- a/aws/components/datastream/state.ftl
+++ b/aws/components/datastream/state.ftl
@@ -18,7 +18,7 @@
             },
             "Attributes" : {
                 "STREAM_NAME" : getExistingReference(streamId),
-                "STREAM_ARN" : getExistingReference(streamId, ARN_ATTRIBUTE_TYPE)
+                "STREAM_ARN" : getArn(streamId)
             },
             "Roles" : {
                 "Outbound" : {

--- a/aws/services/kinesis/resource.ftl
+++ b/aws/services/kinesis/resource.ftl
@@ -98,7 +98,16 @@
     /]
 [/#macro]
 
-[#macro createFirehoseStream id destination name="" dependencies="" ]
+[#macro createFirehoseStream
+        id
+        destination
+        name=""
+        deliveryStreamType=""
+        kinesisStreamSourceId=""
+        roleId=""
+        dependencies=""
+        tags=[] ]
+
     [@cfResource
         id=id
         type="AWS::KinesisFirehose::DeliveryStream"
@@ -108,7 +117,20 @@
                 "DeliveryStreamName",
                 name
             ) +
+            attributeIfContent(
+                "DeliveryStreamType",
+                deliveryStreamType
+            ) +
+            attributeIfContent(
+                "KinesisStreamSourceConfiguration",
+                kinesisStreamSourceId,
+                {
+                    "KinesisStreamARN" : getArn(kinesisStreamSourceId),
+                    "RoleARN" : getArn(roleId)
+                }
+            ) +
             destination
+        tags=tags
         outputs=KINESIS_FIREHOSE_STREAM_OUTPUT_MAPPINGS
         dependencies=dependencies
     /]

--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -109,6 +109,10 @@
                                 "Provider" : "awstest",
                                 "Name" : "correspondent"
                             },
+                            "datafeed" : {
+                                "Provider" : "awstest",
+                                "Name" : "datafeed"
+                            },
                             "datapipeline" : {
                                 "Provider" : "awstest",
                                 "Name" : "datapipeline"

--- a/awstest/modules/datafeed/module.ftl
+++ b/awstest/modules/datafeed/module.ftl
@@ -1,0 +1,112 @@
+[#ftl]
+
+[@addModule
+    name="datafeed"
+    description="Testing module for the aws datastream component"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_datafeed  ]
+
+    [#-- Data Stream Source --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "datafeedstreamsource": {
+                            "Type" : "datafeed",
+                            "deployment:Unit": "aws-datafeed",
+                            "Profiles" : {
+                                "Testing" : [ "datafeedstreamsource" ]
+                            },
+                            "aws:DataStreamSource" : {
+                                "Enabled" : true,
+                                "Link" : {
+                                    "Tier": "app",
+                                    "Component" : "datafeedstreamsource-datastream"
+                                }
+                            },
+                            "Destination" : {
+                                "Link": {
+                                    "Tier" : "app",
+                                    "Component": "datafeedstreamsource-s3"
+                                }
+                            }
+                        },
+                        "datafeedstreamsource-datastream":{
+                            "Type": "datastream",
+                            "deployment:Unit": "aws-datafeed"
+                        },
+                        "datafeedstreamsource-s3":{
+                            "Type": "s3",
+                            "deployment:Unit": "aws-datafeed"
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "datafeedstreamsource" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "Firehose" : {
+                                    "Name" : "firehosestreamXappXdatafeedstreamsource",
+                                    "Type" : "AWS::KinesisFirehose::DeliveryStream"
+                                },
+                                "Stream" : {
+                                    "Name" : "datastreamXappXdatafeedstreamsource",
+                                    "Type" : "AWS::Kinesis::Stream"
+                                }
+                            },
+                            "Output" : [
+                                "firehosestreamXappXdatafeedstreamsource",
+                                "firehosestreamXappXdatafeedstreamsourceXarn",
+                                "datastreamXappXdatafeedstreamsource",
+                                "datastreamXappXdatafeedstreamsourceXarn"
+                            ]
+                        },
+                        "JSON" : {
+                            "Exists" : [
+                                "Resources.firehosestreamXappXdatafeedstreamsource.Properties.KinesisStreamSourceConfiguration.KinesisStreamARN"
+                            ],
+                            "Match" : {
+                                "DeliveryStreamType" : {
+                                    "Path"  : "Resources.firehosestreamXappXdatafeedstreamsource.Properties.DeliveryStreamType",
+                                    "Value" : "KinesisStreamAsSource"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "datafeedstreamsource" : {
+                    "datafeed" : {
+                        "TestCases" : [ "datafeedstreamsource" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
+                    }
+                }
+            }
+        }
+
+        stackOutputs=[
+            {
+                "Account" : "0123456789",
+                "Region" : "mock-region-1",
+                "DeploymentUnit" : "aws-datafeed",
+
+                "datastreamXappXdatafeedstreamsource": "mockedup-integration-application-datafeedstreamsource",
+                "datastreamXappXdatafeedstreamsourceXarn" : "arn:aws:kinesis:mock-region-1:0123456789:stream/mockedup-integration-application-datafeedstreamsource",
+
+                "s3XappXdatafeedstreamsource": "mockedup-integration-application-datafeedstreamsource-568132487",
+                "s3XappXdatafeedstreamsourceXarn" : "arn:aws:s3:::mockedup-integration-application-datafeedstreamsource-568132487e"
+            }
+        ]
+    /]
+
+[/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for using a kinesis datafirehose as a kinesis data stream consumer

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This is an AWS specific implementation which allows you to essentially have a serverless managed consumer of kinesis datastreams using the firehose service and its integration with services like lambda. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and added test cases

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

