### PR TITLE
fix(network): handle missing subnet lookup

### DIFF
--- a/aws/components/network/state.ftl
+++ b/aws/components/network/state.ftl
@@ -43,7 +43,11 @@
                ) ]
             [@fatal
                 message="Incomplete Network attribute configuration for " + networkTier.Name + " tier"
-                context=networkTier
+                context={
+                    "NetworkName": occurrence.Core.RawFullName,
+                    "Tier": networkTier.Name,
+                    "Network" : networkTier.Network
+                }
                 detail="Link, RouteTable and NetworkACL attribute values must be provided. If no network is required, set the Enabled attribute to false (it is true by default)."
             /]
             [#continue]
@@ -71,7 +75,8 @@
                                     formatName(core.FullName, networkTier.Name, zone.Name))]
 
             [#local subnetIndex = ( networkTier.Index * network.Zones.Order?size ) + zone?index]
-            [#local subnetCIDR = subnetCIDRS[subnetIndex]]
+
+            [#local subnetCIDR = (subnetCIDRS[subnetIndex])!"HamletFatal: Could not allocate subnet for ${networkTier.Id}/${zone.Id}" ]
             [#local subnets =  mergeObjects( subnets, {
                 networkTier.Id  : {
                     zone.Id : {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Add a fall back when a subnet can not be determined
- Updates the error message when network configuration is missing to prevent console buffers from being overloaded.

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allow for other exceptions during the network processing to be exposed. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

