### PR TITLE
fix: remove version on setupWAFRule call

### DIFF
--- a/aws/services/waf/resource.ftl
+++ b/aws/services/waf/resource.ftl
@@ -328,8 +328,7 @@
                     valueSet=valueSet
                     regional=regional
                     rateKey=rule.RateKey!""
-                    rateLimit=rule.RateLimit!""
-                    version=version /]
+                    rateLimit=rule.RateLimit!""/]
             [/#if]
 
             [#local v2OverrideAction = ""]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Remove redundant version being passed to setupWAFRule, causing failures

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Builds of CDN are failing 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Built locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

