### PR TITLE
feat(datacatalog): aws implemetation using Glue

### DIFF
--- a/aws/components/datacatalog/id.ftl
+++ b/aws/components/datacatalog/id.ftl
@@ -1,0 +1,24 @@
+[#ftl]
+
+[@addResourceGroupInformation
+    type=DATACATALOG_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_GLUE_SERVICE
+        ]
+/]
+
+[@addResourceGroupInformation
+    type=DATACATALOG_TABLE_COMPONENT_TYPE
+    attributes=[]
+    provider=AWS_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AWS_GLUE_SERVICE,
+            AWS_IDENTITY_SERVICE
+        ]
+/]

--- a/aws/components/datacatalog/setup.ftl
+++ b/aws/components/datacatalog/setup.ftl
@@ -104,7 +104,7 @@
         [/#list]
 
         [#local serDeParams = {}]
-        [#list solution.Format.SerDe.Parameters as k,v ]
+        [#list solution.Format.Serialisation.Parameters as k,v ]
             [#if v.Enabled ]
                 [#local serDeParams = mergeObjects(
                     serDeParams,
@@ -147,7 +147,7 @@
                     solution.Format.Output,
                     {},
                     {},
-                    solution.Format.SerDe.Library,
+                    solution.Format.Serialisation.Library,
                     "",
                     serDeParams
                 )]

--- a/aws/components/datacatalog/setup.ftl
+++ b/aws/components/datacatalog/setup.ftl
@@ -1,0 +1,239 @@
+[#ftl]
+
+[#macro aws_datacatalog_cf_deployment_generationcontract occurrence ]
+    [@addDefaultGenerationContract subsets=["template"] /]
+[/#macro]
+
+[#macro aws_datacatalog_cf_deployment occurrence ]
+    [@debug message="Entering" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core ]
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local resources = occurrence.State.Resources ]
+
+    [#local database = resources["database"]]
+
+    [@createAWSGlueDatabase
+        id=database.Id
+        name=database.Name
+        description=(solution.Description)!""
+    /]
+
+    [#list (occurrence.Occurrences![])?filter(
+            x -> x.Configuration.Solution.Enabled
+            && x.Core.Type == DATACATALOG_TABLE_COMPONENT_TYPE ) as subOccurrence]
+
+        [#local core = subOccurrence.Core ]
+        [#local solution = subOccurrence.Configuration.Solution ]
+        [#local resources = subOccurrence.State.Resources ]
+
+        [#local baselineLinks = getBaselineLinks(subOccurrence, [ "Encryption" ] )]
+        [#local baselineComponentIds = getBaselineComponentIds(baselineLinks)]
+
+        [#local table = resources["table"]]
+
+        [#local locationPath = ""]
+        [#local source = getLinkTarget(occurrence, solution.Source.Link )]
+
+        [#if source?has_content ]
+            [#switch source.Core.Type ]
+                [#case S3_COMPONENT_TYPE ]
+                [#case BASELINE_DATA_COMPONENT_TYPE ]
+                    [#local locationPath = formatRelativePath(
+                        "s3://${source.State.Attributes.NAME}",
+                        solution.Source.Prefix
+                    )]
+                    [#break]
+
+                [#default]
+                    [@fatal
+                        message="Unsupported source type"
+                        context={
+                            "Id" : subOccurrence.Core.Id,
+                            "Name" : subOccurrence.Core.FullRawName,
+                            "SourceType" : source.Core.Type,
+                            "Source" : solution.Source.Link
+                        }
+                    /]
+            [/#switch]
+        [/#if]
+
+        [#local partitionKeys = []]
+        [#list solution.Layout.Partitioning as k,v ]
+            [#if v.Enabled]
+                [#local partitionKeys = combineEntities(
+                    partitionKeys,
+                    [
+                        getAWSGlueTableColumn(
+                            (v.Name)!k,
+                            v.Type,
+                            v.Description
+                        )
+                    ]
+                )]
+            [/#if]
+        [/#list]
+
+        [#local tableColumns = []]
+        [#list solution.Layout.Columns as k,v ]
+            [#if v.Enabled]
+                [#local tableColumns = combineEntities(
+                    tableColumns,
+                    [
+                        getAWSGlueTableColumn(
+                            (v.Name)!k,
+                            v.Type,
+                            v.Description
+                        )
+                    ],
+                    UNIQUE_COMBINE_BEHAVIOUR
+                )]
+            [/#if]
+        [/#list]
+
+        [#local tableParams = {}]
+        [#list solution.Parameters as k,v]
+            [#if v.Enabled ]
+                [#local tableParams = mergeObjects(
+                    tableParams,
+                    {
+                        (v.Key)!k: v.Value
+                    }
+                )]
+            [/#if]
+        [/#list]
+
+        [#local serDeParams = {}]
+        [#list solution.Format.SerDe.Parameters as k,v ]
+            [#if v.Enabled ]
+                [#local serDeParams = mergeObjects(
+                    serDeParams,
+                    {
+                        (v.Key)!k: v.Value
+                    }
+                )]
+            [/#if]
+        [/#list]
+
+        [#local contextLinks = getLinkTargets(subOccurrence) ]
+        [#local _context =
+            {
+                "DefaultEnvironment" : defaultEnvironment(subOccurrence, contextLinks, baselineLinks),
+                "Environment" : {},
+                "Links" : contextLinks,
+                "BaselineLinks" : baselineLinks,
+                "DefaultCoreVariables" : false,
+                "DefaultEnvironmentVariables" : false,
+                "DefaultLinkVariables" : false,
+                "DefaultBaselineVariables" : false,
+                "Policy" : [],
+                "ManagedPolicy" : [],
+                "SourceLink": source,
+                "PartitionKeys": partitionKeys,
+                "TableColumns" : tableColumns,
+                "LocationPath" : locationPath
+            }
+        ]
+        [#local _context = invokeExtensions(subOccurrence, _context )]
+
+        [#local tableStorageDescriptor =
+                getAWSGlueTableStorageDescriptor(
+                    [],
+                    _context.TableColumns,
+                    solution.Source.DecompressData
+                    solution.Format.Input,
+                    _context.LocationPath,
+                    0,
+                    solution.Format.Output,
+                    {},
+                    {},
+                    solution.Format.SerDe.Library,
+                    "",
+                    serDeParams
+                )]
+
+        [@createAWSGlueTable
+            id=table.Id
+            name=table.Name
+            databaseId=database.Id
+            partitionKeys=_context.PartitionKeys
+            storageDescriptor=tableStorageDescriptor
+            parameters=tableParams
+        /]
+
+        [#if solution.Crawler.Enabled ]
+            [#local crawler = resources["crawler"]]
+            [#local crawlerRole = resources["crawlerRole"]]
+            [#local policySet = {} ]
+
+            [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
+                [#-- Gather the set of applicable policies --]
+                [#-- Any permissions added via extensions --]
+                [#local policySet =
+                    addInlinePolicyToSet(
+                        policySet,
+                        formatDependentPolicyId(crawlerRole.Id),
+                        _context.Name,
+                        _context.Policy
+                    )
+                ]
+
+                [#local policySet =
+                    addInlinePolicyToSet(
+                        policySet,
+                        formatDependentPolicyId(crawlerRole.Id, "source"),
+                        "source",
+                        getLinkTargetsOutboundRoles(source)
+                    )]
+
+                [#-- Ensure we don't blow any limits as far as possible --]
+                [#local policySet = adjustPolicySetForRole(policySet) ]
+
+                [#-- Create any required managed policies --]
+                [#-- They may result when policies are split to keep below AWS limits --]
+                [@createCustomerManagedPoliciesFromSet policies=policySet /]
+
+                [#-- Create a role under which the function will run and attach required policies --]
+                [#-- The role is mandatory though there may be no policies attached to it --]
+                [@createRole
+                    id=crawlerRole.Id
+                    trustedServices=[
+                        "glue.amazonaws.com"
+                    ]
+                    managedArns=getManagedPoliciesFromSet(policySet)
+                    tags=getOccurrenceTags(subOccurrence)
+                /]
+
+                [#-- Create any inline policies that attach to the role --]
+                [@createInlinePoliciesFromSet policies=policySet roles=crawlerRole.Id /]
+            [/#if]
+
+            [#local targets = {
+                "CatalogTargets" : [
+                    getAWSGlueCrawlerTarget(
+                        "catalog",
+                        "",
+                        database.Id,
+                        [ table.Id ]
+                    )
+                ]
+            }]
+
+            [@createAWSGlueCrawler
+                id=cralwer.Id
+                name=crawler.Name
+                roleId=crawlerRole.Id
+                targets=targets
+                description=(solution.Description)!""
+                crawlerSecurityConfigurationId=""
+                glueDatabaseId=database.Id
+                recrawlBehaviour=solution.Crawler.RecrawlingPolicy
+                scheduleExpression=solution.Crawler.Schedule
+                schemaChangeDeleteBehaviour=solution.Crawler.SchemaChanges.Delete
+                schemaChangeUpdateBehaviour=solution.Crawler.SchemaChanges.Update
+                tags=getOccurrenceTags(subOccurrence)
+            /]
+        [/#if]
+
+    [/#list]
+[/#macro]

--- a/aws/components/datacatalog/state.ftl
+++ b/aws/components/datacatalog/state.ftl
@@ -1,0 +1,66 @@
+[#ftl]
+
+[#macro aws_datacatalog_cf_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local databaseId = formatResourceId(AWS_GLUE_DATABASE_RESOURCE_TYPE, core.Id)]
+
+    [#assign componentState =
+        {
+            "Resources" : {
+                "database" : {
+                    "Id" : databaseId,
+                    "Name" : replaceAlphaNumericOnly(core.RawFullName, "_"),
+                    "Type" : AWS_GLUE_DATABASE_RESOURCE_TYPE
+                }
+            },
+            "Attributes" : {
+                "NAME" : getExistingReference(databaseId)
+            }
+        }
+    ]
+
+[/#macro]
+
+
+[#macro aws_datacatalogtable_cf_state occurrence parent={} ]
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#local tableId = formatResourceId(AWS_GLUE_TABLE_RESOURCE_TYPE, core.Id)]
+
+    [#local resources = {
+        "table": {
+            "Id" : tableId,
+            "Name": core.SubComponent.RawName,
+            "Type" : AWS_GLUE_TABLE_RESOURCE_TYPE
+        }
+    }]
+
+    [#if solution.Crawler.Enabled ]
+        [#local resources = mergeObjects(
+            resources,
+            {
+                "crawler" : {
+                    "Id" : formatResourceId(AWS_GLUE_CRAWLER_RESOURCE_TYPE, core.Id),
+                    "Name": core.RawFullName,
+                    "Type": AWS_GLUE_CRAWLER_RESOURCE_TYPE
+                },
+                "crawlerRole": {
+                    "Id": formatResourceId(AWS_IAM_RESOURCE_ROLE_TYPE, core.Id, "crawler"),
+                    "Type" : AWS_IAM_ROLE_RESOURCE_TYPE
+                }
+            }
+        )]
+    [/#if]
+
+    [#assign componentState =
+        {
+            "Resources" : resources,
+            "Attributes" : {
+                "NAME": getExistingReference(tableId)
+            }
+        }
+    ]
+[/#macro]

--- a/aws/services/glue/id.ftl
+++ b/aws/services/glue/id.ftl
@@ -1,0 +1,30 @@
+[#ftl]
+
+[#-- Resources --]
+[#assign AWS_GLUE_DATABASE_RESOURCE_TYPE = "gluedatabase" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_GLUE_SERVICE
+    resource=AWS_GLUE_DATABASE_RESOURCE_TYPE
+/]
+
+[#assign AWS_GLUE_TABLE_RESOURCE_TYPE = "gluetable" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_GLUE_SERVICE
+    resource=AWS_GLUE_TABLE_RESOURCE_TYPE
+/]
+
+[#assign AWS_GLUE_CRAWLER_RESOURCE_TYPE = "gluecrawler" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_GLUE_SERVICE
+    resource=AWS_GLUE_CRAWLER_RESOURCE_TYPE
+/]
+
+[#assign AWS_GLUE_CONNECTION_RESOURCE_TYPE = "glueconnection" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_GLUE_SERVICE
+    resource=AWS_GLUE_CONNECTION_RESOURCE_TYPE
+/]

--- a/aws/services/glue/resource.ftl
+++ b/aws/services/glue/resource.ftl
@@ -1,0 +1,584 @@
+[#ftl]
+
+[#assign AWS_GLUE_DATABASE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_GLUE_DATABASE_RESOURCE_TYPE
+    mappings=AWS_GLUE_DATABASE_OUTPUT_MAPPINGS
+/]
+
+[#assign AWS_GLUE_TABLE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_GLUE_TABLE_RESOURCE_TYPE
+    mappings=AWS_GLUE_TABLE_OUTPUT_MAPPINGS
+/]
+
+[#assign AWS_GLUE_CRAWLER_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_GLUE_CRAWLER_RESOURCE_TYPE
+    mappings=AWS_GLUE_CRAWLER_OUTPUT_MAPPINGS
+/]
+
+[#assign AWS_GLUE_CONNECTION_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        }
+    }
+]
+
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_GLUE_CONNECTION_RESOURCE_TYPE
+    mappings=AWS_GLUE_CONNECTION_OUTPUT_MAPPINGS
+/]
+
+[#-- Glue - Database --]
+[#macro createAWSGlueDatabase id name description="" locationUri="" parameters={} ]
+    [@cfResource
+        id=id
+        type="AWS::Glue::Database"
+        properties={
+            "CatalogId": {
+                "Ref" : "AWS::AccountId"
+            },
+            "DatabaseInput": {
+                "Name": name
+            } +
+            attributeIfContent(
+                "Parameters",
+                parameters
+            ) +
+            attributeIfContent(
+                "Description",
+                description
+            ) +
+            attributeIfContent(
+                "LocationUri",
+                locationUri
+            )
+        }
+        outputs=AWS_GLUE_DATABASE_OUTPUT_MAPPINGS
+    /]
+[/#macro]
+
+[#-- Glue - Table --]
+[#function getAWSGlueTableColumn name type="" comment="" ]
+    [#return
+        {
+            "Name": name
+        } +
+        attributeIfContent(
+            "Type",
+            type
+        ) +
+        attributeIfContent(
+            "Comment",
+            comment
+        )
+    ]
+[/#function]
+
+[#function getAWSGlueTableStorageDescriptor
+        bucketColumns=[]
+        columns=[]
+        compressed=false
+        inputFormat=""
+        location=""
+        numberOfBuckets=0
+        outputFormat=""
+        parameters={}
+        schemaReference={}
+        serdeSerializationLibrary=""
+        serdeName=""
+        serdeParameters={}
+        skewedInfo={}
+        sortColumns=[]
+        storedAsSubDirectories=false
+    ]
+
+    [#local serdeInfo = {} +
+        attributeIfContent(
+            "SerializationLibrary",
+            serdeSerializationLibrary
+        ) +
+        attributeIfContent(
+            "Name",
+            serdeName
+        ) +
+        attributeIfContent(
+            "Parameters",
+            serdeParameters
+        )
+    ]
+
+    [#return
+        {} +
+        attributeIfContent(
+            "BucketColumns",
+            bucketColumns
+        ) +
+        attributeIfContent(
+            "Columns",
+            columns
+        ) +
+        attributeIfTrue(
+            "Compressed",
+            compressed,
+            compressed
+        ) +
+        attributeIfContent(
+            "InputFormat",
+            inputFormat
+        ) +
+        attributeIfContent(
+            "Location",
+            location
+        ) +
+        attributeIfTrue(
+            "NumberOfBuckets",
+            numberOfBuckets > 0,
+            numberOfBuckets
+        ) +
+        attributeIfContent(
+            "OutputFormat",
+            outputFormat
+        ) +
+        attributeIfContent(
+            "Parameters",
+            parameters
+        ) +
+        attributeIfContent(
+            "SchemaReference",
+            schemaReference
+        ) +
+        attributeIfContent(
+            "SkewedInfo",
+            skewedInfo
+        ) +
+        attributeIfContent(
+            "SortColumns",
+            sortColumns
+        ) +
+        attributeIfTrue(
+            "StoredAsSubDirectories",
+            storedAsSubDirectories,
+            storedAsSubDirectories
+        ) +
+        attributeIfContent(
+            "SerdeInfo",
+            serdeInfo
+        )
+    ]
+
+[/#function]
+
+[#macro createAWSGlueTable
+        id
+        name
+        databaseId
+        parameters={}
+        partitionKeys=[]
+        retention=0
+        storageDescriptor={} ]
+
+    [@cfResource
+        id=id
+        type="AWS::Glue::Table"
+        properties={
+            "CatalogId": {
+                "Ref" : "AWS::AccountId"
+            },
+            "DatabaseName": getReference(databaseId),
+            "TableInput": {
+                "Name": name,
+                "TableType": "EXTERNAL_TABLE",
+                "PartitionKeys": partitionKeys
+            } +
+            attributeIfContent(
+                "Parameters",
+                parameters
+            ) +
+            attributeIfTrue(
+                "Retention",
+                retention > 0,
+                retention
+            ) +
+            attributeIfContent(
+                "StorageDescriptor",
+                storageDescriptor
+            )
+        }
+        outputs=AWS_GLUE_TABLE_OUTPUT_MAPPINGS
+    /]
+[/#macro]
+
+[#-- Glue - Crawler --]
+[#function getAWSGlueCrawlerConfiguration
+        combineCompatibleSchemas=true
+        tableLevel=0
+        tableThreshold=0 ]
+
+    [#local grouping = {} +
+        atrributeIfTrue(
+            "TableGroupingPolicy",
+            combineCompatibleSchemas,
+            "CombineCompatibleSchemas"
+        ) +
+        attributeIfTrue(
+            "TableLevelConfiguration",
+            (tableLevel > 0),
+            tableLevel
+        ) ]
+
+    [#local result = { } +
+        attributeIfContent(
+            "Grouping",
+            grouping
+        ) +
+        attributeIfTrue(
+            "CrawlerOutput",
+            (tableThreshold > 0),
+            {
+                "Tables": {
+                    "tableThreshold" : tableThreshold
+                }
+            }
+        )
+    ]
+
+    [#if result?has_content ]
+        [#local result = mergeObjects(
+            {
+                "Version": 1.0
+            },
+            result
+        )]
+    [/#if]
+    [#return result]
+[/#function]
+
+[#function getAWSGlueCrawlerTarget
+        type
+        glueConnectionId=""
+        catalogDatabaseId=""
+        catalogTableIds=[]
+        dynmodbTableId=""
+        jdbcExclusions=[]
+        jdbcPath=""
+        mongoPath=""
+        s3EventDlqId=""
+        s3EventQueueId=""
+        s3Path=""
+        s3SampleSize=0]
+
+    [#local result = {}]
+
+    [#switch type ]
+        [#case "catalog" ]
+            [#local result = {
+                "DatabaseName" : getReference(catalogId),
+                "Tables" : getReferences(catalogTableIds)
+            }]
+            [#break]
+
+        [#case "dynamodb"]
+            [#local result = {
+                "Path": getReference(dynmoDbTableId)
+            }]
+            [#break]
+
+        [#case "jdbc"]
+            [#local result = {
+                "ConnectionName": getReference(glueConnectionId)
+            } +
+            attributeIfContent(
+                "Exclusions",
+                jdbcExclusions
+            ) +
+            attributeIfContent(
+                "Path",
+                jdbcPath
+            ) ]
+            [#break]
+
+        [#case "mongodb"]
+            [#local result = {
+                "ConnectionName": getReference(glueConnectionId)
+            } +
+            attributeIfContent(
+                "Path",
+                mongoPath
+            ) ]
+            [#break]
+
+        [#case "s3"]
+            [#local result = {
+                "ConnectionName": getReference(glueConnectionId)
+            } +
+            attributeIfContent(
+                "DlqEventQueueArn",
+                getArn(s3EventDlqId)
+            ) +
+            attributeIfContent(
+                "EventQueueArn",
+                getArn(s3EventQueueId)
+            ) +
+            attributeIfContent(
+                "Path",
+                s3Path
+            ) +
+            attributeIfTrue(
+                "SampleSize",
+                s3SampleSize > 0,
+                s3SampleSize
+            )]
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Invalid glue crawler target type"
+                context={
+                    "Id": id,
+                    "Type": type
+                }
+            /]
+    [/#switch]
+    [#return result]
+[/#function]
+
+[#macro createAWSGlueCrawler
+            id
+            name
+            roleId
+            targets
+            description=""
+            classifiers=[]
+            cnfiguration={}
+            crawlerSecurityConfigurationId=""
+            glueDatabaseId=""
+            recrawlBehaviour=""
+            scheduleExpression=""
+            schemaChangeDeleteBehaviour=""
+            schemaChangeUpdateBehaviour=""
+            tablePrefix=""
+            tags={} ]
+
+    [#local recrawlBehavior = recrawlBehavior?upper_case ]
+    [#switch recrawlBehaviour]
+        [#case "CRAWL_EVERYTHING"]
+        [#case "EVERYTHING"]
+            [#local recrawlBehavior = "CRAWL_EVERYTHING" ]
+            [#break]
+        [#case "CRAWL_NEW_FOLDERS_ONLY"]
+        [#case "NEWONLY"]
+            [#local recrawlBehavior = "CRAWL_NEW_FOLDERS_ONLY" ]
+            [#break]
+        [#default]
+            [@fatal
+                message="Invalid glue cralwer recrawlBehavior"
+                context={
+                    "id": id,
+                    "recrawlBehaviour": recrawlBehaviour
+                }
+            /]
+    [/#switch]
+
+    [#local schemaChangeDeleteBehaviour = schemaChangeDeleteBehaviour?upper_case]
+    [#switch schemaChangeDeleteBehaviour]
+        [#case "LOG"]
+            [#break]
+
+        [#case "DELETE_FROM_DATABASE"]
+        [#case "DELETE"]
+            [#local schemaChangeDeleteBehaviour = "DELETE_FROM_DATABASE"]
+            [#break]
+
+        [#case "DEPRECATE_IN_DATABASE"]
+        [#case "DEPRECATE"]
+            [#local schemaChangeDeleteBehaviour = "DEPRECATE_IN_DATABASE"]
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Invalid glue cralwer schema change delete behaviour"
+                context={
+                    "id": id,
+                    "schemaChangeDeleteBehaviour": schemaChangeDeleteBehaviour
+                }
+            /]
+    [/#switch]
+
+    [#local schemaChangeUpdateBehaviour = schemaChangeUpdateBehaviour?upper_case]
+    [#switch schemaChangeUpdateBehaviour]
+        [#case "LOG"]
+            [#break]
+        [#case "UPDATE_IN_DATABASE"]
+        [#case "UPDATE"]
+            [#local schemaChangeUpdateBehaviour = "UPDATE_IN_DATABASE"]
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Invalid glue cralwer schema change update behaviour"
+                context={
+                    "id": id,
+                    "schemaChangeUpdateBehaviour": schemaChangeUpdateBehaviour
+                }
+            /]
+    [/#switch]
+
+    [#local schemaChangePolicy = {} +
+        attributeIfContent(
+            "UpdateBehavior",
+            schemaChangeUpdateBehaviour
+        )+
+        attributeIfContent(
+            "DeleteBehavior",
+            schemaChangeDeleteBehaviour
+        )]
+
+    [@cfResource
+        id=id
+        type="AWS::Glue::Crawler"
+        properties={
+            "Name": name,
+            "Role": getArn(roleId),
+            "Targets": targets
+        } +
+        attributeIfContent(
+            "Description",
+            description
+        ) +
+        attributeIfContent(
+            "Classifiers",
+            classifiers
+        ) +
+        attributeIfContent(
+            "Configuration",
+            cnfiguration
+        ) +
+        attributeIfContent(
+            "CrawlerSecurityConfiguration",
+            getReference(crawlerSecurityConfigurationId)
+        ) +
+        attributeIfContent(
+            "DatabaseName",
+            getReference(databaseId)
+        ) +
+        attributeIfContent(
+            "RecrawlPolicy",
+            recrawlBehaviour,
+            {
+                "RecrawlBehavior": recrawlBehavior
+            }
+        ) +
+        attributeIfContent(
+            "Schedule",
+            scheduleExpression,
+            {
+                "ScheduleExpression": scheduleExpression
+            }
+        ) +
+        attributeIfContent(
+            "SchemaChangePolicy",
+            schemaChangePolicy
+        ) +
+        attributeIfContent(
+            "TablePrefix",
+            tablePrefix
+        )
+        tags=tags
+        outputs=AWS_GLUE_CRAWLER_OUTPUT_MAPPINGS
+    /]
+[/#macro]
+
+[#-- Glue - Connection --]
+[#macro createAWSGlueConnection
+        id
+        name
+        description
+        connectionType
+        connectionProperties={}
+        matchCriteria=[]
+        subnetId=""
+        availabilityZone=""
+        securityGroupIds=[] ]
+
+    [#local connectionType = connectionType?upper_case]
+    [#switch connectionType ]
+        [#case "JDBC"]
+        [#case "KAFKA"]
+        [#case "MONGODB"]
+        [#case "NETWORK"]
+            [#break]
+
+        [#default]
+            [@fatal
+                message="Invalid glue connection type"
+                context={
+                    "Id": id,
+                    "ConnectionType": connectionType
+                }
+            /]
+    [/#switch]
+
+    [@cfResource
+        id=id
+        type="AWS::Glue::Connection"
+        properties={
+            "CatalogId": {
+                "Ref" : "AWS::AccountId"
+            },
+            "ConnectionInput": {
+                "Name": name,
+                "ConnectionType": connectionType
+            } +
+            attributeIfContent(
+                "ConnectionProperties",
+                connectionProperties
+            ) +
+            attributeIfContent(
+                "Description",
+                description
+            ) +
+            attributeIfContent(
+                "MatchCriteria",
+                matchCriteria
+            ) +
+            attributeIfContent(
+                "PhysicalConnectionRequirements",
+                subnetId,
+                {
+                    "SubnetId": subnetId,
+                    "SecurityGroupIdList": getReferences(securityGroupIds),
+                    "AvailabilityZone": availabilityZone
+                }
+            )
+        }
+        outputs=AWS_GLUE_CONNECTION_OUTPUT_MAPPINGS
+    /]
+[/#macro]

--- a/aws/services/service.ftl
+++ b/aws/services/service.ftl
@@ -73,6 +73,9 @@
 [#assign AWS_FSX_SERVICE = "fsx" ]
 [@addService provider=AWS_PROVIDER service=AWS_FSX_SERVICE /]
 
+[#assign AWS_GLUE_SERVICE = "glue" ]
+[@addService provider=AWS_PROVIDER service=AWS_GLUE_SERVICE /]
+
 [#assign AWS_TRANSFER_SERVICE = "transfer" ]
 [@addService provider=AWS_PROVIDER service=AWS_TRANSFER_SERVICE /]
 

--- a/awstest/inputseeders/awstest/id.ftl
+++ b/awstest/inputseeders/awstest/id.ftl
@@ -109,6 +109,10 @@
                                 "Provider" : "awstest",
                                 "Name" : "correspondent"
                             },
+                            "datacatalog" : {
+                                "Provider" : "awstest",
+                                "Name" : "datacatalog"
+                            },
                             "datafeed" : {
                                 "Provider" : "awstest",
                                 "Name" : "datafeed"

--- a/awstest/modules/datacatalog/module.ftl
+++ b/awstest/modules/datacatalog/module.ftl
@@ -42,7 +42,7 @@
                                     "Format": {
                                         "Input": "org.apache.hadoop.mapred.TextInputFormat",
                                         "Output": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
-                                        "SerDe": {
+                                        "Serialisation": {
                                             "Library": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
                                         }
                                     }

--- a/awstest/modules/datacatalog/module.ftl
+++ b/awstest/modules/datacatalog/module.ftl
@@ -1,0 +1,102 @@
+[#ftl]
+
+[@addModule
+    name="datacatalog"
+    description="Testing module for the aws datacatalog component"
+    provider=AWSTEST_PROVIDER
+    properties=[]
+/]
+
+[#macro awstest_module_datacatalog ]
+
+    [#-- Data Stream Source --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "datacatalogbase": {
+                            "Type" : "datacatalog",
+                            "deployment:Unit": "aws-datacatalog",
+                            "Profiles" : {
+                                "Testing" : [ "datacatalogbase" ]
+                            },
+                            "Tables" : {
+                                "base" : {
+                                    "Source" : {
+                                        "Link" : {
+                                            "Tier": "app",
+                                            "Component": "datacatalogbase-s3"
+                                        }
+                                    },
+                                    "Layout": {
+                                        "Columns": {
+                                            "date": {
+                                                "Type": "date"
+                                            },
+                                            "size": {
+                                                "Type": "bigint"
+                                            }
+                                        }
+                                    },
+                                    "Format": {
+                                        "Input": "org.apache.hadoop.mapred.TextInputFormat",
+                                        "Output": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                                        "SerDe": {
+                                            "Library": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "datacatalogbase-s3":{
+                            "Type": "s3",
+                            "deployment:Unit": "aws-datacatalog"
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "datacatalogbase" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "Firehose" : {
+                                    "Name" : "gluedatabaseXappXdatacatalogbase",
+                                    "Type" : "AWS::Glue::Database"
+                                },
+                                "Stream" : {
+                                    "Name" : "gluetableXappXdatacatalogbaseXbase",
+                                    "Type" : "AWS::Glue::Table"
+                                }
+                            },
+                            "Output" : [
+                                "gluedatabaseXappXdatacatalogbase"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "EnsureSubComponentNameUsed" : {
+                                    "Path"  : "Resources.gluetableXappXdatacatalogbaseXbase.Properties.TableInput.Name",
+                                    "Value" : "base"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "datacatalogbase" : {
+                    "datacatalog" : {
+                        "TestCases" : [ "datacatalogbase" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
+                    }
+                }
+            }
+        }
+    /]
+
+[/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for creating datacatalogs using AWS Glue
- Creates resources for the key Glue services for dealing with catalogues
    - Database - A collection of tables
    - Table - A column based data structure
    - Crawler - A service to automatically crawl data for a table
    - Connector - A connection to a service that requires extra config

The formatting and layout use a relatively loose schema from hamlet perspective as there are quite a few config options available for both of these options which are best left to the user.

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
AWS Glue is now used to define and control the databases you can search for in Athena, Being able to discover and create tables for Athena makes it easy to query data stored in S3

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with test suite

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/2049

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

