### PR TITLE
fix(user): pseudo stack handling and ses removal

### DIFF
--- a/aws/components/user/state.ftl
+++ b/aws/components/user/state.ftl
@@ -67,8 +67,7 @@
                 "USERNAME" : getExistingReference(userId),
                 "ARN" : userArn,
                 "ACCESS_KEY" : getExistingReference(userId, USERNAME_ATTRIBUTE_TYPE),
-                "SECRET_KEY" : getExistingReference(userId, PASSWORD_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme),
-                "SES_SMTP_PASSWORD" : getExistingReference(userId, KEY_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme)
+                "SECRET_KEY" : getExistingReference(userId, PASSWORD_ATTRIBUTE_TYPE)?ensure_starts_with(encryptionScheme)
             } +
             attributeIfTrue(
                 "FILETRANSFER_USERNAME",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
- Ensures a unique psuedo stack is generated for each user instead of overriding when there are multiple users in a deploymentUnit
- Remove the SES password generation as the method being used is no longer accepted by SES API endpoints and instead requires Sig4 signing
- Cleans up some of the formatting for generating the bash script

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When creating a deployment that has multiple users the pseudo stack for credentials would be overwrriten for each user created 


## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- The SES User password has been removed and replaced with a runbook/module as password generation is now dependent on the region of SES you are using. 

The Module https://github.com/hamlet-io/engine-plugin-aws/blob/master/aws/modules/ses_smtp_user/module.ftl can be used to create an SMTP user in AWS along with a runbook to generate the username and password based on a provided region.

