### PR TITLE
fix(lambda): remove env vars for lambda@edge

### DIFF
--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -251,18 +251,6 @@
         [/#list]
     [/#if]
 
-    [#-- clear all environment variables for EDGE deployments --]
-    [#if deploymentType == "EDGE" ]
-        [#local _context += {
-            "DefaultEnvironment" : {},
-            "Environment" : {},
-            "DefaultCoreVariables" : false,
-            "DefaultEnvironmentVariables" : false,
-            "DefaultLinkVariables" : false,
-            "DefaultBaselineVariables" : false
-        }]
-    [/#if]
-
     [#local finalEnvironment = getFinalEnvironment(fn, _context, solution.Environment) ]
     [#local finalAsFileEnvironment = getFinalEnvironment(fn, _context, solution.Environment + {"AsFile" : false}) ]
     [#local asFileFormat = solution.Environment.FileFormat ]
@@ -447,9 +435,15 @@
             [/#list]
         [/#if]
 
+        [#if deploymentType == "EDGE" ]
+            [#local functionContext =  _context + {"Environment": {}} ]
+        [#else]
+            [#local functionContext = _context ]
+        [/#if]
+
         [@createLambdaFunction
             id=fnId
-            settings=_context +
+            settings=functionContext +
                 {
                     "Handler" : solution.Handler,
                     "RunTime" : solution.RunTime,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Environment variables aren't supported for lambda@edge so don't include them

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
While we did disable them through the default context configuration, it was still easy to inject environment variables with the current process. 

This ensures that environment variables can't be added to the lambda function by directly removing the Environment object

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

