### PR TITLE
fix(images): remove filename from CODE_SRC_PREFIX config for mobileapp component

### DIFF
--- a/aws/components/mobileapp/setup.ftl
+++ b/aws/components/mobileapp/setup.ftl
@@ -40,7 +40,7 @@
             "APPDATA_PREFIX"    : getAppDataFilePrefix(occurrence),
 
             "CODE_SRC_BUCKET" : (image.ImageLocation?remove_beginning("s3://")?keep_before("/"))!"",
-            "CODE_SRC_PREFIX" : (image.ImageLocation?remove_beginning("s3://")?keep_after("/"))!"",
+            "CODE_SRC_PREFIX" : (image.ImageLocation?remove_beginning("s3://")?keep_after("/")?keep_before_last("/"))!"",
             "APP_BUILD_FORMATS" : solution.BuildFormats?join(","),
             "KMS_PREFIX"        : solution.EncryptionPrefix,
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Removes the image filename from the `CODE_SRC_PREFIX` config value for the mobileapp component
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The expo publish script appends the image filename when retrieving the image from the registry, leading to the incorrect link and failing the build. It was decided to fix the `CODE_SRC_PREFIX` config value to align it with the previous approach and the config parameter name.
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Locally
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

