### PR TITLE
fix(s3): add delete marker replication handling

### DIFF
--- a/aws/services/s3/resource.ftl
+++ b/aws/services/s3/resource.ftl
@@ -290,6 +290,14 @@
     filter={}
     priority=0
 ]
+    [#local deleteMarkerReplication = "NotRequired" ]
+    [#if filter?has_content ]
+        [#if (filter.And.TagFilter)?? || (filter.TagFilter)?? ]
+            [#local deleteMarkerReplication = "Disabled"]
+        [#elseif (filter.And.Prefix)?? || (filter.Prefix)?? ]
+            [#local deleteMarkerReplication = "Enabled"]
+        [/#if]
+    [/#if]
 
     [#local destinationEncryptionConfiguration = {}]
     [#if encryptReplica && replicaKMSKeyId?has_content]
@@ -352,6 +360,13 @@
             "Priority",
             priority > 0,
             priority
+        ) +
+        attributeIfTrue(
+            "DeleteMarkerReplication",
+            deleteMarkerReplication != "NotRequired",
+            {
+                "Status": deleteMarkerReplication
+            }
         )
     ]
 [/#function]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- include the DeleteReplicationMarker option for v2 based replication on S3 replication

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
This is required when using the V2 replication via filters. Set to a fixed value at the moment as it can only be used in limited circumstances and replication requires versioning so the data is still retained. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

