### PR TITLE
feat(baseline): cmk access for cloudwatch service

### DIFF
--- a/aws/extensions/cmk_cloudwatch_access/extension.ftl
+++ b/aws/extensions/cmk_cloudwatch_access/extension.ftl
@@ -1,0 +1,42 @@
+[#ftl]
+
+[@addExtension
+    id="cmk_cloudwatch_access"
+    aliases=[
+        "_cmk_cloudwatch_access"
+    ]
+    description=[
+        "Grants access to a CMK from the CloudWatch Service"
+    ]
+    supportedTypes=[
+        BASELINE_KEY_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_cmk_cloudwatch_access_deployment_setup occurrence ]
+
+    [@Policy
+        [
+            getPolicyStatement(
+                [
+                    "kms:GenerateDataKey*",
+                    "kms:Decrypt"
+                ],
+                "*"
+                {
+                    "Service" : "cloudwatch.amazonaws.com"
+                },
+                {
+                    "StringEquals": {
+                        "aws:SourceAccount" : {
+                            "Ref": "AWS::AccountId"
+                        }
+                    }
+                },
+                true,
+                "CloudWatch Service Principal Access"
+            )
+        ]
+    /]
+
+[/#macro]

--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -174,7 +174,8 @@
                                     "_cmk_ses_access",
                                     "_cmk_cloudfront_access",
                                     "_cmk_sns_access",
-                                    "_cmk_sqs_access"
+                                    "_cmk_sqs_access",
+                                    "_cmk_cloudwatch_access"
                                 ]
                             },
                             "oai": {

--- a/aws/modules/baseline/module.ftl
+++ b/aws/modules/baseline/module.ftl
@@ -81,7 +81,8 @@
                                             "_cmk_ses_access",
                                             "_cmk_cloudfront_access",
                                             "_cmk_sns_access",
-                                            "_cmk_sqs_access"
+                                            "_cmk_sqs_access",
+                                            "_cmk_cloudwatch_access"
                                         ]
                                     },
                                     "oai": {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Allows the cloudwatch service to access CMKs
- Used for sending alerts via CMK encrypted SNS topics

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Aligns with the recommended security practices of encrypting any data at rest where possible including services like SNS

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

