### PR TITLE
fix(computetask): windows directory creation

### DIFF
--- a/aws/extensions/computetask_awswin_cfninit_asg/extension.ftl
+++ b/aws/extensions/computetask_awswin_cfninit_asg/extension.ftl
@@ -36,9 +36,9 @@
             "# 'Create logging dir for cfninit scripts' ;",
             "Start-Transcript -Path c:\\ProgramData\\Hamlet\\Logs\\user-data.log -Append ;",
             "echo 'Create staging dirs for cfninit scripts' ;",
-            "mkdir c:\\ProgramData\\Hamlet\\Scripts ;",
-            "mkdir c:\\Temp ;",
-            "mkdir c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent ;",
+            "New-Item -Type Directory -Force c:\\ProgramData\\Hamlet\\Scripts ;",
+            "New-Item -Type Directory -Force c:\\Temp ;",
+            "New-Item -Type Directory -Force c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent ;",
             "echo 'Remainder of configuration via metadata' ;",
             {
                 "Fn::Sub" : [

--- a/aws/extensions/computetask_awswin_cfninit_wait/extension.ftl
+++ b/aws/extensions/computetask_awswin_cfninit_wait/extension.ftl
@@ -46,9 +46,9 @@
             "# 'Create logging dir for cfninit scripts' ;",
             "Start-Transcript -Path c:\\ProgramData\\Hamlet\\Logs\\user-data.log -Append ;",
             "echo 'Create staging dirs for cfninit scripts' ;",
-            "mkdir c:\\ProgramData\\Hamlet\\Scripts ;",
-            "mkdir c:\\Temp ;",
-            "mkdir c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent ;",
+            "New-Item -Type Directory -Force c:\\ProgramData\\Hamlet\\Scripts ;",
+            "New-Item -Type Directory -Force c:\\Temp ;",
+            "New-Item -Type Directory -Force c:\\ProgramData\\Amazon\\AmazonCloudWatchAgent ;",
             "echo 'Remainder of configuration via metadata' ;",
             {
                 "Fn::Sub" : [

--- a/aws/extensions/computetask_awswin_hamletenv/extension.ftl
+++ b/aws/extensions/computetask_awswin_hamletenv/extension.ftl
@@ -67,19 +67,6 @@
         engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
         content={
                 "files" : {
-                    "c:\\ProgramData\\Hamlet\\Scripts\\set_dirs.ps1" : {
-                        "content" : {
-                            "Fn::Join" : [
-                                "\n",
-                                [
-                                    "Start-Transcript -Path c:\\ProgramData\\Hamlet\\Logs\\user-step.log -Append ;",
-                                    r'echo "Directory and File Creation - set_dirs.ps1" ;'
-                                    r"mkdir c:\ProgramData\Hamlet\Logs\codeontap"
-                                ]
-                            ]
-                        },
-                        "mode" : "000755"
-                    },
                     "c:\\ProgramData\\Hamlet\\Scripts\\set_env.ps1" : {
                         "content" : {
                             "Fn::Join" : [
@@ -105,11 +92,7 @@
                     }
                 },
                 "commands": {
-                    "01Directories" : {
-                        "command" : "powershell.exe -ExecutionPolicy Bypass -Command c:\\ProgramData\\Hamlet\\Scripts\\set_dirs.ps1",
-                        "ignoreErrors" : false
-                    },
-                    "02SetEnv" : {
+                    "01SetEnv" : {
                         "command" : "powershell.exe -ExecutionPolicy Bypass -Command c:\\ProgramData\\Hamlet\\Scripts\\source_env.ps1",
                         "ignoreErrors" : false
                     }

--- a/aws/extensions/computetask_awswin_scriptsdeployment/extension.ftl
+++ b/aws/extensions/computetask_awswin_scriptsdeployment/extension.ftl
@@ -35,7 +35,7 @@
                             "Fn::Join" : [
                                 "\n",
                                 [
-                                    r'mkdir c:\ProgramData\Hamlet\Scripts ;',
+                                    r'New-Item -Type Directory -Force c:\ProgramData\Hamlet\Scripts ;',
                                     r'Set-Location -Path "C:\Program Files\Amazon\AWSCLIV2" ;',
                                     {
                                         "Fn::Sub" : [


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Use the powershell new-item command with -Force to handle re-running the cfn-init commands without failure
- Removes the initial directory setup script for windows as it only creates one directory that we no longer need

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Noticed during re-runs of cfn-init commands that the directory creation was raising errors. This uses force to create the directory which will handle the existing directory. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

