### PR TITLE
fix(apigateway): Authorization header passthrough

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -723,12 +723,6 @@
             [#local cachePolicy = cfResources["cachePolicy"] ]
             [#local originRequestPolicy = cfResources["originRequestPolicy"]]
 
-            [#-- Determine if the Authorization header is required for API authorization --]
-            [#local cacheHeaders=[] ]
-            [#if lambdaAuthorizers?has_content || cognitoPools?has_content || ((openapiIntegrations.Security.sigv4)??)]
-                [#local cacheHeaders=["Authorization"] ]
-            [/#if]
-
             [@createCFCachePolicy
                 id=cachePolicy.Id
                 name=cachePolicy.Name
@@ -737,7 +731,7 @@
                     "Max": 0,
                     "Default": 0
                 }
-                headerNames=cacheHeaders cookieNames=[]
+                headerNames=[] cookieNames=[]
                 queryStringNames=[] compressionProtocols=[]
             /]
 

--- a/aws/services/cf/resource.ftl
+++ b/aws/services/cf/resource.ftl
@@ -525,9 +525,10 @@
     [#if policy == "LinkType" ]
         [#switch originLinkType ]
             [#case APIGATEWAY_COMPONENT_TYPE]
-                [#-- Note that the Authorization header, if required, must be included in the cache policy --]
-                [#-- An error is thrown if you attempt to add it in the origin request policy --]
-                [#local headerNames =
+                [#-- As of 2022-10-19, to get the Authorization header passed through without cacheing, --]
+                [#-- the AllViewer behaviour must be used (triggered by a header name of _all).         --]
+                [#-- TODO(mfl): revisit once AWS has responded to the numerous feedback it has received on this issue --]
+                [#--local headerNames =
                     combineEntities(
                         [
                             "Accept",
@@ -540,7 +541,7 @@
                         customHeaders,
                         UNIQUE_COMBINE_BEHAVIOUR
                     )
-                ]
+                --]
                 [#break]
 
             [#case MOBILEAPP_COMPONENT_TYPE]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Switch to using the `allViewer` header behaviour on the origin request policy to get the Authorization header passed through.

## Motivation and Context
This is an AWS suggested workaround. At present the `Authorization` can't be explicitly included in an origin request policy, and equally can't be included in a cache policy where the TTL=0.

## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

