### PR TITLE
feat(db): add support for RDS Proxies

### DIFF
--- a/aws/services/kms/policy.ftl
+++ b/aws/services/kms/policy.ftl
@@ -104,7 +104,7 @@
 [#function secretsManagerKMSStatement actions keyId secretId secretRegion ]
 
     [#-- Handle empty region value if attribute is not set --]
-    [#if ! secretRegion?has_content ]
+    [#if ! secretRegion?has_content || secretRegion?is_hash ]
         [#local secretRegion = getRegion()]
     [/#if]
 

--- a/aws/services/rds/id.ftl
+++ b/aws/services/rds/id.ftl
@@ -7,6 +7,7 @@
     service=AWS_RELATIONAL_DATABASE_SERVICE
     resource=AWS_RDS_RESOURCE_TYPE
 /]
+
 [#assign AWS_RDS_SUBNET_GROUP_RESOURCE_TYPE = "rdsSubnetGroup" ]
 [@addServiceResource
     provider=AWS_PROVIDER
@@ -20,12 +21,14 @@
     service=AWS_RELATIONAL_DATABASE_SERVICE
     resource=AWS_RDS_PARAMETER_GROUP_RESOURCE_TYPE
 /]
+
 [#assign AWS_RDS_OPTION_GROUP_RESOURCE_TYPE = "rdsOptionGroup" ]
 [@addServiceResource
     provider=AWS_PROVIDER
     service=AWS_RELATIONAL_DATABASE_SERVICE
     resource=AWS_RDS_OPTION_GROUP_RESOURCE_TYPE
 /]
+
 [#assign AWS_RDS_SNAPSHOT_RESOURCE_TYPE = "rdsSnapShot" ]
 [@addServiceResource
     provider=AWS_PROVIDER
@@ -46,11 +49,33 @@
     service=AWS_RELATIONAL_DATABASE_SERVICE
     resource=AWS_RDS_CLUSTER_RESOURCE_TYPE
 /]
+
 [#assign AWS_RDS_CLUSTER_PARAMETER_GROUP_RESOURCE_TYPE = "rdsClusterParameterGroup" ]
 [@addServiceResource
     provider=AWS_PROVIDER
     service=AWS_RELATIONAL_DATABASE_SERVICE
     resource=AWS_RDS_CLUSTER_PARAMETER_GROUP_RESOURCE_TYPE
+/]
+
+[#assign AWS_RDS_PROXY_RESOURCE_TYPE = "rdsProxy" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_RELATIONAL_DATABASE_SERVICE
+    resource=AWS_RDS_PROXY_RESOURCE_TYPE
+/]
+
+[#assign AWS_RDS_PROXY_ENDPOINT_RESOURCE_TYPE = "rdsProxyEndpoint" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_RELATIONAL_DATABASE_SERVICE
+    resource=AWS_RDS_PROXY_ENDPOINT_RESOURCE_TYPE
+/]
+
+[#assign AWS_RDS_PROXY_TARGET_GROUP_RESOURCE_TYPE = "rdsProxyTargetGroup" ]
+[@addServiceResource
+    provider=AWS_PROVIDER
+    service=AWS_RELATIONAL_DATABASE_SERVICE
+    resource=AWS_RDS_PROXY_TARGET_GROUP_RESOURCE_TYPE
 /]
 
 [#function formatDependentRDSSnapshotId resourceId extensions... ]

--- a/aws/services/secretsmanager/policy.ftl
+++ b/aws/services/secretsmanager/policy.ftl
@@ -27,7 +27,14 @@
             allow,
             sid
         ) +
-        secretsManagerKMSStatement(["kms:Decrypt"], kmsKeyId, id, getReference(id, REGION_ATTRIBUTE_TYPE))
+        secretsManagerKMSStatement(
+            [
+                "kms:Decrypt"
+            ],
+            kmsKeyId,
+            id,
+            getReference(id, REGION_ATTRIBUTE_TYPE)
+        )
     ]
 [/#function]
 

--- a/awstest/modules/db/module.ftl
+++ b/awstest/modules/db/module.ftl
@@ -639,4 +639,86 @@
             }
         }
     /]
+
+    [#-- DBProxy  --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "db" : {
+                    "Components" : {
+                        "postgresdbproxy" : {
+                            "Type" : "db",
+                            "deployment:Unit" : "aws-db",
+                            "Engine" : "postgres",
+                            "EngineVersion" : "14",
+                            "Profiles" : {
+                                "Testing" : [ "postgresdbproxy" ]
+                            },
+                            "rootCredential:Source" : "SecretStore",
+                            "rootCredential:SecretStore" : {
+                                "Link" : {
+                                    "Tier" : "db",
+                                    "Component": "postgresdbproxy-secretstore"
+                                }
+                            },
+                            "Proxies" : {
+                                "reader": {
+                                    "AuthorisedUsers" : {
+                                        "root" : {
+                                            "Source": "DBRoot"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "postgresdbproxy-secretstore" : {
+                            "Type" : "secretstore",
+                            "deployment:Unit" : "aws-db",
+                            "Engine" : "aws:secretsmanager"
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "postgresdbproxy" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "rdsInstance" : {
+                                    "Name" : "rdsXdbXpostgresdbproxy",
+                                    "Type" : "AWS::RDS::DBInstance"
+                                },
+                                "secret" : {
+                                    "Name" : "secretXdbXpostgresdbproxyXRootCredentials",
+                                    "Type" : "AWS::SecretsManager::Secret"
+                                },
+                                "rdsProxy" : {
+                                    "Name" : "rdsProxyXdbXpostgresdbproxyXreader",
+                                    "Type" : "AWS::RDS::DBProxy"
+                                },
+                                "rdsProxyTargetGroup" : {
+                                    "Name" : "rdsProxyTargetGroupXdbXpostgresdbproxyXreader",
+                                    "Type" : "AWS::RDS::DBProxyTargetGroup"
+                                }
+                            },
+                            "Output" : [
+                                "rdsXdbXpostgresdbproxyXdns",
+                                "rdsXdbXpostgresdbproxyXport",
+                                "secretXdbXpostgresdbproxyXRootCredentialsXarn"
+                            ]
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "postgresdbproxy" : {
+                    "db" : {
+                        "TestCases" : [ "postgresdbproxy" ]
+                    }
+                }
+            }
+        }
+    /]
+
 [/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Implements the Proxy db subcomponent using the RDS Proxy service
- This adds support for the Proxy, TargetGroup and Endpoint services required to fully implement RDS Proxy
- Fixes an issue in secrets manager permissions which didn't support region refs

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Implement the proxy definition outlined in https://github.com/hamlet-io/engine/pull/2074

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally includes test suite updates and has been deployed into an environment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/2074

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

