### PR TITLE
feat: add support for allExcept on cachepolicy

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -186,6 +186,7 @@
             cookieNames=subSolution.Cookies
             headerNames=subSolution.Headers
             queryStringNames=subSolution.QueryParams
+            queryStringExclude=subSolution.QueryParamExclude
             compressionProtocols=subSolution.CompressionEncoding
         /]
 

--- a/aws/services/cf/resource.ftl
+++ b/aws/services/cf/resource.ftl
@@ -295,6 +295,7 @@
         cookieNames=[]
         headerNames=[]
         queryStringNames=[]
+        queryStringExclude=false
         compressionProtocols=[]  ]
 
     [@cfResource
@@ -336,7 +337,7 @@
                             "QueryStringBehavior" : queryStringNames?has_content?then(
                                 queryStringNames?seq_contains("_all")?then(
                                     "all",
-                                    "whitelist"
+                                    queryStringExclude?then("allExcept","whitelist")
                                 ),
                                 "none"
                             )


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
Add new QueryParamExclude option to access allExcept querystring policy option

## Motivation and Context
Needed to access allExcept querystring policy option

## How Has This Been Tested?
local build

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/2096

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- Set QueryParamExclude to true to access allExcept (default = false)

