### PR TITLE
fix(lambda): size checking

### DIFF
--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -300,21 +300,24 @@
 
     [#local _context += finalEnvironment ]
 
-    [#-- AWS has a 4k limit on the size of the environment - check how close we are --]
-    [#local envSize = getJSON(finalEnvironment)?length]
-    [#local sizeRemedy = "One solution might be to limit the attributes included on links via the IncludeInContext attribute" ]
-    [#-- Not clear what AWS counts in the 4k limit but this should be close --]
-    [#if envSize > 4096]
-        [@fatal
-            message="Lambda environment size of " + envSize?c + " exceeds the AWS limit of 4096"
-            detail=sizeRemedy
-        /]
-    [#-- It is a bit arbitrary as to what defines close --]
-    [#elseif envSize > 3896]
-        [@warn
-            message="Lambda environment size of " + envSize?c + " is close to the AWS limit of 4096"
-            detail=sizeRemedy
-        /]
+    [#if deploymentSubsetRequired("lambda", true) ]
+        [#-- AWS has a 4k limit on the size of the environment - check how close we are --]
+        [#local envSize = getJSON(finalEnvironment)?length]
+
+        [#local sizeRemedy = "One solution might be to limit the attributes included on links via the IncludeInContext attribute" ]
+        [#-- Not clear what AWS counts in the 4k limit but this should be close --]
+        [#if envSize > 4096]
+            [@fatal
+                message="Lambda environment size of " + envSize?c + " exceeds the AWS limit of 4096"
+                detail=sizeRemedy
+            /]
+        [#-- It is a bit arbitrary as to what defines close --]
+        [#elseif envSize > 3896]
+            [@warn
+                message="Lambda environment size of " + envSize?c + " is close to the AWS limit of 4096"
+                detail=sizeRemedy
+            /]
+        [/#if]
     [/#if]
 
     [#local roleId = formatDependentRoleId(fnId)]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Only check environment size if generating the lambda specific templates - ignore for subsets.

## Motivation and Context
- better contextualise the size error 

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

