### PR TITLE
fix(network): dns resolver resource references

### DIFF
--- a/aws/components/network/setup.ftl
+++ b/aws/components/network/setup.ftl
@@ -207,7 +207,7 @@
             [@createRoute53ResolverLoggingAssociation
                 id=dnsQueryLoggerAssocId
                 resolverLoggingId=dnsQueryLoggerId
-                vpcId=vpcId
+                vpcId=vpcResourceId
             /]
         [/#if]
     [/#list]

--- a/aws/components/network/state.ftl
+++ b/aws/components/network/state.ftl
@@ -177,7 +177,6 @@
                 "vpc" : {
                     "Legacy" : legacyVpc,
                     "Id" : legacyVpc?then(formatVPCId(), vpcId),
-                    "Legacy" : legacyVpc,
                     "ResourceId" : vpcId,
                     "Name" : vpcName,
                     "Address": networkCIDR,


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Correct the reference to the vpc resource in the DNS resolver to work correctly with legacy vpcs.

Also remove a redundant line of code in the vpc state function.

## Motivation and Context
Ensure continued support for older deployments.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

