### PR TITLE
fix(db): BASH_SOURCE usage in bash scripts

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -498,7 +498,7 @@
                             valueIfTrue(
                                 [
                                     r'   info "Removing old ssh pseudo stack output ..."',
-                                    r'   legacy_pseudo_stack_file="$(fileBase "${BASH_SOURCE}")"',
+                                    r'   legacy_pseudo_stack_file="$(fileBase "${BASH_SOURCE[0]}")"',
                                     r'   legacy_pseudo_stack_filepath="${CF_DIR/baseline/cmk}${legacy_pseudo_stack_file/-baseline-/-cmk-}-keypair-pseudo-stack.json"',
                                     r'   if [ -f "${legacy_pseudo_stack_filepath}" ]; then',
                                     r'       info "Deleting ${legacy_pseudo_stack_filepath} ..."',
@@ -520,7 +520,7 @@
                                 r'    delete_ssh_credentials "'+ getRegion() + r'" ' +
                                         r'"${key_pair_name}" || return $?',
                                 r'    delete_pki_credentials "${SEGMENT_OPERATIONS_DIR}" || return $?',
-                                r'    rm -f "${CF_DIR}/$(fileBase "${BASH_SOURCE}")-keypair-pseudo-stack.json"',
+                                r'    rm -f "${CF_DIR}/$(fileBase "${BASH_SOURCE[0]}")-keypair-pseudo-stack.json"',
                                 r'    ;;',
                                 r'  create|update)',
                                 r'    manage_ssh_credentials || return $?',
@@ -580,7 +580,7 @@
                                         "    delete_oai_credentials" + " " +
                                                "\"" + getRegion() + "\" " +
                                                "\"" + legacyOAIName + "\" || return $?",
-                                        "    rm -f \"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-pseudo-stack.json\"",
+                                        "    rm -f \"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE[0]}\")-pseudo-stack.json\"",
                                         "    ;;",
                                         "  create|update)",
                                         "    info \"Removing legacy oai credential ...\"",
@@ -594,7 +594,7 @@
                                                  "\"" + getRegion() + "\" " +
                                                  "\"" + legacyOAIName + "\" || return $?",
                                         "      info \"Removing legacy oai pseudo stack output\"",
-                                        "      legacy_pseudo_stack_file=\"$(fileBase \"$\{BASH_SOURCE}\")\"",
+                                        "      legacy_pseudo_stack_file=\"$(fileBase \"$\{BASH_SOURCE[0]}\")\"",
                                         "      legacy_pseudo_stack_filepath=\"$\{CF_DIR/baseline/cmk}/$\{legacy_pseudo_stack_file/-baseline-/-cmk-}-pseudo-stack.json\"",
                                         "      if [ -f \"$\{legacy_pseudo_stack_filepath}\" ]; then",
                                         "         info \"Deleting $\{legacy_pseudo_stack_filepath} ...\"",

--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -993,9 +993,9 @@
             [#local rdsFQDN = getExistingReference(rdsId, DNS_ATTRIBUTE_TYPE)]
             [#local rdsCA = getExistingReference(rdsId, "ca")]
 
-            [#local passwordPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-password-pseudo-stack.json\"" ]
-            [#local urlPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\""]
-            [#local caPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-ca-pseudo-stack.json\""]
+            [#local passwordPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE[0]}\")-password-pseudo-stack.json\"" ]
+            [#local urlPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE[0]}\")-url-pseudo-stack.json\""]
+            [#local caPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE[0]}\")-ca-pseudo-stack.json\""]
             [@addToDefaultBashScriptOutput
                 content=
                 [

--- a/aws/components/docdb/setup.ftl
+++ b/aws/components/docdb/setup.ftl
@@ -742,9 +742,9 @@
             [#local ddsFQDN = getExistingReference(ddsId, DNS_ATTRIBUTE_TYPE)]
             [#local ddsCA = getExistingReference(ddsId, "ca")]
 
-            [#local passwordPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-password-pseudo-stack.json\"" ]
-            [#local urlPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-url-pseudo-stack.json\""]
-            [#local caPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE}\")-ca-pseudo-stack.json\""]
+            [#local passwordPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE[0]}\")-password-pseudo-stack.json\"" ]
+            [#local urlPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE[0]}\")-url-pseudo-stack.json\""]
+            [#local caPseudoStackFile = "\"$\{CF_DIR}/$(fileBase \"$\{BASH_SOURCE[0]}\")-ca-pseudo-stack.json\""]
             [@addToDefaultBashScriptOutput
                 content=
                 [


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Uses the expected array evaluation for BASH_SOURCE when generating bash scripts in the db components

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The BASH_SOURCE builtin bash environment variable is actually an array of the source files for the script. Using array based lookup for the value ensures the file is right. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

