### PR TITLE
fix(cw): update permissions for cw logs to kinesis

### DIFF
--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -107,7 +107,10 @@
                             logFilterId=logwatcher.LogFilter
                             destination=streamId
                             role=streamSubscriptionRoleId
-                            dependencies=streamId
+                            dependencies=[
+                                streamId,
+                                streamSubscriptionPolicyId
+                            ]
                         /]
                     [/#if]
                 [/#if]

--- a/aws/services/cw/resource.ftl
+++ b/aws/services/cw/resource.ftl
@@ -154,6 +154,7 @@
 
             [#local roleRequired = false]
             [#local forwardingRoleId = formatDependentRoleId(logGroupId, linkTarget.Core.Id ) ]
+            [#local forwardingRolePolicyId = formatDependentPolicyId(logGroupId, linkTarget.Core.Id )]
 
             [#if ((linkTargetRoles.Outbound["logwatcher"].Policy)!{})?has_content ]
 
@@ -196,7 +197,7 @@
                     /]
 
                     [@createPolicy
-                        id=formatDependentPolicyId(logGroupId, linkTarget.Core.Id )
+                        id=forwardingRolePolicyId
                         name="log-forwarding"
                         statements=linkTargetRoles.Outbound["logwatcher"].Policy +
                                     iamPassRolePermission(
@@ -218,7 +219,11 @@
                                 forwardingRoleId,
                                 ""
                         )
-                        dependencies=dependencies
+                        dependencies=dependencies +
+                            roleRequired?then(
+                                [forwardingRolePolicyId],
+                                []
+                            )
                     /]
             [/#if]
     [/#if]

--- a/aws/services/kinesis/policy.ftl
+++ b/aws/services/kinesis/policy.ftl
@@ -19,10 +19,9 @@
         [
             getPolicyStatement(
                 [
-                    "firehose:DeleteDeliveryStream",
-                    "firehose:PutRecord",
-                    "firehose:PutRecordBatch",
-                    "firehose:UpdateDestination"
+                    [#-- Full permissions required based on AWS documentation --]
+                    [#-- https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html#FirehoseExample --]
+                    "firehose:*"
                 ],
                 getArn(id)
             )


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds dependency on the policy for creating the log subscription to ensure that test messages work ok
- Update policy to a broader permissions set on kinesis as advised by AWS support and their doco

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
IT looks like AWS has made some changes to how the log subscription process behaves which now causes a log subscription deployment to fail if the test message can't get through. After an AWS support case it looks like broader permissions are required to get this going. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and on user deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

