### PR TITLE
fix(waf): support v1 -> v2 migrations

### DIFF
--- a/aws/components/apigateway/state.ftl
+++ b/aws/components/apigateway/state.ftl
@@ -271,13 +271,13 @@ created in either case.
         [#local wafResources =
             {
                 "acl" : {
-                    "Id" : formatDependentWAFAclId(apiId),
-                    "Arn": (solution.WAF.Version == "v2")?then({ "Fn::GetAtt" : [ formatDependentWAFAclId(apiId), "Arn" ] }, ""),
+                    "Id" : formatDependentWAFAclId(solution.WAF.Version, apiId),
+                    "Arn": (solution.WAF.Version == "v2")?then({ "Fn::GetAtt" : [ formatDependentWAFAclId(solution.WAF.Version, apiId), "Arn" ] }, ""),
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
                     "Type" : AWS_WAF_ACL_RESOURCE_TYPE
                 },
                 "association" : {
-                    "Id" : formatDependentWAFAclAssociationId(apiId),
+                    "Id" : formatDependentWAFAclAssociationId(solution.WAF.Version, apiId),
                     "Type" : AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE
                 }
             } ]

--- a/aws/components/cdn/state.ftl
+++ b/aws/components/cdn/state.ftl
@@ -43,8 +43,8 @@
                     "Type" : AWS_CLOUDFRONT_DISTRIBUTION_RESOURCE_TYPE
                 },
                 "wafacl" : {
-                    "Id" : formatDependentWAFAclId(cfId),
-                    "Arn": (solution.WAF.Version == "v2")?then({ "Fn::GetAtt" : [ formatDependentWAFAclId(cfId), "Arn" ] }, ""),
+                    "Id" : formatDependentWAFAclId(solution.WAF.Version, cfId),
+                    "Arn": (solution.WAF.Version == "v2")?then({ "Fn::GetAtt" : [ formatDependentWAFAclId(solution.WAF.Version, cfId), "Arn" ] }, ""),
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
                     "Type" : AWS_WAF_ACL_RESOURCE_TYPE
                 }

--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -68,13 +68,13 @@
         [#local wafResources =
             {
                 "acl" : {
-                    "Id" : formatDependentWAFAclId(id),
-                    "Arn": (solution.WAF.Version == "v2")?then({ "Fn::GetAtt" : [ formatDependentWAFAclId(id), "Arn" ] }, ""),
+                    "Id" : formatDependentWAFAclId(solution.WAF.Version, id),
+                    "Arn": (solution.WAF.Version == "v2")?then({ "Fn::GetAtt" : [ formatDependentWAFAclId(solution.WAF.Version, id), "Arn" ] }, ""),
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
                     "Type" : AWS_WAF_ACL_RESOURCE_TYPE
                 },
                 "association" : {
-                    "Id" : formatDependentWAFAclAssociationId(id),
+                    "Id" : formatDependentWAFAclAssociationId(solution.WAF.Version, id),
                     "Type" : AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE
                 }
             } ]

--- a/aws/services/waf/id.ftl
+++ b/aws/services/waf/id.ftl
@@ -7,89 +7,70 @@
 [#-- reousrce type definitions will be needed here but for now --]
 [#-- AWs hasn't defined any of interest                        --]
 [#assign AWS_WAF_RULE_RESOURCE_TYPE = "wafRule" ]
-[@addServiceResource
-    provider=AWS_PROVIDER
-    service=AWS_WEB_APPLICATION_FIREWALL_SERVICE
-    resource=AWS_WAF_RULE_RESOURCE_TYPE
-/]
 [#assign AWS_WAF_ACL_RESOURCE_TYPE = "wafAcl" ]
-[@addServiceResource
-    provider=AWS_PROVIDER
-    service=AWS_WEB_APPLICATION_FIREWALL_SERVICE
-    resource=AWS_WAF_ACL_RESOURCE_TYPE
-/]
 [#assign AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE = "wafAssoc" ]
-[@addServiceResource
-    provider=AWS_PROVIDER
-    service=AWS_WEB_APPLICATION_FIREWALL_SERVICE
-    resource=AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE
-/]
-
-[#-- TODO(mfl): Deprecate direct creation of IPSet rule --]
 [#assign AWS_WAF_IPSET_RESOURCE_TYPE = "wafIpSet" ]
-[#function formatWAFIPSetId group regional=false ]
-    [#return regional?then(
-            formatAccountResourceId(
-                AWS_WAF_IPSET_RESOURCE_TYPE,
-                group),
-            formatAccountResourceId(
-                AWS_WAF_IPSET_RESOURCE_TYPE,
-                group))
-    ]
-[/#function]
-[#function formatWAFIPSetRuleId group]
-    [#return formatDependentWAFRuleId(
-                formatWAFIPSetId(group))]
-[/#function]
 
-[#function formatWAFConditionId type ids...]
-    [#return formatResourceId(
-                "waf" + type,
-                ids)]
-[/#function]
+[#assign AWS_WAFV2_RULE_RESOURCE_TYPE = "wafv2Rule" ]
+[#assign AWS_WAFV2_ACL_RESOURCE_TYPE = "wafv2Acl" ]
+[#assign AWS_WAFV2_ACL_ASSOCIATION_RESOURCE_TYPE = "wafv2Assoc" ]
+[#assign AWS_WAFV2_IPSET_RESOURCE_TYPE = "wafv2IpSet" ]
 
-[#function formatDependentWAFConditionId type resourceId extensions...]
+[#list [
+    AWS_WAF_RULE_RESOURCE_TYPE,
+    AWS_WAF_ACL_RESOURCE_TYPE,
+    AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE,
+    AWS_WAF_IPSET_RESOURCE_TYPE,
+    AWS_WAFV2_RULE_RESOURCE_TYPE,
+    AWS_WAFV2_ACL_RESOURCE_TYPE,
+    AWS_WAFV2_ACL_ASSOCIATION_RESOURCE_TYPE,
+    AWS_WAFV2_IPSET_RESOURCE_TYPE ] as resource]
+
+    [@addServiceResource
+        provider=AWS_PROVIDER
+        service=AWS_WEB_APPLICATION_FIREWALL_SERVICE
+        resource=resource
+    /]
+[/#list]
+
+
+[#function formatDependentWAFConditionId version type resourceId extensions...]
     [#return formatDependentResourceId(
-                "waf" + type,
-                resourceId,
-                extensions)]
+        (version == "v2")?then(
+            "wafv2",
+            "waf"
+        ) + type,
+        resourceId,
+        extensions)]
 [/#function]
 
-[#function formatWAFRuleId ids...]
-    [#return formatResourceId(
-                AWS_WAF_RULE_RESOURCE_TYPE,
-                ids)]
-[/#function]
-
-[#function formatDependentWAFRuleId resourceId extensions...]
+[#function formatDependentWAFRuleId version resourceId extensions...]
     [#return formatDependentResourceId(
-                AWS_WAF_RULE_RESOURCE_TYPE,
-                resourceId,
-                extensions)]
+            (version == "v2")?then(
+                AWS_WAFV2_RULE_RESOURCE_TYPE,
+                AWS_WAF_RULE_RESOURCE_TYPE
+            ),
+            resourceId,
+            extensions)]
 [/#function]
 
-[#function formatWAFAclId ids...]
-    [#return formatResourceId(
-                AWS_WAF_ACL_RESOURCE_TYPE,
-                ids)]
-[/#function]
-
-[#function formatDependentWAFAclId resourceId extensions...]
+[#function formatDependentWAFAclId version resourceId extensions...]
     [#return formatDependentResourceId(
-                AWS_WAF_ACL_RESOURCE_TYPE,
-                resourceId,
-                extensions)]
+            (version == "v2")?then(
+                AWS_WAFV2_ACL_RESOURCE_TYPE,
+                AWS_WAF_ACL_RESOURCE_TYPE
+            ),
+            resourceId,
+            extensions)]
 [/#function]
 
-[#function formatWAFAclAssociationId ids...]
-    [#return formatResourceId(
-                AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE,
-                ids)]
-[/#function]
-
-[#function formatDependentWAFAclAssociationId resourceId extensions...]
+[#function formatDependentWAFAclAssociationId version resourceId extensions...]
     [#return formatDependentResourceId(
-                AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE,
-                resourceId,
-                extensions)]
+        (version == "v2")?then(
+            AWS_WAFV2_ACL_ASSOCIATION_RESOURCE_TYPE,
+            AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE
+        ),
+        resourceId,
+        extensions
+    )]
 [/#function]

--- a/aws/services/waf/resource.ftl
+++ b/aws/services/waf/resource.ftl
@@ -116,11 +116,8 @@
                         }}] ]
                 [#break]
                 [#case AWS_WAF_IP_MATCH_CONDITION_TYPE]
-                    [#--local result += formatWAFIPMatchTuples(filter, valueSet, version) 
-                        Also assumes that only one condition of IPAddressGroups is valid
-                    --]
                     [#local v2WkStatement += [ { "IPSetReferenceStatement": {
-                        "Arn": { "Fn::GetAtt" : [ formatDependentWAFConditionId(condition.Type, id, "c1"), "Arn" ] }
+                        "Arn": { "Fn::GetAtt" : [ formatDependentWAFConditionId("v2", condition.Type, id, "c1"), "Arn" ] }
                         }}] ]
                 [#break]
                 [#default]
@@ -294,7 +291,7 @@
         [#local conditionName = condition.Name!conditionId]
         [#-- Generate id/name from rule equivalents if not provided --]
         [#if !conditionId?has_content]
-            [#local conditionId = formatDependentWAFConditionId(condition.Type, id, "c" + condition?counter?c)]
+            [#local conditionId = formatDependentWAFConditionId(version, condition.Type, id, "c" + condition?counter?c)]
         [/#if]
         [#if !conditionName?has_content]
             [#local conditionName = formatName(name,"c" + condition?counter?c,condition.Type)]
@@ -368,7 +365,7 @@
             [#-- Rule to be created with the acl --]
             [#-- Generate id/name/metric from acl equivalents if not provided --]
             [#if !ruleId?has_content]
-                [#local ruleId = formatDependentWAFRuleId(id,"r" + rule?counter?c)]
+                [#local ruleId = formatDependentWAFRuleId(version, id,"r" + rule?counter?c)]
             [/#if]
             [#if !ruleName?has_content]
                 [#local ruleName = formatName(name,"r" + rule?counter?c,rule.NameSuffix!"")]
@@ -417,7 +414,7 @@
                                 "Statement" : v2Statement,
                                 "VisibilityConfig" : {
                                     "CloudWatchMetricsEnabled" : true,
-                                    "MetricName" : ruleMetric,
+                                    "MetricName" : ruleName,
                                     "SampledRequestsEnabled" : true
                                 }
                             }
@@ -456,7 +453,7 @@
                     "Scope": regional?then("REGIONAL","CLOUDFRONT"),
                     "VisibilityConfig" : {
                         "CloudWatchMetricsEnabled" : true,
-                        "MetricName" : metric?replace("-","X"),
+                        "MetricName" : ruleName,
                         "SampledRequestsEnabled" : true
                     }
                 }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Includes the v2 version in WAF resource Ids to allow for CFN to perform migrations of WAF resources when the resource type changes

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When updating an existing deployment to use WAF v2 instead of WAF classic CloudFormation couldn't change the Type of a resource with the same Id. This would result in the deployment failing and meant that you had to do a stopstart deployment to perform the migration

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

