### PR TITLE
fix(image): s3 path when pull image

### DIFF
--- a/aws/extensions/runbook_registry_source_object/extension.ftl
+++ b/aws/extensions/runbook_registry_source_object/extension.ftl
@@ -26,14 +26,15 @@
         {
             "TaskParameters" : {
                 "BucketName" : ((image.RegistryPath)!"")?replace("s3://", "")?keep_before("/"),
-                "Object": ((image.RegistryPath)!"")?replace("s3://", "")?keep_after("/")
-                    + (_context.Inputs["input:Reference"] == "_latest")?then(
+                "Object": formatRelativePath(
+                    ((image.RegistryPath)!"")?replace("s3://", "")?keep_after("/"),
+                    (_context.Inputs["input:Reference"] == "_latest")?then(
                         image.Reference,
                         _context.Inputs["input:Reference"]
-                    )
-                    + (image.ImageFileName)!""
+                    ),
+                    (image.ImageFileName)!""
+                )
             }
         }
     )]
-
 [/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- fixes the formatting of the s3 path when pulling an image from the registry 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
/ not included in the path for putting together the S3 uri

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

