### PR TITLE
fix(s3): oai permissions

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -73,7 +73,6 @@
             [#local bucketName = subResources["bucket"].Name ]
             [#local bucketPolicyId = subResources["bucketpolicy"].Id ]
             [#local legacyS3 = subResources["bucket"].LegacyS3 ]
-            [#local links = getLinkTargets(subOccurrence)]
             [#local versioningEnabled = (subSolution.Replication!{})?has_content?then(true, subSolution.Versioning)]
 
             [#local replicationRoleId = subResources["role"].Id]
@@ -83,7 +82,7 @@
             [#local replicationDestinationAccountId = "" ]
             [#local replicationExternalPolicy = []]
 
-            [#local contextLinks = getLinkTargets(occurrence)]
+            [#local contextLinks = getLinkTargets(subOccurrence)]
             [#local _context =
                 {
                     "Links" : contextLinks,
@@ -226,7 +225,7 @@
                                     [#else]
                                         [@fatal
                                             message="Only one replication destination is supported"
-                                            context=links
+                                            context=contextLinks
                                         /]
                                     [/#if]
                                     [#break]
@@ -257,7 +256,7 @@
                             getS3ReplicationConfiguration(replicationRoleId, replicationRules)]
 
                         [#local replicationLinkPolicies =
-                            getLinkTargetsOutboundRoles(links) +
+                            getLinkTargetsOutboundRoles(contextLinks) +
                             replicateEncryptedData?then(
                                 s3EncryptionReadPermission(
                                     cmkId,


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Correct the extension/policy logic to work on the subOccurrence rather than the occurrence.

## Motivation and Context
Bucket policy wasn't including permissions for the baseline OAI.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

