### PR TITLE
fix(baselinedata): policy lookup on suboccurrence

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -89,7 +89,7 @@
                     "Policy" : []
                 }
             ]
-            [#local _context = invokeExtensions(occurrence, _context )]
+            [#local _context = invokeExtensions(subOccurrence, _context )]
 
             [#if ( deploymentSubsetRequired(BASELINE_COMPONENT_TYPE, true) && legacyS3 == false ) ||
                 ( deploymentSubsetRequired("s3") && legacyS3 == true) ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Fixes the lookup for S3 policy to use the suboccurrence instead of parent baseline occurrence

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Bucket policies couldn't be modified using the Extensions processing on baseline buckets

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

