### PR TITLE
fix(ecs): skip lb processing when no lb port

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -840,8 +840,14 @@
                     [#list container.PortMappings![] as portMapping]
                         [#if portMapping.LoadBalancer?has_content]
                             [#local loadBalancer = portMapping.LoadBalancer]
+
+                            [#if ! container.Links[loadBalancer.Link]??]
+                                [#continue]
+                            [/#if]
+
                             [#local link = container.Links[loadBalancer.Link] ]
                             [@debug message="Link" context=link enabled=false /]
+
                             [#local linkCore = link.Core ]
                             [#local linkResources = link.State.Resources ]
                             [#local linkConfiguration = link.Configuration.Solution ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Add a skip when the lb port component can not be found

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Template generation would fail when a port can't be found

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

