### PR TITLE
feat(module): add ses send events to service logs

### DIFF
--- a/aws/modules/aws_service_log_db/module.ftl
+++ b/aws/modules/aws_service_log_db/module.ftl
@@ -797,6 +797,75 @@
                                             }
                                         }
                                     }
+                                },
+                                "ses_send_events": {
+                                    "Source": {
+                                        "Link" : {
+                                            "Tier": "mgmt",
+                                            "Component": "baseline",
+                                            "SubComponent": "opsdata",
+                                            "Instance": "",
+                                            "Version": "",
+                                            "Type": "baselinedata"
+                                        },
+                                        "Prefix": "SES/SendEvent/"
+                                    },
+                                    "Layout": {
+                                        "Columns": {
+                                            "eventType": {
+                                                "Type": "string"
+                                            },
+                                            "complaint": {
+                                                "Type": "struct<arrivaldate:string,complainedrecipients:array<struct<emailaddress:string>>,complaintfeedbacktype:string,feedbackid:string,timestamp:string,useragent:string>"
+                                            },
+                                            "bounce": {
+                                                "Type": "struct<bouncedrecipients:array<struct<action:string,diagnosticcode:string,emailaddress:string,status:string>>,bouncesubtype:string,bouncetype:string,feedbackid:string,reportingmta:string,timestamp:string>"
+                                            },
+                                            "mail": {
+                                                "Type": "struct<timestamp:string,source:string,sourceArn:string,sendingAccountId:string,messageId:string,destination:string,headersTruncated:boolean,headers:array<struct<name:string,value:string>>,commonHeaders:struct<from:array<string>,to:array<string>,messageId:string,subject:string>,tags:struct<ses_configurationset:string,ses_source_ip:string,ses_outgoing_ip:string,ses_from_domain:string,ses_caller_identity:string>>"
+                                            },
+                                            "send": {
+                                                "Type": "string"
+                                            },
+                                            "delivery": {
+                                                "Type": "struct<processingtimemillis:int,recipients:array<string>,reportingmta:string,smtpresponse:string,timestamp:string>"
+                                            },
+
+                                            "open": {
+                                                "Type": "struct<ipaddress:string,timestamp:string,userAgent:string>"
+                                            },
+                                            "reject": {
+                                                "Type": "struct<reason:string>"
+                                            },
+                                            "click": {
+                                                "Type": "struct<ipAddress:string,timestamp:string,userAgent:string,link:string>"
+                                            }
+                                        }
+                                    },
+                                    "Format" : {
+                                        "Input": "org.apache.hadoop.mapred.TextInputFormat",
+                                        "Output": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                                        "Serialisation": {
+                                            "Library": "org.openx.data.jsonserde.JsonSerDe",
+                                            "Parameters": {
+                                                "mapping.ses_configurationset": {
+                                                    "Value": "ses:configuration-set"
+                                                },
+                                                "mapping.ses_source_ip": {
+                                                    "Value": "ses:source-ip"
+                                                },
+                                                "mapping.ses_from_domain": {
+                                                    "Value": "ses:from-domain"
+                                                },
+                                                "mapping.ses_caller_identity": {
+                                                    "Value": "ses:caller-identity"
+                                                },
+                                                "mapping.ses_outgoing_ip": {
+                                                    "Value": "ses:outgoing-ip"
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the saved SES send event logs into the service log athena table

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Aligning with https://github.com/hamlet-io/engine-plugin-aws/pull/712 this would allow for easily querying and searching SES based send events to diagnose emails sent from systems

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

