### PR TITLE
refactor(mta): move to using cfn for config set event destination

### DIFF
--- a/aws/components/mta/state.ftl
+++ b/aws/components/mta/state.ftl
@@ -45,6 +45,7 @@
                 {
                     "Attributes" : {
                         "REGION" : getRegion(),
+                        "MAIL_DOMAIN" : formatDomainName(primaryDomainObject),
                         "FROM" : hostName + "@" + formatDomainName(primaryDomainObject),
                         "ENDPOINT" : formatDomainName("email", getRegion(), "amazonaws", "com")
                     },
@@ -134,6 +135,22 @@
         [#break]
 
         [#case "send"]
+
+            [#local configSetDestinations = {}]
+
+            [#list occurrence.Configuration.Solution.Links as linkId,link ]
+                [#local configSetDestinations = mergeObjects(
+                    configSetDestinations,
+                    {
+                        linkId : {
+                            "Id": formatResourceId(AWS_SES_CONFIGSET_DEST_RESOURCE_TYPE, occurrence.Core.Id, linkId),
+                            "Name": formatName(occurrence.Core.RawFullName, linkId),
+                            "Type" : AWS_SES_CONFIGSET_DEST_RESOURCE_TYPE
+                        }
+                    }
+                )]
+            [/#list]
+
             [#assign componentState +=
                 {
                     "Resources" : {
@@ -141,7 +158,8 @@
                             "Id" : formatResourceId(AWS_SES_CONFIGSET_RESOURCE_TYPE, core.Id),
                             "Name" : occurrence.Core.FullName,
                             "Type" : AWS_SES_CONFIGSET_RESOURCE_TYPE
-                        }
+                        },
+                        "configSetDestinations" : configSetDestinations
                     }
                 }
             ]

--- a/aws/services/ses/id.ftl
+++ b/aws/services/ses/id.ftl
@@ -51,13 +51,3 @@
     service=AWS_SIMPLE_EMAIL_SERVICE
     resource=AWS_SES_CONFIGSET_DEST_RESOURCE_TYPE
 /]
-
-[#function formatSESConfigSetId ]
-    [#return formatResourceId(AWS_SES_CONFIGSET_RESOURCE_TYPE) ]
-[/#function]
-
-[#function formatSESConfigDestinationId extensions...]
-    [#return formatResourceId(
-                AWS_SES_CONFIGSET_DEST_RESOURCE_TYPE,
-                extensions)]
-[/#function]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
- Moves from CLI to cloudformation resource for adding the configuration set event destination in the MTA component.
- Adds the MAIL_DOMAIN as an attribute so that it can be used by components to know their expected domain

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Removes the use of the CLI and allows for streamlined management of the mta component through cfn

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and on active deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

