### PR TITLE
feat(mta): Add support for bounces on receive

### DIFF
--- a/aws/services/ses/resource.ftl
+++ b/aws/services/ses/resource.ftl
@@ -96,6 +96,7 @@
         configSetId
         matchingEventTypes
         destinationType
+        enabled=true
         name=""
         topicId=""
         firehoseId=""
@@ -104,6 +105,7 @@
 ]
 
     [#local eventDestination = {
+            "Enabled": enabled,
             "MatchingEventTypes": matchingEventTypes
         } +
         attributeIfContent(
@@ -216,6 +218,22 @@
                 "LambdaAction" : {
                     "FunctionArn" : getArn(lambdaId),
                     "InvocationType" : valueIfTrue("Event", event, "RequestResponse")
+                } +
+                attributeIfContent("TopicArn", topicIdOrArn, getArn(topicIdOrArn))
+            }
+        ]
+    ]
+[/#function]
+
+[#function getSESReceiptBounceAction sender message smtpyReplyCode statusCode topicIdOrArn="" ]
+    [#return
+        [
+            {
+                "BounceAction" : {
+                    "Message" : message,
+                    "Sender" : sender,
+                    "SmtpReplyCode" : smtpyReplyCode,
+                    "StatusCode": statusCode
                 } +
                 attributeIfContent("TopicArn", topicIdOrArn, getArn(topicIdOrArn))
             }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds SES receive rule for sending bounces on a rules based approach
- Fixes an issue where a stop action wouldn't be added if a topic wasn't found for the SES receive rule
- Fixes an issue with send events that would disable forwarding by default !???

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Bounces are used to notify mail senders that an email couldn't be accepted. This reduces email loads as or tells mail servers to back off when under load. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/2099

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

