### PR TITLE
fix(lb): protocol checks for nlb

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -383,9 +383,9 @@
         [#switch engine ]
             [#case "network" ]
 
-                [#if ! ["UDP", "TCP"]?seq_contains(sourcePort.Protocol)]
+                [#if ! ["UDP", "TCP", "SSL"]?seq_contains(sourcePort.Protocol)]
                     [@fatal
-                        message="Invalid source port protocol - supports TCP or UDP Protocols"
+                        message="Invalid source port protocol - supports TCP or UDP or SSL Protocols"
                         context={
                             "lb": occurrence.Core.RawId,
                             "lbport": subOccurrence.Core.RawId,
@@ -409,19 +409,6 @@
                     /]
                 [/#if]
 
-                [#if ["aws:alb"]?seq_contains(solution.Forward.TargetType) &&
-                        ! ["TCP"]?seq_contains(destinationPort.Protocol) ]
-
-                    [@fatal
-                        message="Invalid destination port protocol - supports HTTP or HTTPS Protocols"
-                        context={
-                            "lb": occurrence.Core.RawId,
-                            "lbport": subOccurrence.Core.RawId,
-                            "TargetType": solution.Forward.TargetType,
-                            "Protocol": destinationPort.Protocol
-                        }
-                    /]
-                [/#if]
                 [#break]
 
             [#case "application" ]
@@ -440,6 +427,20 @@
 
                 [#if ["instance", "ip"]?seq_contains(solution.Forward.TargetType) &&
                         ! ["HTTP", "HTTPS"]?seq_contains(destinationPort.Protocol) ]
+
+                    [@fatal
+                        message="Invalid destination port protocol - supports HTTP or HTTPS Protocols"
+                        context={
+                            "lb": occurrence.Core.RawId,
+                            "lbport": subOccurrence.Core.RawId,
+                            "TargetType": solution.Forward.TargetType,
+                            "Protocol": destinationPort.Protocol
+                        }
+                    /]
+                [/#if]
+
+                [#if ["aws:alb"]?seq_contains(solution.Forward.TargetType) &&
+                        ! ["TCP"]?seq_contains(destinationPort.Protocol) ]
 
                     [@fatal
                         message="Invalid destination port protocol - supports HTTP or HTTPS Protocols"


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Allow for the SSL protocol to be used for network load balancers
- Move the lambda check to ALB only

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When using the SSL offload service on NLB template generation would fail to complete

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

