### PR TITLE
fix(waf): handle WAFProfiles and metric name

### DIFF
--- a/aws/services/waf/resource.ftl
+++ b/aws/services/waf/resource.ftl
@@ -536,11 +536,10 @@
         [#break]
 
         [#case "v2"]
-            [#local defAction = defaultAction?lower_case?cap_first ]
             [#local properties=
                 {
                     "DefaultAction" : {
-                        defAction: {}
+                        defaultAction?lower_case?cap_first : {}
                     },
                     "Name": name,
                     "Rules" : aclRules,
@@ -564,20 +563,10 @@
 
 [#macro createWAFAclFromSecurityProfile id name metric wafSolution securityProfile occurrence={} regional=false version="v1"]
     [#if wafSolution.OWASP ]
-        [#local OWASPProfile = "OWASP2017"]
-        [#if securityProfile.WAFProfile != OWASPProfile]
-            [@fatal
-                message="WAF Profile can not be set when using OWASP mode for WAF - Update the security profile to use ${OWASPProfile} as the WAFProfile"
-                context={
-                    "Id": id,
-                    "Name":name,
-                    "SecurityProfile": securityProfile
-                }
-            /]
-        [/#if]
+        [#local wafProfile = getReferenceData(WAFPROFILE_REFERENCE_TYPE)[("OWASP2017")]!{}]
+    [#else]
+        [#local wafProfile = getReferenceData(WAFPROFILE_REFERENCE_TYPE)[(securityProfile.WAFProfile)]!{} ]
     [/#if]
-
-    [#local wafProfile = getReferenceData(WAFPROFILE_REFERENCE_TYPE)[(securityProfile.WAFProfile)]!{} ]
 
     [#local wafValueSet = resolveDynamicValues(
         getReferenceData(WAFVALUESET_REFERENCE_TYPE)[securityProfile.WAFValueSet!""]!{},

--- a/aws/services/waf/resource.ftl
+++ b/aws/services/waf/resource.ftl
@@ -547,7 +547,7 @@
                     "Scope": regional?then("REGIONAL","CLOUDFRONT"),
                     "VisibilityConfig" : {
                         "CloudWatchMetricsEnabled" : true,
-                        "MetricName" : ruleName,
+                        "MetricName" : name,
                         "SampledRequestsEnabled" : true
                     }
                 }
@@ -563,11 +563,22 @@
 [/#macro]
 
 [#macro createWAFAclFromSecurityProfile id name metric wafSolution securityProfile occurrence={} regional=false version="v1"]
-    [#if wafSolution.OWASP]
-        [#local wafProfile = getReferenceData(WAFPROFILE_REFERENCE_TYPE)[securityProfile.WAFProfile!""]!{} ]
-    [#else]
-        [#local wafProfile = {"Rules" : [], "DefaultAction" : "ALLOW"} ]
+    [#if wafSolution.OWASP ]
+        [#local OWASPProfile = "OWASP2017"]
+        [#if securityProfile.WAFProfile != OWASPProfile]
+            [@fatal
+                message="WAF Profile can not be set when using OWASP mode for WAF - Update the security profile to use ${OWASPProfile} as the WAFProfile"
+                context={
+                    "Id": id,
+                    "Name":name,
+                    "SecurityProfile": securityProfile
+                }
+            /]
+        [/#if]
     [/#if]
+
+    [#local wafProfile = getReferenceData(WAFPROFILE_REFERENCE_TYPE)[(securityProfile.WAFProfile)]!{} ]
+
     [#local wafValueSet = resolveDynamicValues(
         getReferenceData(WAFVALUESET_REFERENCE_TYPE)[securityProfile.WAFValueSet!""]!{},
         {"occurrence": occurrence}


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Use the WAF Profile from the security profile at all times
- Fix the name for the default rule metric name

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
- The WAFProfile was being ignored if OWASP wasn't enabled on the WAF configuration
- The default metric would change to the name of the last rule or fail when no rules are present

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

