### PR TITLE
fix(baseline): data bucket object ownership

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -301,6 +301,8 @@
                 [@createS3Bucket
                     id=bucketId
                     name=bucketName
+                    cannedACL="LogDeliveryWrite"
+                    objectOwnershipConfiguration=getS3ObjectOwnershipConfiguration("ownerpreferred")
                     versioning=versioningEnabled
                     lifecycleRules=lifecycleRules
                     notifications=notifications


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Revert back to the provision of an ACL on data buckets, since cloudfront requires this when writing logs to the bucket.

## Motivation and Context
Until AWS fix their own services to align with the object policy they recommend as best case, ACLs are needed to permit access logs to be written to S3.

## How Has This Been Tested?
Customer site

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

