### PR TITLE
feat(lb): add support for multi value in lb lambda

### DIFF
--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -186,8 +186,9 @@
                                 [#case TOPIC_COMPONENT_TYPE]
                                 [#case S3_COMPONENT_TYPE ]
                                 [#case MTA_RULE_COMPONENT_TYPE ]
+                                [#case LB_COMPONENT_TYPE ]
                                 [#case LB_PORT_COMPONENT_TYPE]
-                                [#case LB_ORIGIN_COMPONENT_TYPE]
+                                [#case LB_BACKEND_COMPONENT_TYPE]
                                     [@createLambdaPermission
                                         id=formatLambdaPermissionId(fn, "link", linkName)
                                         targetId=targetFunctionId

--- a/aws/components/lb/id.ftl
+++ b/aws/components/lb/id.ftl
@@ -58,6 +58,17 @@
                 {
                     "Names" : "TargetType",
                     "Values" : [ "shared:ip", "shared:instance", "alb", "lambda"]
+                },
+                {
+                    "Names": "TargetType:lambda",
+                    "Children" : [
+                        {
+                            "Names" : "MultiValueHeaders",
+                            "Description" : "Send lists for header values to support multiple instances of the same header key",
+                            "Types": BOOLEAN_TYPE,
+                            "Default" : false
+                        }
+                    ]
                 }
             ]
         }
@@ -83,6 +94,17 @@
         {
             "Names" : "TargetType",
             "Values" : [ "shared:ip", "shared:instance", "alb", "lambda"]
+        },
+        {
+            "Names": "TargetType:lambda",
+            "Children" : [
+                {
+                    "Names" : "MultiValueHeaders",
+                    "Description" : "Send lists for header values to support multiple instances of the same header key",
+                    "Types": BOOLEAN_TYPE,
+                    "Default" : false
+                }
+            ]
         }
     ]
 /]

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -273,6 +273,12 @@
                     "slow_start.duration_seconds" : solution.SlowStartTime
                 },
                 {}
+            ) +
+            (solution.TargetType == "aws:lambda" && solution["aws:TargetType:lambda"].MultiValueHeaders )?then(
+                {
+                    "lambda.multi_value_headers.enabled": true
+                },
+                {}
             )]
 
         [@createTargetGroup
@@ -396,7 +402,7 @@
                 [/#if]
 
                 [#if ["instance", "ip"]?seq_contains(solution.Forward.TargetType) &&
-                        ! ["HTTP", "HTTPS", "TCP"]?seq_contains(destinationPort.Protocol) && 
+                        ! ["HTTP", "HTTPS", "TCP"]?seq_contains(destinationPort.Protocol) &&
                         ! isPresent(solution.Backend) ]
 
                     [@fatal
@@ -442,7 +448,7 @@
                 [/#if]
 
                 [#if ["aws:alb"]?seq_contains(solution.Forward.TargetType) &&
-                        ! ["TCP"]?seq_contains(destinationPort.Protocol) && 
+                        ! ["TCP"]?seq_contains(destinationPort.Protocol) &&
                         ! isPresent(solution.Backend)]
 
                     [@fatal
@@ -982,7 +988,14 @@
                             "slow_start.duration_seconds" : solution.Forward.SlowStartTime
                         },
                         {}
-                    )]
+                    ) +
+                    (solution.Forward.TargetType == "aws:lambda" && solution.Forward["aws:TargetType:lambda"].MultiValueHeaders )?then(
+                        {
+                            "lambda.multi_value_headers.enabled": true
+                        },
+                        {}
+                    )
+                ]
 
                 [#-- This is to handle the migration from creating listener rules via the cli into Cloudformation --]
                 [#if firstMappingForPort ]

--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -145,7 +145,15 @@
                 "INTERNAL_FQDN" : getExistingReference(id, DNS_ATTRIBUTE_TYPE)
             },
             "Roles" : {
-                "Inbound" : {},
+                "Inbound" : {
+                    "invoke" : {
+                        "Principal" : "elasticloadbalancing.amazonaws.com",
+                        "SourceArn" : formatRegionalArn(
+                            "elasticloadbalancing",
+                            "targetgroup/*"
+                        )
+                    }
+                },
                 "Outbound" : {}
             }
         }


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds the ability to control the use of multi value headers/params
- fixes invoke permissions on lb component to support the lb or the tg

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
ALB -> Lambda by default only supports single headers so when using Set-Cookie headers in responses it doesn't work as the general practice is to provide the same header twice. 
MultiValue support is an lb configuration option which modifies the request received by the lambda to use arrays for headers and params

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

