### PR TITLE
feat: add smtp endpoint address to send mta

### DIFF
--- a/aws/components/mta/state.ftl
+++ b/aws/components/mta/state.ftl
@@ -47,7 +47,8 @@
                         "REGION" : getRegion(),
                         "MAIL_DOMAIN" : formatDomainName(primaryDomainObject),
                         "FROM" : hostName + "@" + formatDomainName(primaryDomainObject),
-                        "ENDPOINT" : formatDomainName("email", getRegion(), "amazonaws", "com")
+                        "ENDPOINT" : formatDomainName("email", getRegion(), "amazonaws", "com"),
+                        "SMTP_ENDPOINT" : formatDomainName("email-smtp", getRegion(), "amazonaws", "com")
                     },
                     "Roles" : {
                         "Outbound" : {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds an SMTP_ENDPOINT attribute on the send MTA component to save having to remember or look it up when the SMTP service needs to be used

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The current ENDPOINT attribute maps to the standard API service not the SMTP service

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

