### PR TITLE
fix: update shared release workflow version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,5 @@ jobs:
 
   package:
     if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') }}
-    uses: hamlet-io/.github/.github/workflows/engine_image_release.yml@1.1.1
+    uses: hamlet-io/.github/.github/workflows/engine_image_release.yml@1.1.2
     secrets: inherit


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Update the workflow version to pick up the fix to ensure the edge tag is added correctly to docker images.

## Motivation and Context
Unicycle release was not picking up changes as `edge` tags were not being added to docker builds.

## How Has This Been Tested?
Difficult to test outside of github. Tested immediately following commit.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

