### PR TITLE
feat(lambda): lambda aliases

### DIFF
--- a/aws/components/lambda/state.ftl
+++ b/aws/components/lambda/state.ftl
@@ -26,6 +26,9 @@
     [#local solution = occurrence.Configuration.Solution ]
 
     [#local id = formatResourceId(AWS_LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id)]
+
+    [#local region = getExistingReference(id, REGION_ATTRIBUTE_TYPE)!getRegion()]
+
     [#-- Unversioned lambda ARN - make available to permit linkage even if function isn't deployed --]
     [#local arn =
         formatArn(
@@ -84,8 +87,6 @@
             ]
         [/#if]
     [/#if]
-
-    [#local region = getExistingReference(id, REGION_ATTRIBUTE_TYPE)!getRegion()]
 
     [#local lgId = formatLogGroupId(core.Id)]
     [#local lgName = formatAbsolutePath("aws", "lambda", core.FullName)]

--- a/aws/components/lambda/state.ftl
+++ b/aws/components/lambda/state.ftl
@@ -26,13 +26,63 @@
     [#local solution = occurrence.Configuration.Solution ]
 
     [#local id = formatResourceId(AWS_LAMBDA_FUNCTION_RESOURCE_TYPE, core.Id)]
+    [#-- Unversioned lambda ARN - make available to permit linkage even if function isn't deployed --]
+    [#local arn =
+        formatArn(
+            getRegionObject().Partition,
+            "lambda",
+            region,
+            accountObject.ProviderId,
+            "function:" + core.FullName,
+            true
+        )
+    ]
 
-    [#local versionOutputId = formatResourceId(AWS_LAMBDA_VERSION_RESOURCE_TYPE, core.Id) ]
+    [#local fixedCodeVersion = {} ]
+    [#if isPresent(solution.FixedCodeVersion) ]
 
-    [#if solution.FixedCodeVersion.NewVersionOnDeploy ]
-        [#local versionId = formatId(versionOutputId, runId )]
-    [#else]
-        [#local versionId = versionOutputId]
+        [#local versionOutputId = formatResourceId(AWS_LAMBDA_VERSION_RESOURCE_TYPE, core.Id) ]
+
+        [#-- The arn changes as part of the deployment process to reflect the new version --]
+        [#local arn = getExistingReference(versionOutputId) ]
+        [#local fixedCodeVersion =
+            {
+                "version" : {
+                    "Id" : versionOutputId,
+                    "ResourceId" :
+                        valueIfTrue(
+                            formatId(versionOutputId, runId),
+                            solution.FixedCodeVersion.NewVersionOnDeploy,
+                            versionOutputId
+                        ),
+                    "Type" : AWS_LAMBDA_VERSION_RESOURCE_TYPE
+                }
+            }
+        ]
+
+        [#if solution.FixedCodeVersion.Alias?has_content]
+            [#local aliasId = formatResourceId(AWS_LAMBDA_ALIAS_RESOURCE_TYPE, core.Id) ]
+            [#local fixedCodeVersion +=
+                {
+                    "alias" : {
+                        "Id" : aliasId,
+                        "Name" : solution.FixedCodeVersion.Alias,
+                        "Type" : AWS_LAMBDA_ALIAS_RESOURCE_TYPE
+                    }
+                }
+            ]
+            [#-- Alias ARN is fixed - make available to permit linkage even if function isn't deployed --]
+            [#local arn =
+                formatArn(
+                    getRegionObject().Partition,
+                    "lambda",
+                    region,
+                    accountObject.ProviderId,
+                    ["function", core.FullName, solution.FixedCodeVersion.Alias]?join(":")
+                    true
+                )
+            ]
+        [/#if]
     [/#if]
 
     [#local region = getExistingReference(id, REGION_ATTRIBUTE_TYPE)!getRegion()]
@@ -41,8 +91,6 @@
     [#local lgName = formatAbsolutePath("aws", "lambda", core.FullName)]
 
     [#local securityGroupId = formatDependentSecurityGroupId(id)]
-
-    [#local fixedCodeVersion = isPresent(solution.FixedCodeVersion) ]
 
     [#local logMetrics = {} ]
     [#list solution.LogMetrics as name,logMetric ]
@@ -75,15 +123,7 @@
                 }
             } +
             attributeIfContent("logMetrics", logMetrics) +
-            attributeIfTrue(
-                "version",
-                fixedCodeVersion,
-                {
-                    "Id" : versionOutputId,
-                    "ResourceId" : versionId,
-                    "Type" : AWS_LAMBDA_VERSION_RESOURCE_TYPE
-                }
-            ) +
+            fixedCodeVersion +
             attributeIfTrue(
                 "securityGroup",
                 solution.VPCAccess,
@@ -95,17 +135,7 @@
             ),
             "Attributes" : {
                 "REGION" : region,
-                "ARN" : valueIfTrue(
-                            getExistingReference(versionOutputId),
-                            fixedCodeVersion
-                            formatArn(
-                                getRegionObject().Partition,
-                                "lambda",
-                                region,
-                                accountObject.ProviderId,
-                                "function:" + core.FullName,
-                                true)
-                ),
+                "ARN" : arn,
                 "NAME" : core.FullName,
                 "DEPLOYMENT_TYPE": solution.DeploymentType
             },

--- a/aws/services/lambda/id.ftl
+++ b/aws/services/lambda/id.ftl
@@ -32,6 +32,13 @@
     resource=AWS_LAMBDA_VERSION_RESOURCE_TYPE
 /]
 
+[#assign AWS_LAMBDA_ALIAS_RESOURCE_TYPE = "lambdaAlias" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_LAMBDA_SERVICE
+    resource=AWS_LAMBDA_ALIAS_RESOURCE_TYPE
+/]
+
 [#function formatLambdaPermissionId occurrence extensions...]
     [#return formatResourceId(
                 AWS_LAMBDA_PERMISSION_RESOURCE_TYPE,

--- a/aws/services/lambda/resource.ftl
+++ b/aws/services/lambda/resource.ftl
@@ -31,6 +31,20 @@
         },
         ARN_ATTRIBUTE_TYPE : {
             "UseRef" : true
+        },
+        VERSION_ATTRIBUTE_TYPE : {
+            "Attribute" : "Version"
+        }
+    }
+]
+
+[#assign LAMBDA_ALIAS_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        ARN_ATTRIBUTE_TYPE : {
+            "UseRef" : true
         }
     }
 ]
@@ -54,6 +68,8 @@
 [#assign lambdaMappings =
     {
         AWS_LAMBDA_FUNCTION_RESOURCE_TYPE : LAMBDA_FUNCTION_OUTPUT_MAPPINGS,
+        AWS_LAMBDA_VERSION_RESOURCE_TYPE : LAMBDA_VERSION_OUTPUT_MAPPINGS,
+        AWS_LAMBDA_ALIAS_RESOURCE_TYPE : LAMBDA_ALIAS_OUTPUT_MAPPINGS,
         AWS_LAMBDA_PERMISSION_RESOURCE_TYPE : LAMBDA_PERMISSION_OUTPUT_MAPPINGS,
         AWS_LAMBDA_EVENT_SOURCE_TYPE : LAMBDA_EVENT_SOURCE_MAPPINGS
     }
@@ -170,6 +186,43 @@
                 }
             )
         outputs=LAMBDA_VERSION_OUTPUT_MAPPINGS
+        outputId=outputId
+        dependencies=dependencies
+        updateReplacePolicy=updateReplacePolicy
+        deletionPolicy=deletionPolicy
+    /]
+[/#macro]
+
+[#macro createLambdaAlias id name
+            functionId
+            targetId
+            description=""
+            dependencies=""
+            outputId=""
+            deletionPolicy=""
+            updateReplacePolicy=""
+            provisionedExecutions=-1 ]
+    [@cfResource
+        id=id
+        type="AWS::Lambda::Alias"
+        properties=
+            {
+                "Name" : name,
+                "FunctionName" : getReference(functionId),
+                "FunctionVersion" : getReference(targetId, VERSION_ATTRIBUTE_TYPE)
+            } +
+            attributeIfContent(
+                "Description",
+                description
+            ) +
+            attributeIfTrue(
+                "ProvisionedConcurrencyConfig",
+                provisionedExecutions >= 1,
+                {
+                    "ProvisionedConcurrentExecutions" : provisionedExecutions
+                }
+            )
+        outputs=LAMBDA_ALIAS_OUTPUT_MAPPINGS
         outputId=outputId
         dependencies=dependencies
         updateReplacePolicy=updateReplacePolicy


### PR DESCRIPTION

## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
When deploying a fixed lambda version, provide the option of a lambda alias to avoid the need to update references when a new version of the lambda is created.

Provisioning is also applied to the alias if configured in order that it moves to the latest version of the lambda.

## Motivation and Context
- simplify deployment sequencing and dependency management

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- https://github.com/hamlet-io/engine/pull/2015
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

