### PR TITLE
feat(runbook): add push_image runbook for images

### DIFF
--- a/aws/modules/baseline/module.ftl
+++ b/aws/modules/baseline/module.ftl
@@ -240,6 +240,296 @@
                                     }
                                 }
                             }
+                        },
+                        "baseline_push-image": {
+                            "Type": "runbook",
+                            "Engine": "hamlet",
+                            "Inputs" : {
+                                "ImagePath" : {
+                                    "Description" : "Path to the image to push",
+                                    "Types" : [ "string" ]
+                                },
+                                "DockerImage": {
+                                    "Description" : "Local docker iamge to push",
+                                    "Types" : [ "string" ]
+                                },
+                                "Reference" : {
+                                    "Description" : "Unique reference for this image",
+                                    "Types" : [ "string" ],
+                                    "Mandatory" : true
+                                },
+                                "Tag" : {
+                                    "Description" : "A human friednly tag to apply to the image",
+                                    "Types" : [ "string" ],
+                                    "Default" : ""
+                                },
+                                "Tier" : {
+                                    "Description" : "Tier id of the component to assign the image to",
+                                    "Types" : [ "string" ],
+                                    "Mandatory" : true
+                                },
+                                "Component" : {
+                                    "Description" : "Component id of the component to assign the image to",
+                                    "Types" : [ "string" ],
+                                    "Mandatory" : true
+                                },
+                                "Instance" : {
+                                    "Description" : "Instance Id of the component to assign the image to",
+                                    "Types" : [ "string" ],
+                                    "Default" : ""
+                                },
+                                "Instance" : {
+                                    "Description" : "Instance Id of the component to assign the image to",
+                                    "Types" : [ "string" ],
+                                    "Default" : ""
+                                }
+                            },
+                            "Steps" : {
+                                "aws_login" : {
+                                    "Priority" : 5,
+                                    "Extensions" : [ "_runbook_get_provider_id" ],
+                                    "Task" : {
+                                        "Type" : "set_provider_credentials",
+                                        "Parameters" : {
+                                            "AccountId" : {
+                                                "Value" : "__setting:ACCOUNT__"
+                                            }
+                                        }
+                                    }
+                                },
+                                "zip_stage_path" : {
+                                    "Priority" : 40,
+                                    "Extensions" : [
+                                        "_runbook_registry_type_condition"
+                                    ],
+                                    "Conditions" : {
+                                        "registry_type" : {
+                                            "Value": "s3",
+                                            "Match": "Equals"
+                                        }
+                                    },
+                                    "Task" : {
+                                        "Type" : "file_temp_directory",
+                                        "Parameters" : {}
+                                    },
+                                    "Links" : {
+                                        "image" : {
+                                            "Tier": "__input:Tier__",
+                                            "Component": "__input:Component__",
+                                            "Instance": "__input:Instance__",
+                                            "Version": "__input:Version__"
+                                        }
+                                    }
+                                },
+                                "zip_path" : {
+                                    "Priority": 50,
+                                    "Extensions" : [
+                                        "_runbook_registry_type_condition",
+                                        "_runbook_registry_object_filename"
+                                    ],
+                                    "Conditions" : {
+                                        "registry_type" : {
+                                            "Value": "s3",
+                                            "Match": "Equals"
+                                        }
+                                    },
+                                    "Task" : {
+                                        "Type" : "file_zip_path",
+                                        "Parameters" : {
+                                            "SourcePath" : {
+                                                "Value": "__input:ImagePath__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "image" : {
+                                            "Tier": "__input:Tier__",
+                                            "Component": "__input:Component__",
+                                            "Instance": "__input:Instance__",
+                                            "Version": "__input:Version__"
+                                        }
+                                    }
+                                },
+                                "registry_s3_push" : {
+                                    "Priority" : 100,
+                                    "Extensions" : [
+                                        "_runbook_get_region",
+                                        "_runbook_registry_destination_object",
+                                        "_runbook_registry_type_condition"
+                                    ],
+                                    "Conditions" : {
+                                        "registry_type" : {
+                                            "Value": "s3",
+                                            "Match": "Equals"
+                                        }
+                                    },
+                                    "Task" : {
+                                        "Type": "aws_s3_upload_object",
+                                        "Parameters" : {
+                                            "BucketName" : {
+                                                "Value" : "__context:Environment.IMAGE_REGISTRY_BUCKET_NAME__"
+                                            },
+                                            "LocalPath" : {
+                                                "Value" : "__output:zip_path:destination_path__"
+                                            },
+                                            "AWSAccessKeyId" : {
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Value" : "__output:aws_login:aws_session_token__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "image" : {
+                                            "Tier": "__input:Tier__",
+                                            "Component": "__input:Component__",
+                                            "Instance": "__input:Instance__",
+                                            "Version": "__input:Version__"
+                                        }
+                                    }
+                                },
+                                "registry_ecr_login" : {
+                                    "Priority" : 50,
+                                    "Conditions" : {
+                                        "registry_type" : {
+                                            "Value": "docker",
+                                            "Match": "Equals"
+                                        }
+                                    },
+                                    "Extensions" : [
+                                        "_runbook_get_region",
+                                        "_runbook_get_provider_id",
+                                        "_runbook_registry_type_condition"
+                                    ],
+                                    "Task" : {
+                                        "Type": "aws_ecr_docker_login",
+                                        "Parameters" : {
+                                            "AWSAccessKeyId" : {
+                                                "Value" : "__output:aws_login:aws_access_key_id__"
+                                            },
+                                            "AWSSecretAccessKey" : {
+                                                "Value" : "__output:aws_login:aws_secret_access_key__"
+                                            },
+                                            "AWSSessionToken" : {
+                                                "Value" : "__output:aws_login:aws_session_token__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "image" : {
+                                            "Tier": "__input:Tier__",
+                                            "Component": "__input:Component__",
+                                            "Instance": "__input:Instance__",
+                                            "Version": "__input:Version__"
+                                        }
+                                    }
+                                },
+                                "registry_docker_push" : {
+                                    "Priority" : 100,
+                                    "Conditions" : {
+                                        "registry_type" : {
+                                            "Value": "docker",
+                                            "Match": "Equals"
+                                        }
+                                    },
+                                    "Extensions" : [
+                                        "_runbook_registry_type_condition"
+                                        "_runbook_registry_destination_image"
+                                    ],
+                                    "Task" : {
+                                        "Type": "docker_push_image",
+                                        "Parameters" : {
+                                            "SourceImage" : {
+                                                "Value" : "__input:DockerImage__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "image" : {
+                                            "Tier": "__input:Tier__",
+                                            "Component": "__input:Component__",
+                                            "Instance": "__input:Instance__",
+                                            "Version": "__input:Version__"
+                                        }
+                                    }
+                                },
+                                "registry_docker_push_tag" : {
+                                    "Priority" : 100,
+                                    "Conditions" : {
+                                        "registry_type" : {
+                                            "Value": "docker",
+                                            "Match": "Equals"
+                                        },
+                                        "tag_image" :{
+                                            "Value": "",
+                                            "Match": "NotEquals",
+                                            "Test": "__input:Tag__"
+                                        }
+                                    },
+                                    "Extensions" : [
+                                        "_runbook_registry_type_condition"
+                                        "_runbook_registry_destination_image_tag"
+                                    ],
+                                    "Task" : {
+                                        "Type": "docker_push_image",
+                                        "Parameters" : {
+                                            "SourceImage" : {
+                                                "Value" : "__input:DockerImage__"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "image" : {
+                                            "Tier": "__input:Tier__",
+                                            "Component": "__input:Component__",
+                                            "Instance": "__input:Instance__",
+                                            "Version": "__input:Version__"
+                                        }
+                                    }
+                                },
+                                "cmdb_write_reference" : {
+                                    "Priority" : 200,
+                                    "Extensions" : [
+                                        "_runbook_image_reference_output",
+                                        "_runbook_district_context"
+                                    ],
+                                    "Task": {
+                                        "Type" : "cmdb_write_stack_output"
+                                    },
+                                    "Links" : {
+                                        "image" : {
+                                            "Tier": "__input:Tier__",
+                                            "Component": "__input:Component__",
+                                            "Instance": "__input:Instance__",
+                                            "Version": "__input:Version__"
+                                        }
+                                    }
+                                },
+                                "output_result" : {
+                                    "Priority" : 900,
+                                    "Extensions" : [ "_runbook_image_push_result" ],
+                                    "Task" : {
+                                        "Type" : "output_echo",
+                                        "Parameters" : {
+                                            "Format" : {
+                                                "Value" : "json"
+                                            }
+                                        }
+                                    },
+                                    "Links" : {
+                                        "image" : {
+                                            "Tier": "__input:Tier__",
+                                            "Component": "__input:Component__",
+                                            "Instance": "__input:Instance__",
+                                            "Version": "__input:Version__"
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a baseline runbook used to push images to a registry

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This runbook supports pushing images from a local source to a defined image. The runbook supports providing a set of link parameters along with the source image details and references and the image will be pushed to the registry


## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

