### PR TITLE
feat(network): support default sg nacl control

### DIFF
--- a/aws/components/network/id.ftl
+++ b/aws/components/network/id.ftl
@@ -24,6 +24,20 @@
         ]
 /]
 
+[@addResourceGroupAttributeValues
+    type=NETWORK_ACL_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names": "DefaultACL",
+            "Description" : "Apply the rules for this ACL to the default VPC ACL",
+            "Types" : BOOLEAN_TYPE,
+            "Default": false
+        }
+    ]
+/]
+
+
 [@addResourceGroupInformation
     type=NETWORK_ROUTE_TABLE_COMPONENT_TYPE
     attributes=[]

--- a/aws/components/network/setup.ftl
+++ b/aws/components/network/setup.ftl
@@ -457,14 +457,6 @@
 
             [#if deploymentSubsetRequired(NETWORK_COMPONENT_TYPE, true)]
 
-                [#if ! resources["networkACL"].DefaultACL ]
-                    [@createNetworkACL
-                        id=networkACLId
-                        vpcId=vpcResourceId
-                        tags=getOccurrenceTags(occurrence)
-                    /]
-                [/#if]
-
                 [#if resources["networkACL"].DefaultACL ]
                     [#local networkACLId = {
                         "Fn::GetAtt": [
@@ -472,6 +464,13 @@
                             "DefaultNetworkAcl"
                         ]
                     }]
+                [#else ]
+
+                    [@createNetworkACL
+                        id=networkACLId
+                        vpcId=vpcResourceId
+                        tags=getOccurrenceTags(occurrence)
+                    /]
                 [/#if]
 
                 [#list networkACLRules as id, rule ]

--- a/aws/services/vpc/resource.ftl
+++ b/aws/services/vpc/resource.ftl
@@ -286,7 +286,7 @@
         type="AWS::EC2::SecurityGroupEgress"
         properties=
             {
-                "GroupId" : getReference(groupId)
+                "GroupId" : groupId?is_string?then(getReference(groupId), groupId)
             } +
             getSecurityGroupRules(port, cidr, group, "egress", description )[0]
         outputs={}
@@ -776,7 +776,7 @@
         properties=
             properties +
             {
-                "NetworkAclId" : getReference(networkACLId),
+                "NetworkAclId" : networkACLId?is_string?then(getReference(networkACLId), networkACLId),
                 "Egress" : outbound,
                 "RuleNumber" : rule.RuleNumber,
                 "RuleAction" : rule.Allow?string("allow","deny"),


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for setting rules on the default security group and NACL on a VPC created by hamlet
- Allows for passing a Ref through to a security group and NACL rule
- Fixes the port used for outbound rules in return traffic

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
AWS VPC's always include a default Security group and NACL which cannot be removed, being able to set base rules on these resources ensures that they can't be used for the wrong purpose

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/engine/pull/2107

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

