### PR TITLE
fix(apigateway): authorization values

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -308,7 +308,7 @@
                 [#break]
 
             [#case "SIG4ORIP" ]
-            [#case "aws:SIG4_OR_IP" ]
+            [#case "AWS:SIG4_OR_IP" ]
             [#case "AUTHORIZER_OR_IP" ]
             [#case "AUTHORISER_OR_IP" ]
                 [#-- Resource policy provides ALLOW on IP --]
@@ -343,7 +343,7 @@
                 [#break]
 
             [#case "SIG4ANDIP" ]
-            [#case "aws:SIG4_AND_IP" ]
+            [#case "AWS:SIG4_AND_IP" ]
             [#case "AUTHORIZER_AND_IP" ]
             [#case "AUTHORISER_AND_IP" ]
                 [#-- If IP doesn't match, EXPLICIT DENY regardless   --]
@@ -375,8 +375,10 @@
                         ]
                     ]
                 [/#if]
+                [#break]
 
-
+            [#default]
+                [@fatal message="Internal error: Unknown authorization model" context=apiPolicyAuth /]
                 [#break]
         [/#switch]
     [#else]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Because the authorization model is converted to upper case when first fetched from the solution configuration, treat any provider prefix as upper case as well.

Add a default statement to the authorization processing to catch any internal error where the value being used is unknown.

## Motivation and Context
- correct handling of provider prefixed values
- robustness of code
 
## How Has This Been Tested?
Local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

