### PR TITLE
refactor(lb): use shared security group for backends

### DIFF
--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -131,6 +131,11 @@
                     "Type" : resourceType,
                     "PublicFacing" : publicFacing,
                     "Monitored" : true
+                },
+                "targetGroupSG" : {
+                    "Id" : formatResourceId(AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id, "targetGroup"),
+                    "Name": formatName(core.FullName, "targetGroup"),
+                    "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 }
             } +
             attributeIfContent("wafacl", wafResources) +
@@ -357,12 +362,11 @@
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
     [#local parentSolution = parent.Configuration.Solution ]
+    [#local parentResources = parent.State.Resources]
 
     [#local engine = parentSolution.Engine]
 
     [#local targetGroupId = formatResourceId(AWS_ALB_TARGET_GROUP_RESOURCE_TYPE, core.Id) ]
-    [#local securityGroupId = formatResourceId(AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id)]
-
     [#local port = (getReferenceData(PORT_REFERENCE_TYPE)[solution.Port])!{} ]
     [#local resources = {}]
 
@@ -375,12 +379,6 @@
                     "Id" : targetGroupId,
                     "Type" : AWS_ALB_TARGET_GROUP_RESOURCE_TYPE,
                     "Monitored": true
-                },
-                "sg" : {
-                    "Id" : securityGroupId,
-                    "Name": core.FullName,
-                    "Ports" : [solution.Port],
-                    "Type" : AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE
                 }
             }]
 
@@ -402,7 +400,7 @@
             "Roles" : {
                 "Inbound" : {
                     "networkacl": {
-                        "SecurityGroups" : securityGroupId,
+                        "SecurityGroups" : parentResources.targetGroupSG.Id,
                         "Description" : core.FullName
                     }
                 },
@@ -410,7 +408,7 @@
                     "networkacl" : {
                         "Ports" : [ solution.Port ],
                         "Description" : core.FullName,
-                        "SecurityGroups" : [ securityGroupId ]
+                        "SecurityGroups" : [ parentResources.targetGroupSG.Id ]
                     }
                 }
             }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- moves to using a component level security group for access control into backends 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
- application load balancers have a limit of 5 security group attachments. If you have more than 3 backends defined this will blow the limit ( if you have two listeners http and https, they each get a sec group ) 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

