### PR TITLE
fix(kms): policies for kms encryption from via services

### DIFF
--- a/aws/components/datastream/id.ftl
+++ b/aws/components/datastream/id.ftl
@@ -28,6 +28,7 @@
         [
             AWS_CLOUDWATCH_SERVICE,
             AWS_IDENTITY_SERVICE,
-            AWS_KINESIS_SERVICE
+            AWS_KINESIS_SERVICE,
+            AWS_KEY_MANAGEMENT_SERVICE
         ]
 /]

--- a/aws/extensions/cmk_sns_access/extension.ftl
+++ b/aws/extensions/cmk_sns_access/extension.ftl
@@ -1,19 +1,19 @@
 [#ftl]
 
 [@addExtension
-    id="cmk_s3_access"
+    id="cmk_sns_access"
     aliases=[
-        "_cmk_s3_access"
+        "_cmk_sns_access"
     ]
     description=[
-        "Grants access to a CMK from the S3 Service"
+        "Grants access to a CMK from the SNS Service"
     ]
     supportedTypes=[
         BASELINE_KEY_COMPONENT_TYPE
     ]
 /]
 
-[#macro shared_extension_cmk_s3_access_deployment_setup occurrence ]
+[#macro shared_extension_cmk_sns_access_deployment_setup occurrence ]
 
     [@Policy
         [
@@ -24,11 +24,11 @@
                 ],
                 "*"
                 {
-                    "Service" : "s3.amazonaws.com"
+                    "Service" : "sns.amazonaws.com"
                 },
                 "",
                 true,
-                "S3 Access - Inventory Reports - SNS SQS Notifications"
+                "SNS Service Principal Access"
             )
         ]
     /]

--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -172,7 +172,8 @@
                                 "Extensions": [
                                     "_cmk_s3_access",
                                     "_cmk_ses_access",
-                                    "_cmk_cloudfront_access"
+                                    "_cmk_cloudfront_access",
+                                    "_cmk_sns_access"
                                 ]
                             },
                             "oai": {

--- a/aws/services/kms/policy.ftl
+++ b/aws/services/kms/policy.ftl
@@ -75,11 +75,25 @@
                 getArn(keyId, false, bucketRegion),
                 "",
                 {
-                    "StringEquals" : {
-                        "kms:ViaService" : formatDomainName( "s3", bucketRegion, "amazonaws.com" )
-                    },
                     "StringLike" : {
                         "kms:EncryptionContext:aws:s3:arn" : "arn:aws:s3:::" + formatRelativePath(bucketName, bucketPrefix?ensure_ends_with("*") )
+                    }
+                }
+            )
+        ]
+    ]
+[/#function]
+
+[#function kinesisStreamEncryptionStatement actions keyId kinesisStreamId ]
+    [#return
+        [
+            getPolicyStatement(
+                asArray(actions),
+                getArn(keyId),
+                "",
+                {
+                    "StringEquals" : {
+                        "kms:EncryptionContext:aws:kinesis:arn" : getArn(kinesisStreamId)
                     }
                 }
             )


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds KMS support for datastream consumers and producers
- Adds S3 policies for SNS SQS kms access
- Adds SNS kms policy for dealing with encrypted topics
- Fixes an issue in S3 KMS policies which removes the requirement for the ViaService policy

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Found during further testing of using encryption for various services

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and using policy deployments

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

