### PR TITLE
fix(baseline): default file path for image pull

### DIFF
--- a/aws/modules/baseline/module.ftl
+++ b/aws/modules/baseline/module.ftl
@@ -543,9 +543,9 @@
                             "Engine": "hamlet",
                             "Inputs" : {
                                 "LocalPath" : {
-                                    "Description" : "The path to place the image if a file based image is used",
+                                    "Description" : "The full local path to save the image",
                                     "Types" : [ "string" ],
-                                    "Default" : "./"
+                                    "Default" : "./image.zip"
                                 },
                                 "Reference" : {
                                     "Description" : "The image reference to pull down - _latest is the current one",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Change the default local path for the an image pull to use a full file path as this is required for the image download

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The default parameter uses a directory path which causes the AWS boto command to fail

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested localy

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

