### PR TITLE
fix(s3): allow external policy sharing on public

### DIFF
--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -558,7 +558,7 @@
             dependencies=dependencies
             tags=mergeObjects(getOccurrenceTags(occurrence), backupTags)
             publicAccessBlockConfiguration=(
-                getPublicAccessBlockConfiguration( ! publicPolicyRequired)
+                getPublicAccessBlockConfiguration( !publicPolicyRequired, true, true, !publicPolicyRequired)
             )
             objectOwnershipConfiguration=(
                 getS3ObjectOwnershipConfiguration(objectOwnership)


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Disables the restricted public sharing block rule that only allows sharing for local accounts

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The expectation with our public policy is to allow anon access to contents of the bucket. One of the block policies were missed when this was setup so it was still blocking this level of access

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

