### PR TITLE
fix: dynamic value setup for aws secrets

### DIFF
--- a/aws/dynamicvalues/aws_secret/dynamicvalue.ftl
+++ b/aws/dynamicvalues/aws_secret/dynamicvalue.ftl
@@ -45,10 +45,10 @@
                     "Component"  : sources.occurrence.Core.Component.RawId,
                     "LinkId" : properties.linkId,
                     "Links" : sources.occurrence.Configuration.Solution.Links,
-                    "LinkType" : (linkTarget.Core.Type)!""
+                    "LinkType" : (linkTarget.Core.Type)!"",
+                    "DynamicValue" : value
                 }
             /]
-            [#return ""]
         [/#if]
 
         [#local version = (properties.version == "LATEST")?then("", properties.version)]
@@ -65,5 +65,4 @@
             ]
         }]
     [/#if]
-    [#return "__${vaule}__"]
 [/#function]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- removes the defaulting behaviour for when a secret dynamic evaluation hasn't worked

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Align with the changes to dynamic values in https://github.com/hamlet-io/engine/pull/2042 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/2042

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

