### PR TITLE
feat(runbooks): shorter names and pull image

### DIFF
--- a/aws/extensions/runbook_image_pull_result/extension.ftl
+++ b/aws/extensions/runbook_image_pull_result/extension.ftl
@@ -1,0 +1,48 @@
+[#ftl]
+
+[@addExtension
+    id="runbook_image_pull_result"
+    aliases=[
+        "_runbook_image_pull_result"
+    ]
+    description=[
+        "generate a result output for an image pull"
+    ]
+    supportedTypes=[
+        RUNBOOK_STEP_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_runbook_image_pull_result_runbook_setup occurrence ]
+    [#local imageLink = (_context.Links["image"])!{}]
+    [#if ! imageLink?has_content ]
+        [#return]
+    [/#if]
+    [#local image = imageLink.State.Images[_context.Inputs["input:ImageId"]] ]
+
+    [#assign _context = mergeObjects(
+        _context,
+        {
+            "TaskParameters" : {
+                "Value" : {
+                    "Value": getJSON(
+                        {
+                            "Name": (image.Name)!"",
+                            "RegistryType" : (image.RegistryType)!"",
+                            "Format" : (imageLink.Configuration.Solution.Format)!"",
+                            "Reference": "__input:Reference__",
+                            "Tag": "__input:Tag__",
+                            "s3" : {
+                                "LocalPath" : "__input:ImagePath__",
+                                "RemotePath": "__output:registry_s3_pull:s3_path__"
+                            },
+                            "docker" : {
+                                "ImageName" : image.ImageLocation
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    )]
+[/#macro]

--- a/aws/extensions/runbook_registry_source_container/extension.ftl
+++ b/aws/extensions/runbook_registry_source_container/extension.ftl
@@ -1,0 +1,36 @@
+[#ftl]
+
+[@addExtension
+    id="runbook_registry_source_container"
+    aliases=[
+        "_runbook_registry_source_container"
+    ]
+    description=[
+        "Get the name of the container image to pull from the docker image registry"
+    ]
+    supportedTypes=[
+        RUNBOOK_STEP_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_runbook_registry_source_container_runbook_setup occurrence ]
+
+    [#local imageLink = (_context.Links["image"])!{}]
+    [#if ! imageLink?has_content ]
+        [#return]
+    [/#if]
+    [#local image = imageLink.State.Images[_context.Inputs["input:ImageId"]] ]
+
+    [#assign _context = mergeObjects(
+        _context,
+        {
+            "TaskParameters" : {
+                "Image": (_context.Inputs["input:Reference"] == "_latest")?then(
+                        image.ImageLocation,
+                        (ImageLocation)?replace(image.Reference, "/__input:Reference__/")
+                    )
+            }
+        }
+    )]
+
+[/#macro]

--- a/aws/extensions/runbook_registry_source_object/extension.ftl
+++ b/aws/extensions/runbook_registry_source_object/extension.ftl
@@ -1,0 +1,39 @@
+[#ftl]
+
+[@addExtension
+    id="runbook_registry_source_object"
+    aliases=[
+        "_runbook_registry_source_object"
+    ]
+    description=[
+        "Format the registry parameter details for s3 based object"
+    ]
+    supportedTypes=[
+        RUNBOOK_STEP_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_runbook_registry_source_object_runbook_setup occurrence ]
+
+    [#local imageLink = (_context.Links["image"])!{}]
+    [#if ! imageLink?has_content ]
+        [#return]
+    [/#if]
+    [#local image = imageLink.State.Images[_context.Inputs["input:ImageId"]] ]
+
+    [#assign _context = mergeObjects(
+        _context,
+        {
+            "TaskParameters" : {
+                "BucketName" : ((image.RegistryPath)!"")?replace("s3://", "")?keep_before("/"),
+                "Object": ((image.RegistryPath)!"")?replace("s3://", "")?keep_after("/")
+                    + (_context.Inputs["input:Reference"] == "_latest")?then(
+                        image.Reference,
+                        "/__input:Reference__/"
+                    )
+                    + (image.ImageFileName)!""
+            }
+        }
+    )]
+
+[/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Simplifies the names for the runbooks used in the baseline module
- adds a pull image runbook to pull images from the registry as required


## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Reducing the names to not include baseline explicitly makes it easy to remember/use common runbooks 
Adding the pull image runbook allows for transferring images between environments

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested localy

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

