### PR TITLE
fix(lambda): check deployment units on function

### DIFF
--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -2,7 +2,11 @@
 [#macro aws_lambda_cf_deployment_generationcontract_application occurrence ]
 
     [#local converters = []]
-    [#list (occurrence.Occurrences![])?filter(x -> x.Configuration.Solution.Enabled ) as subOccurrence]
+    [#list (requiredOccurrences(
+                occurrence.Occurrences![],
+                getCLODeploymentUnit(),
+                getDeploymentGroup())
+            ) as subOccurrence]
         [#if subOccurrence.Configuration.Solution.Environment.FileFormat == "yaml" ]
             [#local converters = [ { "subset" : "config", "converter" : "config_yaml" }]]
         [/#if]
@@ -14,7 +18,11 @@
 [#macro aws_lambda_cf_deployment_application occurrence ]
     [@debug message="Entering" context=occurrence enabled=false /]
 
-    [#list (occurrence.Occurrences![])?filter(x -> x.Configuration.Solution.Enabled ) as fn]
+    [#list (requiredOccurrences(
+                occurrence.Occurrences![],
+                getCLODeploymentUnit(),
+                getDeploymentGroup())
+            ) as fn]
         [@internalProcessFunction fn /]
     [/#list]
 [/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Use the requiredOccurrences function to filter lambda functions when using different deployment:Unit for the subcomponent functions

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
issue when using multiple deployment:Unit values across the functions under a component. This would cause all of the funcitons to be be included in all deployments

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

