### PR TITLE
feat(waf): add support for regex pattern set and custom responses

### DIFF
--- a/aws/services/waf/resource.ftl
+++ b/aws/services/waf/resource.ftl
@@ -221,7 +221,7 @@
                             "Scope" : regional?then("REGIONAL","CLOUDFRONT"),
                             "IPAddressVersion" : "IPV4",
                             "Addresses": asFlattenedArray(
-                                filters?map(
+                                filters?map(filter ->
                                     getWAFValueList(filter.Targets, valueSet)
                                 )
                             )


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for creating rules using the regex pattern set resource and then being able to reference it in a rule
- Adds support for custom block responses ( https://docs.aws.amazon.com/waf/latest/developerguide/customizing-the-response-for-blocked-requests.html ) to control how clients find out about the block that occurred

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
- This was partially implemented in the migration to wafv2 but a couple of the steps seem to have been missed along the way 
- Custom block responses provide a way to respond to clients in the same format that they would expect for the application or provide them with a way to get in touch if this isn't expected behaviour

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

