### PR TITLE
fix: athena s3 policy

### DIFF
--- a/aws/components/baseline/state.ftl
+++ b/aws/components/baseline/state.ftl
@@ -144,6 +144,12 @@
                     }
                 },
                 "Outbound" : {
+                    "default" : {},
+                    "all" : s3AllPermission(bucketId) + s3AllEncryptionPolicy,
+                    "produce" : s3ProducePermission(bucketId) + s3AllEncryptionPolicy,
+                    "consume" : s3ConsumePermission(bucketId) + s3ReadEncryptionPolicy,
+                    "replicadestination" : s3ReplicaDestinationPermission(bucketId) + s3AllEncryptionPolicy,
+                    "replicasource" : {},
                     "datafeed" : s3KinesesStreamPermission(bucketId) + s3AllEncryptionPolicy
                 }
             }

--- a/aws/components/s3/state.ftl
+++ b/aws/components/s3/state.ftl
@@ -87,7 +87,7 @@
                     "replicadestination" : s3ReplicaDestinationPermission(id) + s3AllEncryptionPolicy,
                     "replicasource" : {},
                     "datafeed" : s3KinesesStreamPermission(id) + s3AllEncryptionPolicy
-            }
+                }
             }
         }
     ]

--- a/aws/services/athena/policy.ftl
+++ b/aws/services/athena/policy.ftl
@@ -1,11 +1,11 @@
 [#ftl]
 
 [#function formatAthenaWorkGroupArn workgroupName ]
-    [#return 
+    [#return
         formatRegionalArn(
             "athena",
             formatRelativePath(
-                "athena",
+                "workgroup",
                 workgroupName
             )
         )]
@@ -42,7 +42,7 @@
             "*",
             principals,
             conditions
-        ) + 
+        ) +
         getAthenaStatement(
             [
                 "athena:StartQueryExecution",
@@ -56,8 +56,8 @@
                 "athena:CreateNamedQuery",
                 "athena:GetQueryExecution",
                 "athena:BatchGetNamedQuery",
-                "athena:BatchGetQueryExecution", 
-                "athena:GetWorkGroup" 
+                "athena:BatchGetQueryExecution",
+                "athena:GetWorkGroup"
             ],
             workgroupName,
             principals,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Fixes the formatting of the athena workgroup policy to ensure that it works as expected
- Add support for linking to a baseline data bucket and using the same roles that you can on an S3 bucket

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Updating the athena workgroup formatting fixes an issue in the consume policy which prevented querying 
The s3 policy update allows services to access the bucket overall when they need to.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

