### PR TITLE
feat(ecs): add support for container insights

### DIFF
--- a/aws/components/ecs/id.ftl
+++ b/aws/components/ecs/id.ftl
@@ -57,6 +57,18 @@
                     ]
                 }
             ]
+        },
+        {
+            "Names" : "Monitoring",
+            "Description" : "Enable monitoring services for the cluster",
+            "Children" : [
+                {
+                    "Names" : "ContainerInsights",
+                    "Description" : "Enable the ECS Container Insights service",
+                    "Types": BOOLEAN_TYPE,
+                    "Default" : true
+                }
+            ]
         }
     ]
 /]

--- a/aws/services/ecs/resource.ftl
+++ b/aws/services/ecs/resource.ftl
@@ -108,6 +108,7 @@
 [#macro createECSCluster
             id
             name=""
+            containerInsights=false
             tags={}
             dependencies=[] ]
 
@@ -118,6 +119,12 @@
             tags=tags
             dependencies=dependencies
             properties={
+                "ClusterSettings": [
+                    {
+                        "Name": "containerInsights",
+                        "Value": containerInsights?then("enabled", "disabled")
+                    }
+                ]
             } +
             attributeIfContent(
                 "ClusterName",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Enable container insights for the ECS cluster to add enhanced monitoring for the ECS services running on the cluster

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Container insights adds a heap of new monitoring features for containers to keep an eye on them and monitor them. As the containers are generally critical to management of a system we enable this by default

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

