### PR TITLE
fix(ec2): number formatting for priorities

### DIFF
--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -420,7 +420,7 @@
                     creationPolicy={
                         "ResourceSignal" : {
                             "Count" : 1,
-                            "Timeout" : "PT${solution.StartupTimeout}S"
+                            "Timeout" : "PT${solution.StartupTimeout?c}S"
                         }
                     }
                 /]

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -74,7 +74,7 @@
 
             [#if ((cfnInitTask.Content)!{})?has_content ]
 
-                [#local configSetId = "${cfnInitTask.Priorty}_${id}_wait" ]
+                [#local configSetId = "${(cfnInitTask.Priorty)?c}_${id}_wait" ]
                 [#local waitConfigSetTaskList += [ configSetId ] ]
                 [#local cfnInitTasks += {
                     configSetId : cfnInitTask.Content


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Ensures that computer based formatting is used for numbers in ec2 templates

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for numbers greater than 999 to be used in startup timeouts and priority for tasks

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

