### PR TITLE
fix(image): handle single level docker tags

### DIFF
--- a/aws/services/image/resource.ftl
+++ b/aws/services/image/resource.ftl
@@ -98,7 +98,12 @@
 
         [#case "ContainerRegistry"]
         [#case "containerregistry"]
-            [#local tag = (imageConfiguration["Source:ContainerRegistry"]["Image"])?keep_after_last("/")?keep_after(":")]
+            [#local image = imageConfiguration["Source:ContainerRegistry"]["Image"]]
+            [#local tag = image?contains("/")?then(
+                    image?keep_after_last("/"),
+                    image
+                )?keep_after(":")]
+
             [#local reference = tag?has_content?then(tag, "latest")]
             [#local resource = mergeObjects(
                 resource,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- handle finding the tag for a docker image when a single level name is used on the docker image

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When using ?keep_after_last if its not there it returns an empty string instead of the original string. So we need to check that it contains a / before stripping it

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

