### PR TITLE
feat(s3): disable public access by default

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -310,6 +310,9 @@
                     kmsKeyId=cmkId
                     dependencies=bucketDependencies
                     tags=getOccurrenceTags(subOccurrence)
+                    publicAccessBlockConfiguration=(
+                        getPublicAccessBlockConfiguration()
+                    )
                 /]
 
                 [#-- role based bucket policies --]

--- a/aws/services/s3/resource.ftl
+++ b/aws/services/s3/resource.ftl
@@ -357,28 +357,51 @@
     }
 ]
 
+[#-- Default policy applied will essentially disable public ACLs and lock down cross account access if a bucket is public --]
+[#-- https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html --]
+[#function getPublicAccessBlockConfiguration
+        blockPublicPolicy=true
+        blockPublicAcls=true
+        ignorePublicAcls=true
+        restrictPublicBuckets=true
+    ]
+
+    [#return
+        {
+            "BlockPublicAcls" : blockPublicAcls,
+            "BlockPublicPolicy" : blockPublicPolicy,
+            "IgnorePublicAcls" : ignorePublicAcls,
+            "RestrictPublicBuckets" : restrictPublicBuckets
+        }
+    ]
+[/#function]
+
 [@addOutputMapping
     provider=AWS_PROVIDER
     resourceType=AWS_S3_RESOURCE_TYPE
     mappings=S3_OUTPUT_MAPPINGS
 /]
 
-[#macro createS3Bucket id name tier="" component=""
-                        encrypted=false
-                        encryptionSource="aws:kms"
-                        kmsKeyId=""
-                        lifecycleRules=[]
-                        notifications=[]
-                        versioning=false
-                        websiteConfiguration={}
-                        replicationConfiguration={}
-                        cannedACL=""
-                        CORSBehaviours=[]
-                        inventoryReports=[]
-                        dependencies=""
-                        outputId=""
-                        tags={}
-                        ]
+
+[#macro createS3Bucket
+        id
+        name
+        encrypted=false
+        encryptionSource="aws:kms"
+        kmsKeyId=""
+        lifecycleRules=[]
+        notifications=[]
+        versioning=false
+        websiteConfiguration={}
+        replicationConfiguration={}
+        publicAccessBlockConfiguration={}
+        cannedACL=""
+        CORSBehaviours=[]
+        inventoryReports=[]
+        dependencies=""
+        outputId=""
+        tags={}
+    ]
 
     [#local loggingConfiguration = {} ]
 
@@ -520,6 +543,10 @@
             attributeIfContent(
                 "InventoryConfigurations",
                 inventoryReports
+            ) +
+            attributeIfContent(
+                "PublicAccessBlockConfiguration",
+                publicAccessBlockConfiguration
             )
         tags=tags
         outputs=S3_OUTPUT_MAPPINGS


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for the PublicAccessBlock feature of S3
- Sets the default policy to block, ignore and restrict the use of public S3 buckets
- Only allows public policy to be overridden if public access has been enabled for a s3 component
- Removes component and tier from s3 setup as its no longer used

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The primary goal here is to increase security over S3 buckets and to ensure that users of hamlet aren't risking the use of public S3 objects unless they explicitly ask for it.
This also aligns with the changes to AWS S3 bucket creation which now enables this by default. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

