### PR TITLE
fix(image): source values

### DIFF
--- a/aws/components/image/setup.ftl
+++ b/aws/components/image/setup.ftl
@@ -170,7 +170,7 @@
         [#case "openapi"]
 
             [#switch solution.Source]
-                [#case "registry"]
+                [#case "Local"]
                     [#break]
                 [#case "url"]
                     [#if deploymentSubsetRequired("epilogue", false)]
@@ -190,7 +190,6 @@
 
             [#switch solution.Source]
                 [#case "Local"]
-                [#case "registry"]
                     [#break]
 
                 [#case "ContainerRegistry"]
@@ -230,7 +229,7 @@
 
         [#case "lambda_jar" ]
             [#switch solution.Source]
-                [#case "registry"]
+                [#case "Local"]
                     [#break]
                 [#case "url"]
                     [#if deploymentSubsetRequired("epilogue", false)]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
When an image component uses the default configuration, it results in a `Source` attribute value of `Local`. Correct the handling of this value in the image setup, and remove the "registry" value which is not supported via the component configuration.

## Motivation and Context
Correctly handle image components using a local registry.

## How Has This Been Tested?
Customer site

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

