### PR TITLE
feat(dyanmicvalues): add support for aws secrets as dynamic values

### DIFF
--- a/aws/dynamicvalues/aws_secret/dynamicvalue.ftl
+++ b/aws/dynamicvalues/aws_secret/dynamicvalue.ftl
@@ -1,0 +1,69 @@
+[#ftl]
+
+[@addDynamicValueProvider
+    type=AWS_SECRET_DYNAMIC_VALUE_TYPE
+    properties=[
+        {
+            "Type"  : "Description",
+            "Value" : "Returns a reference to a secret stored in a secretstore"
+        }
+    ]
+    parameterOrder=["linkId", "jsonKey", "version" ]
+    parameterAttributes=[
+        {
+            "Names" : "linkId",
+            "Description" : "The Id of the link to the secret",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names" : "jsonKey",
+            "Description" : "If the secret is a json object the key of the value to return",
+            "Types" : STRING_TYPE,
+            "Default" : ""
+        },
+        {
+            "Names" : "version",
+            "Description" : "The version of the secret to reference",
+            "Types" : STRING_TYPE,
+            "Default" : "LATEST"
+        }
+    ]
+/]
+
+[#function shared_dynamicvalue_aws_secret value properties sources={} ]
+
+    [#if sources.occurrence?? ]
+        [#local link = (sources.occurrence.Configuration.Solution.Links[properties.linkId])!{}]
+        [#local linkTarget = getLinkTarget(sources.occurrence, link, false)]
+
+        [#if ! linkTarget?has_content || linkTarget.Core.Type != SECRETSTORE_SECRET_COMPONENT_TYPE ]
+            [@fatal
+                message="Link not found or the wrong type"
+                detail="link must be to a secret store secret"
+                context={
+                    "Component"  : sources.occurrence.Core.Component.RawId,
+                    "LinkId" : properties.linkId,
+                    "Links" : sources.occurrence.Configuration.Solution.Links,
+                    "LinkType" : (linkTarget.Core.Type)!""
+                }
+            /]
+            [#return ""]
+        [/#if]
+
+        [#local version = (properties.version == "LATEST")?then("", properties.version)]
+        [#local secretArn = getReference(linkTarget.State.Resources.secret.Id, ARN_ATTRIBUTE_TYPE)]
+
+        [#return {
+            "Fn::Sub": [
+                r'{{resolve:secretsmanager:${secretArn}:SecretString:${jsonKey}::${version}}}',
+                {
+                    "secretArn" : secretArn,
+                    "jsonKey" : "${properties.jsonKey}",
+                    "version" : "${version}"
+                }
+            ]
+        }]
+    [/#if]
+    [#return "__${vaule}__"]
+[/#function]

--- a/aws/dynamicvalues/dynamicvalue.ftl
+++ b/aws/dynamicvalues/dynamicvalue.ftl
@@ -1,0 +1,3 @@
+[#ftl]
+
+[#assign AWS_SECRET_DYNAMIC_VALUE_TYPE = "aws_secret" ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for providing a reference to a secretstore secret
- Transforms the secret into the appropriate cloudformation ref

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for providing sensitive content in solution configuration that is evaluated at runtime and injected when it needs to be. 
This method is available across some components already but requires explicit configuration. Using this approach allows for a more standardised approach that can be used when the user chooses to.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

