### PR TITLE
fix(apigateway): image source type checking

### DIFF
--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -1161,7 +1161,7 @@
             /]
         [/#if]
 
-        [#if image.Source == "url" || image.Source == "registry" ]
+        [#if image.Source == "url" || ["registry", "Local"]?seq_contains(image.Source) ]
             [@addToDefaultBashScriptOutput
                 content=
                     getAWSImageBuildScript(


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Check for an image source of `Local` rather than `registry` as that is the value returned by `getOccurrenceImage()`.

## Motivation and Context
Incorrect value checking results in no pregeneration script being generated and hence no definition file being available.

## How Has This Been Tested?
Customer site.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

