### PR TITLE
feat(cw): ensure lambda is deleted with canary

### DIFF
--- a/aws/services/cw/resource.ftl
+++ b/aws/services/cw/resource.ftl
@@ -648,6 +648,7 @@
     s3Key=""
     script=""
     vpcEnabled=false
+    deleteLambdaOnDelete=true
     securityGroupIds=[]
     subnets=[]
     vpcId=""
@@ -660,6 +661,7 @@
         properties={
             "Name" : name,
             "ArtifactS3Location" : artifactS3Url,
+            "DeleteLambdaResourcesOnCanaryDeletion": deleteLambdaOnDelete,
             "Code" : {
                 "Handler" : handler
             } +


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a default option to delete lambda functions when a CloudWatch canary that created it is deleted

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This was added into CloudFormation after the initial support for Canary monitors was added, its useful to have and we didn't have other cleanup logic that would interfere.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

