### PR TITLE
fix(cert): raise error on invalid FQDN

### DIFF
--- a/aws/components/apigateway/state.ftl
+++ b/aws/components/apigateway/state.ftl
@@ -298,24 +298,28 @@ created in either case.
     [#local customDomainResources = {} ]
     [#list customDomains as domain]
         [#local customFqdn = formatDomainName(customHostName, domain) ]
-        [#local customFqdnParts = splitDomainName(customFqdn) ]
-        [#local customFqdnId = formatResourceId(AWS_APIGATEWAY_DOMAIN_RESOURCE_TYPE, customFqdnParts) ]
-        [#local customDomainResources +=
-            {
-                customFqdn : {
-                    "domain" : {
-                        "Id" : customFqdnId,
-                        "Name" : customFqdn,
-                        "CertificateId" : certificateId,
-                        "Type" : AWS_APIGATEWAY_DOMAIN_RESOURCE_TYPE
-                    },
-                    "basepathmapping" : {
-                        "Id" : formatDependentResourceId(AWS_APIGATEWAY_BASEPATHMAPPING_RESOURCE_TYPE, customFqdnId),
-                        "Stage" : mappingStage,
-                        "Type" : AWS_APIGATEWAY_BASEPATHMAPPING_RESOURCE_TYPE
+        [#if !customFqdn?contains(".") ]
+            [@fatal message="Missing domain name for API gateway" context=solution /]
+        [#else]
+            [#local customFqdnParts = splitDomainName(customFqdn) ]
+            [#local customFqdnId = formatResourceId(AWS_APIGATEWAY_DOMAIN_RESOURCE_TYPE, customFqdnParts) ]
+            [#local customDomainResources +=
+                {
+                    customFqdn : {
+                        "domain" : {
+                            "Id" : customFqdnId,
+                            "Name" : customFqdn,
+                            "CertificateId" : certificateId,
+                            "Type" : AWS_APIGATEWAY_DOMAIN_RESOURCE_TYPE
+                        },
+                        "basepathmapping" : {
+                            "Id" : formatDependentResourceId(AWS_APIGATEWAY_BASEPATHMAPPING_RESOURCE_TYPE, customFqdnId),
+                            "Stage" : mappingStage,
+                            "Type" : AWS_APIGATEWAY_BASEPATHMAPPING_RESOURCE_TYPE
+                        }
                     }
-                }
-            } ]
+                } ]
+        [/#if]
     [/#list]
 
     [#-- API documentation if required --]
@@ -335,19 +339,23 @@ created in either case.
                     docsHostName,
                     domain) ]
 
-            [#local docsFqdnParts = splitDomainName(docsFqdn) ]
-            [#local docsId = formatS3Id(docsFqdnParts) ]
+            [#if !docsFqdn?contains(".") ]
+                [@fatal message="Missing domain name for API docs" context=solution /]
+            [#else]
+                [#local docsFqdnParts = splitDomainName(docsFqdn) ]
+                [#local docsId = formatS3Id(docsFqdnParts) ]
 
-            [#local docsResources +=
-                {
-                    docsFqdn : {
-                        "bucket" : {
-                            "Id" : docsId,
-                            "Name" : docsFqdn,
-                            "Type" : AWS_S3_RESOURCE_TYPE
+                [#local docsResources +=
+                    {
+                        docsFqdn : {
+                            "bucket" : {
+                                "Id" : docsId,
+                                "Name" : docsFqdn,
+                                "Type" : AWS_S3_RESOURCE_TYPE
+                            }
                         }
-                    }
-                } ]
+                    } ]
+            [/#if]
          [/#list]
     [/#if]
 

--- a/aws/services/acm/id.ftl
+++ b/aws/services/acm/id.ftl
@@ -32,6 +32,10 @@
 [#function formatDomainCertificateId certificateObject, hostName=""]
     [#local primaryDomain = getCertificatePrimaryDomain(certificateObject) ]
     [#if primaryDomain.Name?has_content ]
+        [#if !primaryDomain.Name?contains(".") ]
+            [@fatal message="Missing domain name for ACM primary domain" context=solution /]
+            [#return ""]
+        [/#if]
         [#return
             formatResourceId(
                 AWS_CERTIFICATE_RESOURCE_TYPE,

--- a/aws/services/acm/id.ftl
+++ b/aws/services/acm/id.ftl
@@ -32,10 +32,6 @@
 [#function formatDomainCertificateId certificateObject, hostName=""]
     [#local primaryDomain = getCertificatePrimaryDomain(certificateObject) ]
     [#if primaryDomain.Name?has_content ]
-        [#if !primaryDomain.Name?contains(".") ]
-            [@fatal message="Missing domain name for ACM primary domain" context=solution /]
-            [#return ""]
-        [/#if]
         [#return
             formatResourceId(
                 AWS_CERTIFICATE_RESOURCE_TYPE,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Raise non-stopping fatal error when api gateway domain name does not include at least one dot combines with more general https://github.com/hamlet-io/engine/pull/2008

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Fixes https://github.com/hamlet-io/engine/issues/1665

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Couldn't see how to set up a failure case to test - any advice

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/2008

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

