### PR TITLE
refactor!: remove use of segmentObject

### DIFF
--- a/aws/components/network/state.ftl
+++ b/aws/components/network/state.ftl
@@ -32,8 +32,7 @@
 
     [#local subnets = {} ]
     [#-- Define subnets --]
-    [#list segmentObject.Network.Tiers.Order as tierId]
-        [#local networkTier = getTier(tierId) ]
+    [#list getTiers()?filter(x -> x.Network.Enabled && x.Active ) as networkTier]
         [#if ! (networkTier?has_content && networkTier.Network.Enabled &&
                     networkTier.Network.Link.Tier == core.Tier.Id && networkTier.Network.Link.Component == core.Component.Id &&
                     (networkTier.Network.Link.Version!core.Version.Id) == core.Version.Id && (networkTier.Network.Link.Instance!core.Instance.Id) == core.Instance.Id  ) ]
@@ -48,7 +47,7 @@
                                     formatSubnetName(networkTier, zone),
                                     formatName(core.FullName, networkTier.Name, zone.Name))]
 
-            [#local subnetIndex = ( tierId?index * network.Zones.Order?size ) + zone?index]
+            [#local subnetIndex = ( networkTier.Index * network.Zones.Order?size ) + zone?index]
             [#local subnetCIDR = subnetCIDRS[subnetIndex]]
             [#local subnets =  mergeObjects( subnets, {
                 networkTier.Id  : {
@@ -208,12 +207,7 @@
         [#local legacyIGWRouteId = formatRouteId(routeTableId, "gateway") ]
     [/#if]
 
-    [#list segmentObject.Network.Tiers.Order as tierId]
-        [#local networkTier = getTier(tierId) ]
-        [#if ! (networkTier?has_content && networkTier.Network.Enabled ) ]
-            [#continue]
-        [/#if]
-
+    [#list getTiers()?filter(x -> x.Active && x.Network.Enabled ) as networkTier]
         [#list getZones() as zone]
             [#local zoneRouteTableId = formatId(routeTableId, zone.Id)]
             [#local zoneRouteTableName = formatName(routeTableName, zone.Id)]

--- a/aws/components/network/state.ftl
+++ b/aws/components/network/state.ftl
@@ -38,6 +38,11 @@
                     (networkTier.Network.Link.Version!core.Version.Id) == core.Version.Id && (networkTier.Network.Link.Instance!core.Instance.Id) == core.Instance.Id  ) ]
             [#continue]
         [/#if]
+
+        [#if ! (networkTier.Index)?is_number ]
+            [#continue]
+        [/#if]
+
         [#list getZones() as zone]
             [#local subnetId = legacyVpc?then(
                                     formatSubnetId(networkTier, zone),

--- a/aws/services/iam/policy.ftl
+++ b/aws/services/iam/policy.ftl
@@ -55,17 +55,6 @@
             ),
             permissions.AppData,
             []
-        ) +
-        valueIfTrue(
-            s3AllPermission(baselineIds["AppData"], getAppDataPublicFilePrefix(occurrence)) +
-            s3EncryptionAllPermission(
-                baselineIds["Encryption"],
-                getExistingReference(baselineIds["AppData"], NAME_ATTRIBUTE_TYPE),
-                getAppDataPublicFilePrefix(occurrence),
-                getExistingReference(baselineIds["AppData"], REGION_ATTRIBUTE_TYPE)
-            ),
-            permissions.AppPublic && getAppDataPublicFilePrefix(occurrence)?has_content,
-            []
         )
     ]
 [/#function]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Moves to using the more generic getTiers methods which supports occurrences in different district types
- Removes the use of the AppPublicDataPrefix - This has been removed from the engine to reduce the complexity in managing these different prefixes and is also considered a security risk. This was removed from the core engine to save having to migrate the segment level configuration required to use the public data prefix in the first place.

The preference for public data would be to use an explicitly defined S3 bucket for this particular purpose. It makes it easier to understand from a user perspective and reduces panic reporting when a core S3 bucket has some limited public access

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Aligns with the change in the engine to support occurrence based deployments across multiple district types instead of just the segment base districts

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/1968

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

