### PR TITLE
feat: add support for multiple paths on lb

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -356,7 +356,7 @@
         [#local firstMappingForPort = !listenerPortsSeen?seq_contains(listenerId) ]
         [#switch engine ]
             [#case "application"]
-                [#if solution.Path != "default" ]
+                [#if solution.Path?is_sequence || solution.Path != "default" ]
                     [#-- Only create the listener for default mappings      --]
                     [#-- The ordering of ports changes with their naming    --]
                     [#-- so it isn't sufficient to use the first occurrence --]
@@ -478,20 +478,25 @@
         [#-- Path processing --]
         [#switch engine ]
             [#case "application"]
-                [#if solution.Path == "default" ]
-                    [#local path = "*"]
-                [#else]
-                    [#if solution.Path?ends_with("/") && solution.Path != "/" ]
-                        [#local path = solution.Path?ensure_ends_with("*")]
-                    [#else]
-                        [#local path = solution.Path ]
-                    [/#if]
-                [/#if]
+                [#if solution.Path?is_string]
 
+                    [#if solution.Path == "default" ]
+                        [#local path = "*"]
+                    [#else]
+                        [#if solution.Path?ends_with("/") && solution.Path != "/" ]
+                            [#local path = solution.Path?ensure_ends_with("*")]
+                        [#else]
+                            [#local path = solution.Path ]
+                        [/#if]
+                    [/#if]
+
+                [#elseif solution.Path?is_sequence]
+                    [#local path = solution.Path]
+                [/#if]
 
                 [#if listenerRulePriority?is_string &&
                             listenerRulePriority == "default" ]
-                    [#if solution.HostFilter || solution.Path != "default" ]
+                    [#if solution.HostFilter || (! solution.Path?is_string &&  solution.Path != "default") ]
                         [@fatal
                             message="Request conditions can not be used for default rules"
                             context={

--- a/aws/components/lb/state.ftl
+++ b/aws/components/lb/state.ftl
@@ -241,12 +241,14 @@
 
     [#local path = ""]
 
-    [#if solution.Path != "default" ]
-        [#if (solution.Path)?ends_with("*") ]
-            [#local path = solution.Path?remove_ending("*")?ensure_ends_with("/") ]
-        [#else]
-            [#local path = solution.Path ]
-        [/#if]
+    [#if solution.Path?is_string ]
+        [#local path = solution.Path]
+    [#else]
+        [#local path = solution.Path[0]]
+    [/#if]
+
+    [#if path != "default" && path?ends_with("*") ]
+        [#local path = path?remove_ending("*")?ensure_ends_with("/") ]
     [/#if]
 
     [#local url = scheme + "://" + fqdn  ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for including an array of paths for an lb port mapping

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for consolidating load balancer rules that do the same thing across different paths

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/2102

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

