### PR TITLE
feat(ecs): task cpu, depends on, readonly

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -1626,6 +1626,8 @@
                 dependencies=dependencies
                 fixedName=solution.FixedName
                 tags=getOccurrenceTags(subOccurrence)
+                cpu=solution.Cpu
+                memory=solution.Memory
             /]
 
             [#if containers?size < 1 ]

--- a/aws/services/ecs/resource.ftl
+++ b/aws/services/ecs/resource.ftl
@@ -370,7 +370,12 @@
                 attributeIfContent("HealthCheck", container.HealthCheck!{}) +
                 attributeIfContent("Hostname", container.Hostname!"") +
                 attributeIfContent("Ulimits", ulimits ) +
-                attributeIfContent("DependsOn", container.DependsOn)
+                attributeIfContent("DependsOn", container.DependsOn) +
+                attributeIfTrue(
+                    "ReadonlyRootFilesystem",
+                    container.ReadonlyRootFilesystem,
+                    container.ReadonlyRootFilesystem
+                )
             ]
         ]
     [/#list]
@@ -1097,7 +1102,8 @@
                 "Alerts" : container.Alerts,
                 "Container" : container,
                 "InitProcess" : container.InitProcess,
-                "DependsOn" : dependsOn
+                "DependsOn" : dependsOn,
+                "ReadonlyRootFilesystem": container.ReadonlyRootFilesystem
             } +
             attributeIfContent("LogGroup", containerLogGroup) +
             attributeIfContent("Cpu", container.Cpu) +
@@ -1120,12 +1126,7 @@
             attributeIfContent("RunCapabilities", container.RunCapabilities) +
             attributeIfContent("ContainerNetworkLinks", container.ContainerNetworkLinks) +
             attributeIfContent("PlacementConstraints", container.PlacementConstraints![] ) +
-            attributeIfContent("Ulimits", container.Ulimits ) +
-            attributeIfTrue(
-                "ReadonlyRootFilesystem",
-                container.ReadonlyRootFilesystem,
-                container.ReadonlyRootFilesystem
-            )
+            attributeIfContent("Ulimits", container.Ulimits )
         ]
 
         [#local linkIngressRules = [] ]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for setting CPU/Memory allocation at the task service level
- Adds support for the DependsOn setup that allows for init containers
- Adds readonly root file system support to increase security posture of running containers

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Enabling root only file systems requires adding volumes for directories like /tmp. However doing this creates directories owned by root. Running an init container before the actual container lets you align the new volume permissions with what is expected

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/2103

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

