### PR TITLE
fix(windows): logContent setup for windows logging

### DIFF
--- a/aws/extensions/computetask_awswin_cwlog/extension.ftl
+++ b/aws/extensions/computetask_awswin_cwlog/extension.ftl
@@ -45,6 +45,11 @@
         }
     ]]
 
+    [#local logContent = [
+        "[general]",
+        ""
+    ]]
+
     [#list ((logFileProfile.LogFileGroups)![])?map(
                 x -> (getReferenceData(LOGFILEGROUP_REFERENCE_TYPE)[x])!{}
             ) as logFileGroup ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Fixes a missing variable declaration when setting up the cloudwatch agent for windows

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
template generation was failing when deploying a base windows machine using the aws_win deployment profile

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

