### PR TITLE
fix(apigateway): origin request policy

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -723,6 +723,12 @@
             [#local cachePolicy = cfResources["cachePolicy"] ]
             [#local originRequestPolicy = cfResources["originRequestPolicy"]]
 
+            [#-- Determine if the Authorization header is required for API authorization --]
+            [#local cacheHeaders=[] ]
+            [#if lambdaAuthorizers?has_content || cognitoPools?has_content || ((openapiIntegrations.Security.sigv4)??)]
+                [#local cacheHeaders=["Authorization"] ]
+            [/#if]
+
             [@createCFCachePolicy
                 id=cachePolicy.Id
                 name=cachePolicy.Name
@@ -731,7 +737,7 @@
                     "Max": 0,
                     "Default": 0
                 }
-                headerNames=[] cookieNames=[]
+                headerNames=cacheHeaders cookieNames=[]
                 queryStringNames=[] compressionProtocols=[]
             /]
 

--- a/aws/services/cf/resource.ftl
+++ b/aws/services/cf/resource.ftl
@@ -525,6 +525,8 @@
     [#if policy == "LinkType" ]
         [#switch originLinkType ]
             [#case APIGATEWAY_COMPONENT_TYPE]
+                [#-- Note that the Authorization header, if required, must be included in the cache policy --]
+                [#-- An error is thrown if you attempt to add it in the origin request policy --]
                 [#local headerNames =
                     combineEntities(
                         [
@@ -532,7 +534,6 @@
                             "Accept-Charset",
                             "Accept-Datetime",
                             "Accept-Language",
-                            "Authorization",
                             "Origin",
                             "Referer"
                         ],


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
- remove `Authorization` header from the origin request policy for an API Gateway origin
- detect if the `Authorization` header is required in the cache policy for a cloudfront distribution associated with an API Gateway

## Motivation and Context
Origin request policies cannot contain the "Authorization" header. If required by the origin, it must be included in the cache policy, the headers of which are then automatically included in the origin request.


## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

