### PR TITLE
refactor(iam): remove transitional settings policy support

### DIFF
--- a/aws/services/iam/policy.ftl
+++ b/aws/services/iam/policy.ftl
@@ -31,16 +31,6 @@
                 getExistingReference(baselineIds["OpsData"], NAME_ATTRIBUTE_TYPE),
                 getSettingsFilePrefix(occurrence),
                 getExistingReference(baselineIds["OpsData"], REGION_ATTRIBUTE_TYPE)
-            ) +
-
-            [#-- Support transition between FullRelativePath and FullRelativeRawPath --]
-            s3ReadPermission(baselineIds["OpsData"], occurrence.Core.FullRelativePath) +
-            s3ListPermission(baselineIds["OpsData"], occurrence.Core.FullRelativePath) +
-            s3EncryptionReadPermission(
-                baselineIds["Encryption"],
-                getExistingReference(baselineIds["OpsData"], NAME_ATTRIBUTE_TYPE),
-                occurrence.Core.FullRelativePath,
-                getExistingReference(baselineIds["OpsData"], REGION_ATTRIBUTE_TYPE)
             ),
             permissions.AsFile,
             []


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
This change removes the transitional code introduced as part of the move to include raw component ids in  settings paths. 

## Motivation and Context
When settings was switched to using the component raw name, code was added to support a transition from the old paths to the new.

Unfortunately the transitional code did not include the `settings/` prefix at the start of the path (which is added by `getSettingsFilePrefix()`), meaning that the permissions it generated did not align to the previous format.

As a result the raw name based permissions have been the only effective ones for a number of months.

This change has been introduced partly to remove the unused permissions, but mainly in order to reduce the size of iam pass templates.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

