### PR TITLE
fix(image): update image push runbooks

### DIFF
--- a/aws/components/image/setup.ftl
+++ b/aws/components/image/setup.ftl
@@ -60,7 +60,8 @@
         [#case "docker"]
 
             [#switch solution.Source]
-                [#case "registry"]
+                [#case "Local"]
+                [#local "registry"]
                     [#break]
 
                 [#case "ContainerRegistry"]

--- a/aws/extensions/runbook_image_push_result/extension.ftl
+++ b/aws/extensions/runbook_image_push_result/extension.ftl
@@ -14,11 +14,11 @@
 /]
 
 [#macro shared_extension_runbook_image_push_result_runbook_setup occurrence ]
-
-    [#local image = (_context.Links["image"])!{}]
-    [#if ! image?has_content]
+    [#local imageLink = (_context.Links["image"])!{}]
+    [#if ! imageLink?has_content ]
         [#return]
     [/#if]
+    [#local image = imageLink.State.Images[_context.Inputs["input:ImageId"]] ]
 
     [#assign _context = mergeObjects(
         _context,
@@ -27,9 +27,9 @@
                 "Value" : {
                     "Value": getJSON(
                         {
-                            "Name": image.State.Resources.image.Name,
-                            "RegistryType" : image.State.Resources.image.RegistryType,
-                            "Format" : image.Configuration.Solution.Format,
+                            "Name": (image.Name)!"",
+                            "RegistryType" : (image.RegistryType)!"",
+                            "Format" : (imageLink.Configuration.Solution.Format)!"",
                             "Reference": "__input:Reference__",
                             "Tag": "__input:Tag__",
                             "s3" : {

--- a/aws/extensions/runbook_registry_destination_image/extension.ftl
+++ b/aws/extensions/runbook_registry_destination_image/extension.ftl
@@ -15,16 +15,17 @@
 
 [#macro shared_extension_runbook_registry_destination_image_runbook_setup occurrence ]
 
-    [#local image = (_context.Links["image"])!{}]
-    [#if ! image?has_content]
+    [#local imageLink = (_context.Links["image"])!{}]
+    [#if ! imageLink?has_content ]
         [#return]
     [/#if]
+    [#local image = imageLink.State.Images[_context.Inputs["input:ImageId"]] ]
 
     [#assign _context = mergeObjects(
         _context,
         {
             "TaskParameters" : {
-                "DestinationImage" : ((image.State.Resources["image"].Registry)!"") + ":__input:Reference__"
+                "DestinationImage" : ((image.RegistryPath)!"") + ":__input:Reference__"
             }
         }
     )]

--- a/aws/extensions/runbook_registry_destination_image_tag/extension.ftl
+++ b/aws/extensions/runbook_registry_destination_image_tag/extension.ftl
@@ -15,16 +15,17 @@
 
 [#macro shared_extension_runbook_registry_destination_image_tag_runbook_setup occurrence ]
 
-    [#local image = (_context.Links["image"])!{}]
-    [#if ! image?has_content]
+    [#local imageLink = (_context.Links["image"])!{}]
+    [#if ! imageLink?has_content ]
         [#return]
     [/#if]
+    [#local image = imageLink.State.Images[_context.Inputs["input:ImageId"]] ]
 
     [#assign _context = mergeObjects(
         _context,
         {
             "TaskParameters" : {
-                "DestinationImage" : ((image.State.Resources["image"].Registry)!"") + ":__input:Tag__"
+                "DestinationImage" : ((image.Registry)!"") + ":__input:Tag__"
             }
         }
     )]

--- a/aws/extensions/runbook_registry_destination_object/extension.ftl
+++ b/aws/extensions/runbook_registry_destination_object/extension.ftl
@@ -15,17 +15,18 @@
 
 [#macro shared_extension_runbook_registry_destination_object_runbook_setup occurrence ]
 
-    [#local image = (_context.Links["image"])!{}]
-    [#if ! image?has_content]
+    [#local imageLink = (_context.Links["image"])!{}]
+    [#if ! imageLink?has_content ]
         [#return]
     [/#if]
+    [#local image = imageLink.State.Images[_context.Inputs["input:ImageId"]] ]
 
     [#assign _context = mergeObjects(
         _context,
         {
             "TaskParameters" : {
-                "BucketName" : ((image.State.Resources["image"].Location)!"")?replace("s3://", "")?keep_before("/"),
-                "Object": ((image.State.Resources["image"].Registry)!"")?replace("s3://", "")?keep_after("/")  + "/__input:Reference__/" +  (image.State.Resources["image"].ImageFileName)!""
+                "BucketName" : ((image.Location)!"")?replace("s3://", "")?keep_before("/"),
+                "Object": ((image.Registry)!"")?replace("s3://", "")?keep_after("/")  + "/__input:Reference__/" +  (image.ImageFileName)!""
             }
         }
     )]

--- a/aws/modules/baseline/module.ftl
+++ b/aws/modules/baseline/module.ftl
@@ -250,7 +250,7 @@
                                     "Types" : [ "string" ]
                                 },
                                 "DockerImage": {
-                                    "Description" : "Local docker iamge to push",
+                                    "Description" : "The name and tag of a local docker image that you want to push",
                                     "Types" : [ "string" ]
                                 },
                                 "Reference" : {
@@ -278,10 +278,15 @@
                                     "Types" : [ "string" ],
                                     "Default" : ""
                                 },
-                                "Instance" : {
-                                    "Description" : "Instance Id of the component to assign the image to",
+                                "Version" : {
+                                    "Description" : "Version Id of the component to assign the image to",
                                     "Types" : [ "string" ],
                                     "Default" : ""
+                                },
+                                "ImageId": {
+                                    "Description" : "The Id of the image in the component the image is for",
+                                    "Types" : [ "string" ],
+                                    "Default" : "default"
                                 }
                             },
                             "Steps" : {

--- a/aws/services/image/resource.ftl
+++ b/aws/services/image/resource.ftl
@@ -34,9 +34,10 @@
     [#-- Image Source Control --]
     [#switch (imageConfiguration.Source)!"none" ]
         [#case "link"]
-            [#local imageLink = getLinkTarget(occurrence, imageConfiguration.Source.Link)]
+            [#local imageLink = getLinkTarget(occurrence, imageConfiguration.Link, false )]
+            [#local image = {}]
             [#if imageLink?has_content]
-                [#local image = (asArray(imageLink.State.Images)?filter(x -> x.Format == imageFormat)[0])!{} ]
+                [#local image = ((imageLink.State.Images)?values?filter(x -> x.Format == imageFormat)[0])!{} ]
                 [#if !image?has_content ]
                     [@fatal
                         message="Link Image format doesn't match required image format"
@@ -47,8 +48,9 @@
                         }
                     /]
                 [/#if]
-                [#return { id: mergeObjects(image, {"Source": imageConfiguration.Source})}]
             [/#if]
+
+            [#return { id: mergeObjects(image, {"Source": imageConfiguration.Source})}]
             [#break]
 
         [#case "extension"]
@@ -57,6 +59,7 @@
             [#break]
 
         [#case "registry"]
+        [#case "Local"]
             [#-- Get Image Reference details --]
             [#local reference = getExistingReference(imageId)]
             [#local tag = getExistingReference(imageId, TAG_ATTRIBUTE_TYPE)]
@@ -250,7 +253,7 @@
                             resource.Name
                         )]
 
-                    [#local imageLocation = "${registryPath}:${resource.Reference}"]
+                    [#local imageLocation = "${registryPath}:${(resource.Reference)!''}"]
                     [#break]
             [/#switch]
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Align and fix up the image push runbooks based on the changes made in the definition of images
- Fix the baseline module to include version for the image component
- Add backwards compatibility support around the registry vs local naming of image sources

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This allows for images to be pushed to an image component using runbooks defined as part of the AWS provider. While implementing the overall Image support the runbooks were skipped from a development perspective so didn't quite align with what was expected

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

