### PR TITLE
fix: image copying from registry

### DIFF
--- a/aws/services/image/resource.ftl
+++ b/aws/services/image/resource.ftl
@@ -321,7 +321,7 @@
             "copyFilesFromBucket" + " " +
                 region + " " +
                 image.ImageLocation?keep_after("s3://")?keep_before("/") + " " +
-                image.ImageLocation?keep_after("s3://")?keep_after("/") + " " +
+                image.ImageLocation?keep_after("s3://")?keep_after("/")?keep_before_last("/") + " " +
                 "\"$\{tmpdir}\" || return $?",
             "#",
             "addToArray" + " " +


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Ensure the path used to copy files from a bucket does not include the image specific filename.

## Motivation and Context
At present the image filename is being included in thepath to file to copy, resulting inn no files being copied.

## How Has This Been Tested?
Customer site

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

