### PR TITLE
fix: handle cmk based encryption at rest

### DIFF
--- a/aws/components/sqs/state.ftl
+++ b/aws/components/sqs/state.ftl
@@ -115,7 +115,7 @@
                                         "kms:GenerateDataKey",
                                         "kms:Decrypt"
                                     ],
-                                    baselineIds["Encryption"],
+                                    (baselineIds["Encryption"])!"",
                                     getExistingReference(id, REGION_ATTRIBUTE_TYPE)
                                 ),
                                 []
@@ -126,7 +126,7 @@
                                     [
                                         "kms:Decrypt"
                                     ],
-                                    baselineIds["Encryption"],
+                                    (baselineIds["Encryption"])!"",
                                     getExistingReference(id, REGION_ATTRIBUTE_TYPE)
                                 ),
                                 []

--- a/aws/components/topic/state.ftl
+++ b/aws/components/topic/state.ftl
@@ -41,7 +41,7 @@
                                 (solution.Encrypted)?then(
                                     snsEncryptionStatement(
                                         [ "kms:GenerateDataKey*" ],
-                                        baselineIds["Encryption"],
+                                        (baselineIds["Encryption"])!"",
                                         getExistingReference(topicId, REGION_ATTRIBUTE_TYPE)
                                     ),
                                     []

--- a/aws/services/kms/policy.ftl
+++ b/aws/services/kms/policy.ftl
@@ -123,3 +123,25 @@
         ]
     ]
 [/#function]
+
+
+[#function dynamoDbEncryptionStatement actions keyId keyRegion tableName ]
+    [#return
+        [
+            getPolicyStatement(
+                asArray(actions),
+                getArn(keyId, false, keyRegion),
+                "",
+                {
+                    "StringLike" : {
+                        "kms:ViaService": "dynamodb.*.amazonaws.com"
+                    },
+                    "StringEquals": {
+                        "kms:EncryptionContext:aws:dynamodb:tableName": tableName,
+                        "kms:EncryptionContext:aws:dynamodb:subscriberId" : { "Ref" : "AWS::AccountId" }
+                    }
+                }
+            )
+        ]
+    ]
+[/#function]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds KMS permissions for DynamoDB access when the table is encrypted
- Adds handling for missing baseline keys when state is being determined 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->

- DynamoDb permissions are added for cases when the default Decrypt permissions are disabled but you need to access a dynamoDb Table. The permissions are more restrictive when using the ones provided via the table state 
- Handling of missing baseline keys is for solutions that have been created in the CMDB before running the baseline deployment. Since occurrences are loaded during the baseline deployment setup the baseline keys couldn't be found and caused issues

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

