### PR TITLE
fix(image): include tag state from output

### DIFF
--- a/aws/services/image/resource.ftl
+++ b/aws/services/image/resource.ftl
@@ -75,7 +75,13 @@
         [#case "Local"]
             [#-- Get Image Reference details --]
             [#local reference = getExistingReference(imageId)]
+
+            [#-- TODO(mfl): once the executor starts generating image stacks using the tag attribute, --]
+            [#-- the extra check for NAME_ATTRIBUTE_TYPE can be removed --]
             [#local tag = getExistingReference(imageId, TAG_ATTRIBUTE_TYPE)]
+            [#if ! tag?has_content]
+              [#local tag = getExistingReference(imageId, NAME_ATTRIBUTE_TYPE)]
+            [/#if]
             [#if reference?has_content ]
                 [#local referenceSource = "output"]
             [/#if]


### PR DESCRIPTION

## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
In order to ensure the tag is included in the image state, and to permit future rationalisation of the attribute used, support the use of either attribute to provide the tag value.

## Motivation and Context
Currently the stack output generated by the executor uses the NAME attribute while the image state code expects the TAG attribute.

## How Has This Been Tested?
Customer site

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

