### PR TITLE
fix(cdn): use cloudformation to find cdn id

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -833,16 +833,14 @@
         [#if invalidationPaths?has_content && getExistingReference(cfId)?has_content && (wafVersion == "v1") ]
             [@addToDefaultBashScriptOutput
                 [
-                    "case $\{STACK_OPERATION} in",
-                    "  create|update)"
-                    "       # Invalidate distribution",
-                    "       info \"Invalidating cloudfront distribution ... \"",
-                    "       invalidate_distribution" +
-                    "       \"" + getRegion() + "\" " +
-                    "       \"" + getExistingReference(cfId) + "\" " +
-                    "       \"" + invalidationPaths?join(" ") + "\" || return $?"
-                    " ;;",
-                    " esac"
+                    r'case ${STACK_OPERATION} in',
+                    r'  create|update)',
+                    r'       cf_id="$(get_cloudformation_stack_output "' + getRegion() + r'" "${STACK_NAME}" "' + cfId + r'" "ref" || return $?)"',
+                    r'       # Invalidate distribution',
+                    r'       info "Invalidating cloudfront distribution"',
+                    r'       invalidate_distribution "' + getRegion() + r'" "${cf_id}" "' + invalidationPaths?join(" ") + r'" || return $?',
+                    r' ;;',
+                    r' esac'
                 ]
             /]
         [/#if]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Use the Cloudformation stack output to determine the CF ID when running an invalidation

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When a CF Id has changed and not been reflected in the CMDB the invalidation command doesn't work as it tries to invalidate the wrong ID. Using the CFN stack ensures that its up to date. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

