### PR TITLE
refactor(waf): remove wafv1 support

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -974,7 +974,6 @@
                 bucketPrefix="WAF"
                 cloudwatchEnabled=true
                 cmkKeyId=kmsKeyId
-                version=solution.WAF.Version
                 loggingProfile=loggingProfile
             /]
 
@@ -985,7 +984,6 @@
                 deliveryStreamId=wafLogStreamingResources["stream"].Id
                 deliveryStreamArns=[ wafLogStreamingResources["stream"].Arn ]
                 regional=wafRegional
-                version=solution.WAF.Version
             /]
 
         [/#if]
@@ -999,14 +997,13 @@
                 securityProfile=securityProfile
                 occurrence=occurrence
                 regional=wafRegional
-                version=solution.WAF.Version
             /]
 
             [#if !cfResources?has_content]
                 [#-- Attach to API Gateway if no CloudFront distribution --]
                 [@createWAFAclAssociation
                     id=wafAclResources.association.Id
-                    wafaclId=(solution.WAF.Version == "v1")?then(wafAclResources.acl.Id, wafAclResources.acl.Arn)
+                    wafaclId=wafAclResources.acl.Arn
                     endpointId=
                         formatRegionalArn(
                             "apigateway",
@@ -1023,7 +1020,6 @@
                             }
                         )
                     dependencies=stageId
-                    version=solution.WAF.Version
                 /]
             [/#if]
         [/#if]

--- a/aws/components/apigateway/state.ftl
+++ b/aws/components/apigateway/state.ftl
@@ -281,14 +281,14 @@ created in either case.
         [#local wafResources =
             {
                 "acl" : {
-                    "Id" : formatDependentWAFAclId(solution.WAF.Version, apiId),
-                    "Arn": (solution.WAF.Version == "v2")?then({ "Fn::GetAtt" : [ formatDependentWAFAclId(solution.WAF.Version, apiId), "Arn" ] }, ""),
+                    "Id" : formatDependentWAFAclId(apiId),
+                    "Arn": { "Fn::GetAtt" : [ formatDependentWAFAclId(apiId), "Arn" ] },
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
-                    "Type" : AWS_WAF_ACL_RESOURCE_TYPE
+                    "Type" : AWS_WAFV2_ACL_RESOURCE_TYPE
                 },
                 "association" : {
-                    "Id" : formatDependentWAFAclAssociationId(solution.WAF.Version, apiId),
-                    "Type" : AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE
+                    "Id" : formatDependentWAFAclAssociationId(apiId),
+                    "Type" : AWS_WAFV2_ACL_ASSOCIATION_RESOURCE_TYPE
                 }
             } ]
 

--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -14,10 +14,9 @@
     [#local cfName              = resources["cf"].Name]
 
     [#local wafPresent          = isPresent(solution.WAF) ]
-    [#local wafVersion          = (solution.WAF.Version)!"v1" ]
     [#local wafAclId            = resources["wafacl"].Id]
     [#local wafAclArn           = resources["wafacl"].Arn]
-    [#local wafAclLink          = resources["wafacl"][(wafVersion == "v1")?then("Id","Arn")]]
+    [#local wafAclLink          = resources["wafacl"].Arn]
     [#local wafAclName          = resources["wafacl"].Name]
 
     [#local wafLogStreamingResources = resources["wafLogStreaming"]!{} ]
@@ -804,7 +803,6 @@
                 bucketPrefix="WAF"
                 cloudwatchEnabled=true
                 cmkKeyId=kmsKeyId
-                version=solution.WAF.Version
                 loggingProfile=loggingProfile
             /]
 
@@ -815,7 +813,6 @@
                 deliveryStreamId=wafLogStreamingResources["stream"].Id
                 deliveryStreamArns=[ wafLogStreamingResources["stream"].Arn ]
                 regional=false
-                version=solution.WAF.Version
             /]
         [/#if]
 
@@ -828,13 +825,12 @@
                 wafSolution=solution.WAF
                 securityProfile=securityProfile
                 occurrence=occurrence
-                version=solution.WAF.Version
             /]
         [/#if]
     [/#if]
 
     [#if deploymentSubsetRequired("epilogue", false)]
-        [#if invalidationPaths?has_content && getExistingReference(cfId)?has_content && (wafVersion == "v1") ]
+        [#if invalidationPaths?has_content && getExistingReference(cfId)?has_content ]
             [@addToDefaultBashScriptOutput
                 [
                     r'case ${STACK_OPERATION} in',

--- a/aws/components/cdn/state.ftl
+++ b/aws/components/cdn/state.ftl
@@ -57,10 +57,10 @@
                     "Type" : AWS_CLOUDFRONT_ORIGIN_RESOURCE_TYPE
                 },
                 "wafacl" : {
-                    "Id" : formatDependentWAFAclId(solution.WAF.Version, cfId),
-                    "Arn": (solution.WAF.Version == "v2")?then({ "Fn::GetAtt" : [ formatDependentWAFAclId(solution.WAF.Version, cfId), "Arn" ] }, ""),
+                    "Id" : formatDependentWAFAclId(cfId),
+                    "Arn": { "Fn::GetAtt" : [ formatDependentWAFAclId(cfId), "Arn" ]},
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
-                    "Type" : AWS_WAF_ACL_RESOURCE_TYPE
+                    "Type" : AWS_WAFV2_ACL_RESOURCE_TYPE
                 }
             } +
             attributeIfContent("wafLogStreaming", wafLogStreamResources),

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -1206,7 +1206,6 @@
                         bucketPrefix="WAF"
                         cloudwatchEnabled=true
                         cmkKeyId=kmsKeyId
-                        version=solution.WAF.Version
                         loggingProfile=loggingProfile
                     /]
 
@@ -1217,7 +1216,6 @@
                         deliveryStreamId=wafLogStreamingResources["stream"].Id
                         deliveryStreamArns=[ wafLogStreamingResources["stream"].Arn ]
                         regional=true
-                        version=solution.WAF.Version
                     /]
                 [/#if]
                 [#if wafAclResources?has_content ]
@@ -1231,13 +1229,11 @@
                             securityProfile=securityProfile
                             occurrence=occurrence
                             regional=true
-                            version=solution.WAF.Version
                         /]
                         [@createWAFAclAssociation
                             id=wafAclResources.association.Id
                             wafaclId=(solution.WAF.Version == "v1")?then(wafAclResources.acl.Id, wafAclResources.acl.Arn)
                             endpointId=getReference(lbId)
-                            version=solution.WAF.Version
                         /]
                     [/#if]
                 [/#if]

--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -68,14 +68,14 @@
         [#local wafResources =
             {
                 "acl" : {
-                    "Id" : formatDependentWAFAclId(solution.WAF.Version, id),
-                    "Arn": (solution.WAF.Version == "v2")?then({ "Fn::GetAtt" : [ formatDependentWAFAclId(solution.WAF.Version, id), "Arn" ] }, ""),
+                    "Id" : formatDependentWAFAclId(id),
+                    "Arn": { "Fn::GetAtt" : [ formatDependentWAFAclId(id), "Arn" ] },
                     "Name" : formatComponentWAFAclName(core.Tier, core.Component, occurrence),
-                    "Type" : AWS_WAF_ACL_RESOURCE_TYPE
+                    "Type" : AWS_WAFV2_ACL_RESOURCE_TYPE
                 },
                 "association" : {
                     "Id" : formatDependentWAFAclAssociationId(solution.WAF.Version, id),
-                    "Type" : AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE
+                    "Type" : AWS_WAFV2_ACL_ASSOCIATION_RESOURCE_TYPE
                 }
             } ]
     [/#if]

--- a/aws/services/kinesis/resource.ftl
+++ b/aws/services/kinesis/resource.ftl
@@ -175,7 +175,7 @@
     processorId=""
     cmkKeyId=""
     dependencies=""
-    version="v1"]
+]
 
     [#local logPrefix  = {
             "Fn::Join" : [

--- a/aws/services/waf/id.ftl
+++ b/aws/services/waf/id.ftl
@@ -6,15 +6,6 @@
 [#-- If they end up needing custom attributes, then individual --]
 [#-- reousrce type definitions will be needed here but for now --]
 [#-- AWs hasn't defined any of interest                        --]
-[#assign AWS_WAF_RULE_RESOURCE_TYPE = "wafRule" ]
-[#assign AWS_WAF_ACL_RESOURCE_TYPE = "wafAcl" ]
-[#assign AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE = "wafAssoc" ]
-[#assign AWS_WAF_IPSET_RESOURCE_TYPE = "wafIpSet" ]
-[#assign AWS_WAF_BYTE_MATCH_SET_RESOURCE_TYPE = "wafByteMatchSet" ]
-[#assign AWS_WAF_SIZE_CONSTRAINT_RESOURCE_TYPE = "wafSizeConstraintSet" ]
-[#assign AWS_WAF_SQL_INJECTION_RESOURCE_TYPE = "wafSqlInjectionMatchSet" ]
-[#assign AWS_WAF_XSS_MATCH_SET_RESOURCE_TYPE = "wafXssMatchSet" ]
-
 [#assign AWS_WAFV2_RULE_RESOURCE_TYPE = "wafv2Rule" ]
 [#assign AWS_WAFV2_ACL_RESOURCE_TYPE = "wafv2Acl" ]
 [#assign AWS_WAFV2_ACL_ASSOCIATION_RESOURCE_TYPE = "wafv2Assoc" ]
@@ -37,15 +28,7 @@
         [#case AWS_WAF_BYTE_MATCH_CONDITION_TYPE]
             [#return
                 {
-                    "ResourceType" : {
-                        "v1": {
-                            "hamlet": AWS_WAF_BYTE_MATCH_SET_RESOURCE_TYPE,
-                            "cfn" : {
-                                "global": "AWS::WAF::ByteMatchSet",
-                                "regional": "AWS::WAFRegional::ByteMatchSet"
-                            }
-                        }
-                    },
+                    "ResourceType" : {},
                     "TuplesAttributeKey" : "ByteMatchTuples"
                 }
             ]
@@ -64,17 +47,8 @@
             [#return
                 {
                     "ResourceType" : {
-                        "v1": {
-                            "hamlet": AWS_WAF_IPSET_RESOURCE_TYPE,
-                            "cfn": {
-                                "global" : "AWS::WAF::IPSet",
-                                "regional": "AWS::WAFRegional::ByteMatchSet"
-                            }
-                        },
-                        "v2": {
-                            "hamlet": AWS_WAFV2_IPSET_RESOURCE_TYPE,
-                            "cfn": "AWS::WAFv2::IPSet"
-                        }
+                        "hamlet": AWS_WAFV2_IPSET_RESOURCE_TYPE,
+                        "cfn": "AWS::WAFv2::IPSet"
                     },
                     "TuplesAttributeKey" : "IPSetDescriptors"
                 }
@@ -85,10 +59,8 @@
             [#return
                 {
                     "ResourceType": {
-                        "v2": {
-                            "hamlet": AWS_WAFV2_REGEX_PATTERN_SET_RESOURCE_TYPE,
-                            "cfn": "AWS::WAFv2::RegexPatternSet"
-                        }
+                        "hamlet": AWS_WAFV2_REGEX_PATTERN_SET_RESOURCE_TYPE,
+                        "cfn": "AWS::WAFv2::RegexPatternSet"
                     }
                 }
             ]
@@ -98,15 +70,7 @@
         [#case AWS_WAF_SIZE_CONSTRAINT_CONDITION_TYPE]
             [#return
                 {
-                    "ResourceType" : {
-                        "v1": {
-                            "hamlet": AWS_WAF_SIZE_CONSTRAINT_RESOURCE_TYPE,
-                            "cfn": {
-                                "global" : "AWS::WAF::SizeConstraintSet",
-                                "regional": "AWS::WAFRegional::SizeConstraintSet"
-                            }
-                        }
-                    },
+                    "ResourceType" : {},
                     "TuplesAttributeKey" : "SizeConstraints"
                 }
             ]
@@ -115,15 +79,7 @@
         [#case AWS_WAF_SQL_INJECTION_MATCH_CONDITION_TYPE]
             [#return
                 {
-                    "ResourceType" : {
-                        "v1": {
-                            "hamlet": AWS_WAF_SQL_INJECTION_RESOURCE_TYPE,
-                            "cfn": {
-                                "global": "AWS::WAF::SqlInjectionMatchSet",
-                                "regional": "AWS::WAFRegional::SqlInjectionMatchSet"
-                            }
-                        }
-                    },
+                    "ResourceType" : {},
                     "TuplesAttributeKey" : "SqlInjectionMatchTuples"
                 }
             ]
@@ -132,15 +88,7 @@
         [#case AWS_WAF_XSS_MATCH_CONDITION_TYPE]
             [#return
                 {
-                    "ResourceType" : {
-                        "v1": {
-                            "hamlet": AWS_WAF_XSS_MATCH_SET_RESOURCE_TYPE,
-                            "cfn": {
-                                "global": "AWS::WAF::XssMatchSet",
-                                "regional": "AWS::WAFRegional::XssMatchSet"
-                            }
-                        }
-                    },
+                    "ResourceType" : {},
                     "TuplesAttributeKey" : "XssMatchTuples"
                 }
             ]
@@ -149,14 +97,6 @@
 [/#function]
 
 [#list [
-    AWS_WAF_RULE_RESOURCE_TYPE,
-    AWS_WAF_ACL_RESOURCE_TYPE,
-    AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE,
-    AWS_WAF_IPSET_RESOURCE_TYPE,
-    AWS_WAF_BYTE_MATCH_SET_RESOURCE_TYPE,
-    AWS_WAF_SIZE_CONSTRAINT_RESOURCE_TYPE,
-    AWS_WAF_SQL_INJECTION_RESOURCE_TYPE,
-    AWS_WAF_XSS_MATCH_SET_RESOURCE_TYPE,
 
     AWS_WAFV2_RULE_RESOURCE_TYPE,
     AWS_WAFV2_ACL_RESOURCE_TYPE,
@@ -168,23 +108,6 @@
         provider=AWS_PROVIDER
         service=AWS_WEB_APPLICATION_FIREWALL_SERVICE
         resource=resource
-    /]
-[/#list]
-
-[#list [
-        AWS_WAF_BYTE_MATCH_SET_RESOURCE_TYPE,
-        AWS_WAF_SIZE_CONSTRAINT_RESOURCE_TYPE,
-        AWS_WAF_SQL_INJECTION_RESOURCE_TYPE,
-        AWS_WAF_XSS_MATCH_SET_RESOURCE_TYPE
-    ] as wafV1matchSetResourceType ]
-        [@addOutputMapping
-        provider=AWS_PROVIDER
-        resourceType=wafV1matchSetResourceType
-        mappings={
-            REFERENCE_ATTRIBUTE_TYPE : {
-                "UseRef" : true
-            }
-        }
     /]
 [/#list]
 
@@ -207,8 +130,8 @@
     /]
 [/#list]
 
-[#function formatDependentWAFConditionId version type resourceId extensions...]
-    [#local matchSetResourceType = (getWAFConditionSetMappings(type)["ResourceType"][version]["hamlet"])!"" ]
+[#function formatDependentWAFConditionId type resourceId extensions...]
+    [#local matchSetResourceType = (getWAFConditionSetMappings(type)["ResourceType"]["hamlet"])!"" ]
     [#return
         formatDependentResourceId(
             matchSetResourceType?has_content?then(
@@ -221,32 +144,23 @@
     ]
 [/#function]
 
-[#function formatDependentWAFRuleId version resourceId extensions...]
+[#function formatDependentWAFRuleId resourceId extensions...]
     [#return formatDependentResourceId(
-            (version == "v2")?then(
-                AWS_WAFV2_RULE_RESOURCE_TYPE,
-                AWS_WAF_RULE_RESOURCE_TYPE
-            ),
+            AWS_WAFV2_RULE_RESOURCE_TYPE,
             resourceId,
             extensions)]
 [/#function]
 
-[#function formatDependentWAFAclId version resourceId extensions...]
+[#function formatDependentWAFAclId resourceId extensions...]
     [#return formatDependentResourceId(
-            (version == "v2")?then(
-                AWS_WAFV2_ACL_RESOURCE_TYPE,
-                AWS_WAF_ACL_RESOURCE_TYPE
-            ),
+            AWS_WAFV2_ACL_RESOURCE_TYPE
             resourceId,
             extensions)]
 [/#function]
 
-[#function formatDependentWAFAclAssociationId version resourceId extensions...]
+[#function formatDependentWAFAclAssociationId resourceId extensions...]
     [#return formatDependentResourceId(
-        (version == "v2")?then(
-            AWS_WAFV2_ACL_ASSOCIATION_RESOURCE_TYPE,
-            AWS_WAF_ACL_ASSOCIATION_RESOURCE_TYPE
-        ),
+        AWS_WAFV2_ACL_ASSOCIATION_RESOURCE_TYPE
         resourceId,
         extensions
     )]

--- a/awstest/modules/apigateway/module.ftl
+++ b/awstest/modules/apigateway/module.ftl
@@ -378,4 +378,124 @@
         }
     /]
 
+    [#-- WAF --]
+    [@loadModule
+        definitions={
+            "appXapigatewaywaf" : {
+                "swagger": "2.0",
+                "info": {
+                    "version": "v1.0.0",
+                    "title": "Proxy",
+                    "description": "Pass all requests through to the implementation."
+                },
+                "paths": {
+                    "/{proxy+}": {
+                        "x-amazon-apigateway-any-method": {
+                        }
+                    }
+                },
+                "definitions": {
+                    "Empty": {
+                        "type": "object",
+                        "title": "Empty Schema"
+                    }
+                }
+            }
+        }
+        settingSets=[
+            {
+                "Type" : "Builds",
+                "Scope" : "Products",
+                "Namespace" : "mockedup-integration-app-apigatewaywaf-apigateway",
+                "Settings" : {
+                    "COMMIT" : "123456789#MockCommit#"
+                }
+            },
+            {
+                "Type" : "Settings",
+                "Scope" : "Products",
+                "Namespace" : "mockedup-integration-app-apigatewaywaf-apigateway",
+                "Settings" : {
+                    "apigw": {
+                        "Internal": true,
+                        "Value": {
+                            "Type": "lambda",
+                            "Proxy": false,
+                            "BinaryTypes": ["*/*"],
+                            "ContentHandling": "CONVERT_TO_TEXT",
+                            "Variable": "LAMBDA_API_LAMBDA"
+                        }
+                    }
+                }
+            }
+        ]
+        blueprint={
+            "Tiers" : {
+                "app" : {
+                    "Components" : {
+                        "apigatewaywaf" : {
+                            "deployment:Unit": "aws-apigateway",
+                            "Type": "apigateway",
+                            "Certificate": {},
+                            "Image" : {
+                                "Source" : "none"
+                            },
+                            "WAF": {
+                                "Enabled": true
+                            },
+                            "IPAddressGroups" : [ "_global" ],
+                            "Profiles" : {
+                                "Testing" : [ "apigatewaywaf" ]
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "apigatewaywaf" : {
+                    "apigateway" : {
+                        "TestCases" : [ "apigatewaywaf" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
+                    }
+                }
+            },
+            "TestCases" : {
+                "apigatewaywaf" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "RestApi" : {
+                                    "Name" : "apigatewayXappXapigatewaywaf",
+                                    "Type" : "AWS::ApiGateway::RestApi"
+                                },
+                                "WafACL": {
+                                    "Name": "wafv2AclXapigatewayXappXapigatewaywaf",
+                                    "Type": "AWS::WAFv2::WebACL"
+                                },
+                                "WafAssoc" : {
+                                    "Name": "wafv2AssocXapigatewayXappXapigatewaywaf",
+                                    "Type" : "AWS::WAFv2::WebACLAssociation"
+                                }
+                            },
+                            "Output" : [
+                                "apigatewayXappXapigatewaywaf"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "WafDepends" : {
+                                    "Path"  : "Resources.wafv2AssocXapigatewayXappXapigatewaywaf.DependsOn[0]",
+                                    "Value" : "apiStageXappXapigatewaywaf"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+
 [/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Removes the option to set the version on WAF configurations
- Defaults all resources to use wafv2 across all implementations of waf

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Simplifies the configuration process allows for enabling more of the features available in WAFv2 and aligns with recommended practice from AWS. 

Migrations have been tested successfully from wafv1 to wafv2 without impact on the services so this shouldn't cause any issues with users going forward

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

