### PR TITLE
fix(baseline): permissions for logging

### DIFF
--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -353,13 +353,34 @@
                     [#case "operations" ]
 
                         [#local bucketPolicy +=
-                            [#-- Permission for ELB to write access logs to s3 --]
-                            s3WritePermission(
+                            [#-- Permission for LB to write access logs to s3 --]
+                            getS3Statement(
+                                [
+                                    "s3:PutObject"
+                                ],
                                 bucketName,
                                 "AWSLogs",
                                 "*",
                                 {
                                     "AWS": "arn:aws:iam::" + getRegionObject().Accounts["ELB"] + ":root"
+                                }
+                            ) +
+                            [#-- LB logging for new regions --]
+                            [#-- https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy --]
+                            getS3Statement(
+                                [
+                                    "s3:PutObject"
+                                ],
+                                bucketName,
+                                "AWSLogs",
+                                "*",
+                                {
+                                    "Service": "logdelivery.elasticloadbalancing.amazonaws.com"
+                                },
+                                {
+                                    "StringEquals" : {
+                                        "aws:SourceAccount": [ {"Ref" : "AWS::AccountId"} ]
+                                    }
                                 }
                             ) +
                             [#-- Permission to export cloudwatch logs to S3 in the same account (logs.amazonaws.com) --]
@@ -377,7 +398,10 @@
                                     }
                                 }
                             ) +
-                            s3WritePermission(
+                            getS3Statement(
+                                [
+                                    "s3:PutObject"
+                                ],
                                 bucketName,
                                 "",
                                 "*",
@@ -423,7 +447,10 @@
                                     }
                                 }
                             ) +
-                            s3WritePermission(
+                            getS3Statement(
+                                [
+                                    "s3:PutObject"
+                                ],
                                 bucketName,
                                 "",
                                 "*",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Only allow s3:PutObject instead of s3:PutObject*
- Add support for the new region lb logging to use the fixed principal instead of a fixed AWS account

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
- AWS Security hub benchmark recommends only allowing minimal explicit actions when adding bucket policy for external accounts. Since the LB log forwarded uses an external account the reporting trips up on the current policy 
- Adding the new regions allows for using the new regions if we need to 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

