### PR TITLE
fix(ecs): handle secrets on ec2 tasks

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -715,6 +715,15 @@
             [#local executionRoleRequired = true]
         [/#if]
 
+        [#local containersHaveSecrets = ((containers?map(
+            x -> x.Links?values?map(
+                x -> x.Core.Type == SECRETSTORE_SECRET_COMPONENT_TYPE )
+            )[0])![])?seq_contains(true)]
+
+        [#if containersHaveSecrets ]
+            [#local executionRoleRequired = true ]
+        [/#if]
+
         [#local useCapacityProvider = true ]
 
         [#-- Provides warning for hosting updates this will still deploy but using fixed launch type --]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- add check for secret links on ec2 containers so that the execution role can be assigned

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When using the ECS secrets environment variable integration you need to assign an execution role to the ECS agent so that it can access the secrets. We need to do this for fargate containers but for EC2 tasks this isn't required by default. So we need to ensure that the execution role is added when secrets are found. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

