### PR TITLE
refactor(ecs): lg pass handling

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -643,7 +643,8 @@
     [#local ecsASGCapacityProviderId = parentResources["ecsASGCapacityProvider"].Id]
     [#local essASGCapacityProviderAssociationId = parentResources["ecsCapacityProviderAssociation"].Id ]
 
-    [#if ! (getExistingReference(ecsId)?has_content) ]
+    [#if deploymentSubsetRequired("ecs", true) &&
+        (! (getExistingReference(ecsId)?has_content)) ]
         [@fatal
             message="ECS Cluster not deployed or active"
             context={
@@ -718,7 +719,9 @@
 
         [#-- Provides warning for hosting updates this will still deploy but using fixed launch type --]
         [#-- Only use capacity providers when the assocation is in place --]
-        [#if ( engine == "ec2") && ( ! (getExistingReference(essASGCapacityProviderAssociationId)?has_content)) ]
+        [#if deploymentSubsetRequired("ecs", true) &&
+            ( engine == "ec2") &&
+            ( ! (getExistingReference(essASGCapacityProviderAssociationId)?has_content)) ]
             [#local useCapacityProvider = false ]
             [@warn
                 message="Could not find ECS Capacity provider for Ec2 - Update the solution ecs component"
@@ -824,7 +827,7 @@
                             [#local networkLinks += [ container.Name ] ]
                         [#else]
                             [@fatal
-                                message="Network links only avaialble on bridge mode and ec2 engine"
+                                message="Network links only available on bridge mode and ec2 engine"
                                 context=
                                     {
                                         "Description" : "Container links are only available in bridge mode and ec2 engine",
@@ -980,7 +983,7 @@
                                     [/#if]
 
                                     [#if serviceRecordTypes?seq_contains("A") && networkMode != "awsvpc" ]
-                                        [@fatal message="A record registration only availalbe on awsvpc network Type" context=link /]
+                                        [@fatal message="A record registration only available on awsvpc network Type" context=link /]
                                     [/#if]
 
                                     [#if serviceRecordTypes?seq_contains("AAAA") ]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Permit the lg pass to proceed regardless of whether the ecs cluster has been deployed or not.

## Motivation and Context
At present, the lg pass will fail is the ECS cluster hasn't already been created. In complicated dependency 
scenarios such as those involving log consolidation, it is necessary to run the application lg 
pass before the ECS cluster has been created.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

