### PR TITLE
feat(cloudwatch): extra permissions functions

### DIFF
--- a/aws/services/cw/policy.ftl
+++ b/aws/services/cw/policy.ftl
@@ -34,6 +34,28 @@
     )]
 [/#function]
 
+[#function cwMetricsConsumePermission namespace="*"]
+    [#return
+        [
+            getPolicyStatement(
+                [
+                    "cloudwatch:GetMetricData"
+                ],
+                "*",
+                "",
+                (namespace != "*" )?then(
+                    {
+                        "StringEquals" : {
+                            "cloudwatch:namespace" : namespace
+                        }
+                    },
+                    {}
+                )
+            )
+        ]
+    ]
+[/#function]
+
 
 [#function cwLogsProducePermission logGroupName="" ]
     [#return cwLogsPolicy(
@@ -67,6 +89,13 @@
                 )
             )
         ]
+    ]
+[/#function]
+
+[#function cwMetricsAllPermission namespace="*"]
+    [#return
+        cwLogsProducePermission(namespace) +
+        cwLogsConsumePermission(namespace)
     ]
 [/#function]
 


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add functions to provide "consume" and "all" permissions on cloudwatch metrics.

## Motivation and Context
- address common usage scenarios

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

