### PR TITLE
fix(cdn): origin request policy headers

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -743,7 +743,7 @@
                     [],
                     [],
                     combineEntities(
-                        _context.ForwardHeaders,
+                        _context.ForwardHeaders![],
                         solution.CloudFront.CustomHeaders,
                         UNIQUE_COMBINE_BEHAVIOUR
                     ) +

--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -117,7 +117,7 @@
                 subSolution.RequestForwarding["Policy:Custom"].Methods,
                 subSolution.RequestForwarding["Policy:Custom"].Cookies,
                 combineEntities(
-                    _context.ForwardHeaders,
+                    _context.ForwardHeaders![],
                     subSolution.RequestForwarding["Policy:Custom"].Headers,
                     UNIQUE_COMBINE_BEHAVIOUR
                 ),
@@ -475,7 +475,7 @@
                         originLinkTargetCore.Type,
                         originConfig.RequestForwarding["Policy:Custom"].Methods,
                         originConfig.RequestForwarding["Policy:Custom"].Cookies,
-                        _context.ForwardHeaders,
+                        _context.ForwardHeaders![],
                         originConfig.RequestForwarding["Policy:Custom"].QueryParams
                     )
                 ) id=originRequestPolicy.Id name=originRequestPolicy.Name /]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Add a default for forwarded headers to avoid `Hamlet:null` being added as a header if no specific config is provided.

## Motivation and Context
While it didn't affect the operation of the policy, including an entry for this header value was unnecessary.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

