### PR TITLE
feat(waf): add support for more wafv2 rules

### DIFF
--- a/aws/services/waf/resource.ftl
+++ b/aws/services/waf/resource.ftl
@@ -361,20 +361,19 @@
             [/#if]
             [#switch version]
 
-                [#switch rule.Engine ]
-                    [#case "Conditional" ]
-                        [#break]
-                    [#default]
-                        [@fatal
-                            message="Unsupported engine for WAF V1 - Only the conditional engine is available"
-                            context={
-                                "WafId": id,
-                                "Rule": rule
-                            }
-                        /]
-                [/#switch]
-
                 [#case "v1"]
+                    [#switch rule.Engine ]
+                        [#case "Conditional" ]
+                            [#break]
+                        [#default]
+                            [@fatal
+                                message="Unsupported engine for WAF V1 - Only the conditional engine is available"
+                                context={
+                                    "WafId": id,
+                                    "Rule": rule
+                                }
+                            /]
+                    [/#switch]
                     [#local aclRules +=
                         [
                             {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for defining conditional rate based rules in wafv2
- Adds support for using Vendor Managed Rule groups which include detailed rule management from AWS
- Both are controlled as rules as they can have conditions applied to override their usage

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
AWS Implementation of https://github.com/hamlet-io/engine/pull/2055 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

