### PR TITLE
feat(waf): label matching and vendor overrides

### DIFF
--- a/aws/services/waf/id.ftl
+++ b/aws/services/waf/id.ftl
@@ -12,50 +12,23 @@
 [#assign AWS_WAFV2_IPSET_RESOURCE_TYPE = "wafv2IpSet" ]
 [#assign AWS_WAFV2_REGEX_PATTERN_SET_RESOURCE_TYPE = "wafv2RegexPatternSet" ]
 
-[#-- Condition types --]
-[#assign AWS_WAF_BYTE_MATCH_CONDITION_TYPE = "ByteMatch" ]
-[#assign AWS_WAF_GEO_MATCH_CONDITION_TYPE = "GeoMatch" ]
-[#assign AWS_WAF_IP_MATCH_CONDITION_TYPE = "IPMatch" ]
-[#assign AWS_WAF_REGEX_MATCH_CONDITION_TYPE = "RegexMatch" ]
-[#assign AWS_WAF_SIZE_CONSTRAINT_CONDITION_TYPE = "SizeConstraint" ]
-[#assign AWS_WAF_SQL_INJECTION_MATCH_CONDITION_TYPE = "SqlInjectionMatch" ]
-[#assign AWS_WAF_XSS_MATCH_CONDITION_TYPE = "XssMatch" ]
-
 
 [#-- Capture the variability between the various conditions --]
 [#function getWAFConditionSetMappings conditionType ]
     [#switch conditionType]
-        [#case AWS_WAF_BYTE_MATCH_CONDITION_TYPE]
-            [#return
-                {
-                    "ResourceType" : {},
-                    "TuplesAttributeKey" : "ByteMatchTuples"
-                }
-            ]
-            [#break]
 
-        [#case AWS_WAF_GEO_MATCH_CONDITION_TYPE]
-            [#return
-                {
-                    "ResourceType" : {},
-                    "TuplesAttributeKey" : "GeoMatchConstraints"
-                }
-            ]
-            [#break]
-
-        [#case AWS_WAF_IP_MATCH_CONDITION_TYPE]
+        [#case WAF_IP_MATCH_CONDITION_TYPE]
             [#return
                 {
                     "ResourceType" : {
                         "hamlet": AWS_WAFV2_IPSET_RESOURCE_TYPE,
                         "cfn": "AWS::WAFv2::IPSet"
-                    },
-                    "TuplesAttributeKey" : "IPSetDescriptors"
+                    }
                 }
             ]
             [#break]
 
-        [#case AWS_WAF_REGEX_MATCH_CONDITION_TYPE]
+        [#case WAF_REGEX_MATCH_CONDITION_TYPE]
             [#return
                 {
                     "ResourceType": {
@@ -66,38 +39,34 @@
             ]
             [#break]
 
-
-        [#case AWS_WAF_SIZE_CONSTRAINT_CONDITION_TYPE]
+        [#case WAF_GEO_MATCH_CONDITION_TYPE]
+        [#case WAF_SIZE_CONSTRAINT_CONDITION_TYPE]
+        [#case WAF_SQL_INJECTION_MATCH_CONDITION_TYPE]
+        [#case WAF_BYTE_MATCH_CONDITION_TYPE]
+        [#case WAF_XSS_MATCH_CONDITION_TYPE]
+        [#case WAF_LABEL_MATCH_CONDITION_TYPE]
             [#return
                 {
-                    "ResourceType" : {},
-                    "TuplesAttributeKey" : "SizeConstraints"
-                }
-            ]
-            [#break]
-
-        [#case AWS_WAF_SQL_INJECTION_MATCH_CONDITION_TYPE]
-            [#return
-                {
-                    "ResourceType" : {},
-                    "TuplesAttributeKey" : "SqlInjectionMatchTuples"
-                }
-            ]
-            [#break]
-
-        [#case AWS_WAF_XSS_MATCH_CONDITION_TYPE]
-            [#return
-                {
-                    "ResourceType" : {},
-                    "TuplesAttributeKey" : "XssMatchTuples"
+                    "ResourceType" : {}
                 }
             ]
             [#break]
     [/#switch]
+
+    [@fatal
+        message="Invalid WAF Condition Type"
+        context={
+            "Type": conditionType
+        }
+    /]
+    [#return
+        {
+            "ResourceType" : {}
+        }
+    ]
 [/#function]
 
 [#list [
-
     AWS_WAFV2_RULE_RESOURCE_TYPE,
     AWS_WAFV2_ACL_RESOURCE_TYPE,
     AWS_WAFV2_ACL_ASSOCIATION_RESOURCE_TYPE,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Using labels applied during rule processing as conditions for subsequent rules
- Override the action of a rule provided by a vendor managed rule set
- Use WAFValue Sets for custom HTTP block responses
- Moves WAF conditions from the AWS engine to the core engine as they are generic and this allows for them to be included in our standard WAF rule schema
- Simplifies the resource mapping for WAF Sets as they aren't used much with the move to WAFv2

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The main reason for this PR is to provide support for providing custom responses for block actions on vendoer managed rule sets. 

While overrides are possible on vendor managed rules they only support the basic action override and don't support the extended action options like custom responses 

See: https://aws.amazon.com/blogs/security/how-to-customize-behavior-of-aws-managed-rules-for-aws-waf/

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

