### PR TITLE
feat: queue topic permission extensions

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -970,7 +970,7 @@
                     [#if getExistingReference(listenerId)?has_content && ! getExistingReference(listenerRuleId)?has_content ]
                         [#local ruleCleanupScript += [
                                 "cleanup_elbv2_rules" +
-                                "       \"" + region + "\" " +
+                                "       \"" + getRegion() + "\" " +
                                 "       \"" + getExistingReference(listenerId, ARN_ATTRIBUTE_TYPE) + "\" "
                             ]]
                     [/#if]

--- a/aws/components/sqs/setup.ftl
+++ b/aws/components/sqs/setup.ftl
@@ -153,7 +153,21 @@
             [/#list]
         [/#list]
 
-        [#list solution.Links as linkId,link]
+
+        [#local contextLinks = getLinkTargets(occurrence) ]
+        [#local _context =
+            {
+                "Links" : contextLinks,
+                "Policy" : []
+            }
+        ]
+        [#local _context = invokeExtensions( occurrence, _context )]
+
+        [#if _context.Policy?has_content ]
+            [#local queuePolicyStatements += _context.Policy /]
+        [/#if]
+
+        [#list _context.Links as linkId,link]
 
             [#local linkTarget = getLinkTarget(occurrence, link) ]
 

--- a/aws/components/sqs/setup.ftl
+++ b/aws/components/sqs/setup.ftl
@@ -167,9 +167,7 @@
             [#local queuePolicyStatements += _context.Policy /]
         [/#if]
 
-        [#list _context.Links as linkId,link]
-
-            [#local linkTarget = getLinkTarget(occurrence, link) ]
+        [#list _context.Links as linkId,linkTarget]
 
             [@debug message="Link Target" context=linkTarget enabled=false /]
 

--- a/aws/components/topic/setup.ftl
+++ b/aws/components/topic/setup.ftl
@@ -67,7 +67,20 @@
 
         [#local topicPolicyStatements = []]
 
-        [#list solution.Links as linkId,link]
+        [#local contextLinks = getLinkTargets(occurrence) ]
+        [#local _context =
+            {
+                "Links" : contextLinks,
+                "Policy" : []
+            }
+        ]
+        [#local _context = invokeExtensions( occurrence, _context )]
+
+        [#if _context.Policy?has_content ]
+            [#local topicPolicyStatements += _context.Policy /]
+        [/#if]
+
+        [#list _context.Links as linkId,link]
 
             [#local linkTarget = getLinkTarget(occurrence, link) ]
 

--- a/aws/components/topic/setup.ftl
+++ b/aws/components/topic/setup.ftl
@@ -80,9 +80,7 @@
             [#local topicPolicyStatements += _context.Policy /]
         [/#if]
 
-        [#list _context.Links as linkId,link]
-
-            [#local linkTarget = getLinkTarget(occurrence, link) ]
+        [#list _context.Links as linkId,linkTarget]
 
             [@debug message="Link Target" context=linkTarget enabled=false /]
 

--- a/awstest/modules/lb/module.ftl
+++ b/awstest/modules/lb/module.ftl
@@ -624,7 +624,8 @@
                 "Account" : "0123456789",
                 "Region" : "mock-region-1",
                 "DeploymentUnit" : "aws-lb",
-                "lbXelbXnlbalbXalb" : "lbXelbXnlbalbXalb"
+                "lbXelbXnlbalbXalb" : "lbXelbXnlbalbXalb",
+                "listenerXelbXnlbalbXalbXhttp": "listenerXelbXnlbalbXalbXhttp"
             }
         ]
     /]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Allow for extending queue and topic policies through extensions
- Fixes testing for the lb component to ensure that the lb port is considered deployed. This was changed recently to only treat a target enabled if the actual port has been deployed. 
- Fixes an issue in the Lb component which was attempting to access a global variable instead of using the helper function

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Useful for integrating with services that require a specific policy applied or need to add additional security policies around how the resource can be used

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

