### PR TITLE
refactor(s3): object ownership support

### DIFF
--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -519,6 +519,9 @@
         [/#switch]
     [/#list]
 
+    [#local objectOwnership = solution.ObjectOwnership!""]
+
+
     [#if deploymentSubsetRequired("s3", true)]
 
         [#if _context.Policy?has_content ]
@@ -556,6 +559,9 @@
             tags=mergeObjects(getOccurrenceTags(occurrence), backupTags)
             publicAccessBlockConfiguration=(
                 getPublicAccessBlockConfiguration( ! publicPolicyRequired)
+            )
+            objectOwnershipConfiguration=(
+                getS3ObjectOwnershipConfiguration(objectOwnership)
             )
         /]
     [/#if]

--- a/aws/services/s3/resource.ftl
+++ b/aws/services/s3/resource.ftl
@@ -404,6 +404,44 @@
     ]
 [/#function]
 
+[#function getS3ObjectOwnershipConfiguration
+    ownership=""
+    ]
+
+    [#local result = {} ]
+    [#if ownership?has_content]
+        [#switch ownership ]
+            [#case "owner" ]
+                [#local objectOwner = "BucketOwnerEnforced" ]
+                [#break]
+
+            [#case "ownerpreferred" ]
+                [#local objectOwner = "BucketOwnerPreferred" ]
+                [#break]
+
+            [#case "writer" ]
+                [#local objectOwner = "ObjectWriter" ]
+                [#break]
+
+            [#default]
+                [#local objectOwner = "HamletFatal: Unsupported bucket object ownership of " + ownership]
+        [/#switch]
+
+        [#local result =
+            {
+                "Rules" : [
+                    {
+                        "ObjectOwnership" : objectOwner
+                    }
+                ]
+            }
+        ]
+
+    [/#if]
+
+    [#return result]
+[/#function]
+
 [#assign S3_OUTPUT_MAPPINGS =
     {
         REFERENCE_ATTRIBUTE_TYPE : {
@@ -468,6 +506,7 @@
         cannedACL=""
         CORSBehaviours=[]
         inventoryReports=[]
+        objectOwnershipConfiguration={}
         dependencies=""
         outputId=""
         tags={}
@@ -617,6 +656,10 @@
             attributeIfContent(
                 "PublicAccessBlockConfiguration",
                 publicAccessBlockConfiguration
+            ) +
+            attributeIfContent(
+                "OwnershipControls",
+                objectOwnershipConfiguration
             )
         tags=tags
         outputs=S3_OUTPUT_MAPPINGS


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add support for control of the object ownership for the bucket.

By default, no explicit control is provided to be backwards compatible with previous deployments.

## Motivation and Context
- track AWS enhancements

## How Has This Been Tested?
Local generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- https://github.com/hamlet-io/engine/pull/2104


### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

