### PR TITLE
feat(module): add ses based mail sender with log

### DIFF
--- a/aws/extensions/lambda_ses_mail_sender_eventlog/extension.ftl
+++ b/aws/extensions/lambda_ses_mail_sender_eventlog/extension.ftl
@@ -1,0 +1,51 @@
+[#ftl]
+
+[@addExtension
+    id="lambda_ses_mail_sender_eventlog"
+    aliases=[
+        "_lambda_ses_mail_sender_eventlog"
+    ]
+    description=[
+        "Saves an SES Send email event to a provided S3 bucket location"
+    ]
+    supportedTypes=[
+        LAMBDA_FUNCTION_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_lambda_ses_mail_sender_eventlog_deployment_setup occurrence ]
+
+    [@DefaultLinkVariables enabled=false /]
+    [@DefaultCoreVariables enabled=false /]
+    [@DefaultEnvironmentVariables enabled=false /]
+    [@DefaultBaselineVariables enabled=false /]
+
+    [@lambdaAttributes
+        zipFile=[
+            r'import boto3',
+            r'import json',
+            r'import os',
+            r'from uuid import uuid4',
+            r'from urllib.parse import urlparse',
+            r'',
+            r'client = boto3.client("s3")',
+            r'S3_URL = os.environ["S3_URL"]',
+            r'',
+            r'def lambda_handler(event, context):',
+            r'  """',
+            r'  Logs email events to an S3 bucket',
+            r'  """',
+            r'  for record in event["Records"]:',
+            r'      msg = json.loads(record["body"])',
+            r'      s3_key = urlparse(S3_URL).path',
+            r'      s3_key = s3_key + "/" if not s3_key.endswith("/") and s3_key != "" else s3_key',
+            r'      s3_key = f"{s3_key}SES/SendEvent/' + r"{msg['mail']['sendingAccountId']}/{msg['mail']['source']}/{str(uuid4())}.json" +r'"',
+            r'      client.put_object(',
+            r'          Bucket=urlparse(S3_URL).hostname,',
+            r'          Key=s3_key,',
+            r'          Body=json.dumps(msg).encode("utf-8")',
+            r'      )'
+        ]
+    /]
+
+[/#macro]

--- a/aws/extensions/lambda_ses_mail_sender_notify/extension.ftl
+++ b/aws/extensions/lambda_ses_mail_sender_notify/extension.ftl
@@ -1,0 +1,70 @@
+[#ftl]
+
+[@addExtension
+    id="lambda_ses_mail_sender_notify"
+    aliases=[
+        "_lambda_ses_mail_sender_notify"
+    ]
+    description=[
+        "Sends an SES send event through to a set of nominated recipients"
+    ]
+    supportedTypes=[
+        LAMBDA_FUNCTION_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_lambda_ses_mail_sender_notify_deployment_setup occurrence ]
+
+    [@DefaultLinkVariables enabled=false /]
+    [@DefaultCoreVariables enabled=false /]
+    [@DefaultEnvironmentVariables enabled=false /]
+    [@DefaultBaselineVariables enabled=false /]
+
+    [@lambdaAttributes
+        zipFile=[
+            r'import boto3',
+            r'import json',
+            r'import os',
+            r'',
+            r'client = boto3.client("ses")',
+            r'SENDER_ADDRESS = os.environ["SENDER_ADDRESS"]',
+            r'REPLY_TO_ADDRESS = os.environ.get("REPLY_TO_ADDRESS", SENDER_ADDRESS)',
+            r'',
+            r'BOUNCE_ADDRESSES = os.environ.get("BOUNCE_ADDRESSES","").split(",")',
+            r'',
+            r'def lambda_handler(event, context):',
+            r'  """',
+            r'  Sends bounce or complaint emails to nominated addresses',
+            r'  """',
+            r'  for record in event["Records"]:',
+            r'      msg = json.loads(record["body"])',
+            r'      try:',
+            r'          email_subject = msg["mail"]["commonHeaders"]["subject"]',
+            r'      except KeyError:',
+            r'          email_subject = "Subject Unknown"',
+            r'      event_type = msg["eventType"]',
+            r'      subject = f"Email Event - {event_type} - {email_subject}"',
+            r'      body = json.dumps(msg, indent=2)',
+            r'',
+            r'      if event_type in ["Bounce","Complaint"] and BOUNCE_ADDRESSES:',
+            r'          client.send_email(',
+            r'              Source=SENDER_ADDRESS,',
+            r'              Destination={',
+            r'                  "ToAddresses": BOUNCE_ADDRESSES',
+            r'              },',
+            r'              Message={',
+            r'                  "Subject": {',
+            r'                      "Data": subject',
+            r'                  },',
+            r'                  "Body": {',
+            r'                      "Text" : {',
+            r'                          "Data": body',
+            r'                      }',
+            r'                  }',
+            r'              },',
+            r'              ReplyToAddresses=[ REPLY_TO_ADDRESS ]',
+            r'          )'
+        ]
+    /]
+
+[/#macro]

--- a/aws/modules/ses_mail_sender/module.ftl
+++ b/aws/modules/ses_mail_sender/module.ftl
@@ -1,0 +1,222 @@
+[#ftl]
+
+[@addModule
+    name="ses_mail_sender"
+    description="General helper runbooks to manage S3 buckets"
+    provider=AWS_PROVIDER
+    properties=[
+        {
+            "Names" : "tier",
+            "Type" : STRING_TYPE,
+            "Description" : "The tier the user will be part of",
+            "Default" : "msg"
+        },
+        {
+            "Names" : "componentPrefix",
+            "Type" : STRING_TYPE,
+            "Description" : "The name of the smtp user component",
+            "Default" : "mail"
+        },
+        {
+            "Names" : "deploymentUnitPrefix",
+            "Type" : STRING_TYPE,
+            "Description" : "The deployment unit for the private bastion",
+            "Default" : "mail"
+        },
+        {
+            "Names" : "logToOps",
+            "Type" : BOOLEAN_TYPE,
+            "Description" : "Send all events to S3 in the OpsData Bucket",
+            "Default" : true
+        },
+        {
+            "Names" : "bounceAddresses",
+            "Type" : ARRAY_OF_STRING_TYPE,
+            "Description": "A set of email addresses that should be sent bounce/complaint events",
+            "Default" : []
+        },
+        {
+            "Names" : "senderAddress",
+            "Type" : STRING_TYPE,
+            "Description" : "The email address to use when sending emails",
+            "Default" : "mailer@__attribute:mta:MAIL_DOMAIN__"
+        }
+    ]
+/]
+
+[#macro aws_module_ses_mail_sender tier componentPrefix deploymentUnitPrefix logToOps bounceAddresses senderAddress ]
+
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                tier: {
+                    "Components": {
+                        "${componentPrefix}-relay": {
+                            "Type": "mta",
+                            "Direction": "send",
+                            "deployment:Unit": "${deploymentUnitPrefix}-relay",
+                            "Certificate": {},
+                            "Rules": {
+                                "log": {
+                                    "Action": "log",
+                                    "EventTypes": [
+                                        "reject",
+                                        "bounce",
+                                        "complaint",
+                                        "delivery",
+                                        "send"
+                                    ],
+                                    "Conditions": {
+                                        "Senders": [""]
+                                    },
+                                    "Links": {
+                                        "mail_topic": {
+                                            "Tier": tier,
+                                            "Component": "${componentPrefix}-topic",
+                                            "Version": ""
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "${componentPrefix}-topic": {
+                            "Type": "topic",
+                            "Encrypted" : true,
+                            "deployment:Unit": "${deploymentUnitPrefix}-topic",
+                            "Links" : {
+                                "mail_relay": {
+                                    "Tier": tier,
+                                    "Component": "${componentPrefix}-relay",
+                                    "Direction": "inbound",
+                                    "Role": "invoke"
+                                }
+                            },
+                            "Subscriptions": {
+                                "forward": {
+                                    "RawMessageDelivery": true,
+                                    "Links": {
+                                        "mail_relay": {
+                                            "Enabled": false
+                                        },
+                                        "notify_queue": {
+                                            "Tier": tier,
+                                            "Component": "${componentPrefix}-queue",
+                                            "Instance": "notify"
+                                        },
+                                        "events_queue": {
+                                            "Tier": tier,
+                                            "Component": "${componentPrefix}-queue",
+                                            "Instance": "events"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "${componentPrefix}-queue" : {
+                            "Type": "sqs",
+                            "deployment:Unit": "${deploymentUnitPrefix}-queue",
+                            "DeadLetterQueue": {
+                                "Enabled": true,
+                                "MaxReceives": 5
+                            },
+                            "Encryption": {
+                                "Enabled": true
+                            },
+                            "Instances": {
+                                "notify": {},
+                                "events": {}
+                            },
+                            "Links": {
+                                "topic": {
+                                    "Tier": tier,
+                                    "Component": "${componentPrefix}-topic",
+                                    "Instance": "",
+                                    "Direction": "inbound",
+                                    "Role": "invoke"
+                                }
+                            }
+                        },
+                        "${componentPrefix}-handler": {
+                            "Type": "lambda",
+                            "deployment:Unit": "${deploymentUnitPrefix}-handler",
+                            "Functions": {
+                                "notify": {
+                                    "RunTime": "python3.9",
+                                    "Memory": 128,
+                                    "Encrypted": true,
+                                    "Handler": "index.lambda_handler",
+                                    "Extensions": ["_lambda_ses_mail_sender_notify"],
+                                    "PredefineLogGroup": true,
+                                    "Image": {
+                                        "Source": "extension",
+                                        "source:extension": {
+                                            "CommentCharacters": "#",
+                                            "IncludeRunId": true
+                                        }
+                                    },
+                                    "Settings" : {
+                                        "SENDER_ADDRESS" : {
+                                            "Value": senderAddress
+                                        },
+                                        "BOUNCE_ADDRESSES":{
+                                            "Value": bounceAddresses?join(",")
+                                        }
+                                    },
+                                    "Links": {
+                                        "mta": {
+                                            "Tier": tier,
+                                            "Component": "${componentPrefix}-relay",
+                                            "Instance": "",
+                                            "Version": ""
+                                        },
+                                        "queue": {
+                                            "Tier": tier,
+                                            "Component": "${componentPrefix}-queue",
+                                            "Instance": "notify",
+                                            "Role": "event"
+                                        }
+                                    }
+                                },
+                                "events": {
+                                    "RunTime": "python3.9",
+                                    "Memory": 128,
+                                    "Encrypted": true,
+                                    "Handler": "index.lambda_handler",
+                                    "Extensions": ["_lambda_ses_mail_sender_eventlog"],
+                                    "PredefineLogGroup": true,
+                                    "Image": {
+                                        "Source": "extension",
+                                        "source:extension": {
+                                            "CommentCharacters": "#",
+                                            "IncludeRunId": true
+                                        }
+                                    },
+                                    "Settings" : {
+                                        "S3_URL" : {
+                                            "Value": logToOps?then("s3://__baseline:OpsData:NAME__", "")
+                                        }
+                                    },
+                                    "Links": {
+                                        "queue": {
+                                            "Tier": tier,
+                                            "Component": "${componentPrefix}-queue",
+                                            "Instance": "events",
+                                            "Role": "event"
+                                        },
+                                        "baseline_ops": {
+                                            "Enabled" : logToOps,
+                                            "Tier": tier,
+                                            "Component": "baseline",
+                                            "SubComponent": "opsdata",
+                                            "Role": "produce"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    /]
+[/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a module which configures a mail sending service using SES 
- Logging to the Ops Bucket for all send events 
- An email notification service for Complaint or Bounce messages that will be sent to a nominated address 
- SNS/SQS based queue workers for processing the log data


## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
SES doesn't log information about sent emails by default, this adds a process similar to most other AWS services which will deliver events to our ops bucket and also notify for more critical services. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested on active deployment in development

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

