### PR TITLE
fix(ecs): handle container tagging for ecs version

### DIFF
--- a/aws/services/ecs/resource.ftl
+++ b/aws/services/ecs/resource.ftl
@@ -1081,8 +1081,26 @@
         ]
 
         [#if container.Image.Source == "containerregistry" ]
-            [#local _context += { "Image" : container.Image["Source:containerregistry"].Image }]
-            [@debug message="SourceImage" context=container.Image["Source:containerregistry"].Image enabled=true /]
+            [#local imageName = container.Image["Source:containerregistry"].Image]
+            [#if imageName?contains("/")]
+                [#local imageName = imageName?keep_after_last("/")]
+            [/#if]
+            [#if imageName?contains(":")]
+                [#local imageTag = imageName?keep_after_last(":") ]
+            [#else]
+                [#local imageTag = ""]
+            [/#if]
+
+            [#local _context += {
+                "Image" : (container.Image['Source:containerregistry'].Image)?remove_ending(":${imageTag}")
+            } +
+            (imageTag?has_content && ! ((container.ImageVersion)!"")?has_content)?then(
+                {
+                    "ImageVersion" : imageTag
+                },
+                {}
+            )]
+            [@debug message="SourceImage" context={"Image": _context.Image, "ImageVersion": _context.ImageVersion} enabled=true /]
         [/#if]
 
         [#local linkIngressRules = [] ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- when using the containerregistry image type and a tag is included the tag is currently being stripped from the image name
- This sets the imageVersion if its not provided when using the registry

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Ensures that the correct tag is used for container deployments 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

