### PR TITLE
fix(datacatalog): add subset filter for resources

### DIFF
--- a/aws/components/datacatalog/setup.ftl
+++ b/aws/components/datacatalog/setup.ftl
@@ -13,11 +13,13 @@
 
     [#local database = resources["database"]]
 
-    [@createAWSGlueDatabase
-        id=database.Id
-        name=database.Name
-        description=(solution.Description)!""
-    /]
+    [#if deploymentSubsetRequired(DATACATALOG_COMPONENT_TYPE, true)]
+        [@createAWSGlueDatabase
+            id=database.Id
+            name=database.Name
+            description=(solution.Description)!""
+        /]
+    [/#if]
 
     [#list (occurrence.Occurrences![])?filter(
             x -> x.Configuration.Solution.Enabled
@@ -152,14 +154,16 @@
                     serDeParams
                 )]
 
-        [@createAWSGlueTable
-            id=table.Id
-            name=table.Name
-            databaseId=database.Id
-            partitionKeys=_context.PartitionKeys
-            storageDescriptor=tableStorageDescriptor
-            parameters=tableParams
-        /]
+        [#if deploymentSubsetRequired(DATACATALOG_COMPONENT_TYPE, true)]
+            [@createAWSGlueTable
+                id=table.Id
+                name=table.Name
+                databaseId=database.Id
+                partitionKeys=_context.PartitionKeys
+                storageDescriptor=tableStorageDescriptor
+                parameters=tableParams
+            /]
+        [/#if]
 
         [#if solution.Crawler.Enabled ]
             [#local crawler = resources["crawler"]]
@@ -219,20 +223,22 @@
                 ]
             }]
 
-            [@createAWSGlueCrawler
-                id=cralwer.Id
-                name=crawler.Name
-                roleId=crawlerRole.Id
-                targets=targets
-                description=(solution.Description)!""
-                crawlerSecurityConfigurationId=""
-                glueDatabaseId=database.Id
-                recrawlBehaviour=solution.Crawler.RecrawlingPolicy
-                scheduleExpression=solution.Crawler.Schedule
-                schemaChangeDeleteBehaviour=solution.Crawler.SchemaChanges.Delete
-                schemaChangeUpdateBehaviour=solution.Crawler.SchemaChanges.Update
-                tags=getOccurrenceTags(subOccurrence)
-            /]
+            [#if deploymentSubsetRequired(DATACATALOG_COMPONENT_TYPE, true)]
+                [@createAWSGlueCrawler
+                    id=cralwer.Id
+                    name=crawler.Name
+                    roleId=crawlerRole.Id
+                    targets=targets
+                    description=(solution.Description)!""
+                    crawlerSecurityConfigurationId=""
+                    glueDatabaseId=database.Id
+                    recrawlBehaviour=solution.Crawler.RecrawlingPolicy
+                    scheduleExpression=solution.Crawler.Schedule
+                    schemaChangeDeleteBehaviour=solution.Crawler.SchemaChanges.Delete
+                    schemaChangeUpdateBehaviour=solution.Crawler.SchemaChanges.Update
+                    tags=getOccurrenceTags(subOccurrence)
+                /]
+            [/#if]
         [/#if]
 
     [/#list]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Ensure the glue resources are only created in the standard template

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Running an IAM or LG resource group would add the glue resource to their templates

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

