### PR TITLE
refactor(baseline): bucket policy extensions

### DIFF
--- a/aws/extensions/s3_cw_log_export_access/extension.ftl
+++ b/aws/extensions/s3_cw_log_export_access/extension.ftl
@@ -1,0 +1,58 @@
+[#ftl]
+
+[@addExtension
+    id="s3_cw_log_export_access"
+    aliases=[
+        "_s3_cw_log_export_access"
+    ]
+    description=[
+        "Grants access to the logs.amazonaws.com principal to export logs in s3"
+    ]
+    supportedTypes=[
+        BASELINE_DATA_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_s3_cw_log_export_access_deployment_setup occurrence ]
+
+    [#-- context needs to provide the bucket name/arn/id --]
+    [#local bucketReference = _context.BucketReference!"HamletFatal Missing bucket reference" ]
+
+    [@Policy
+        s3ReadBucketACLPermission(
+            bucketReference,
+            { "Service": "logs." + getRegion() + ".amazonaws.com" },
+            {
+                "StringEquals" : {
+                    "aws:SourceAccount": [ {"Ref" : "AWS::AccountId"} ]
+                },
+                "ArnLike": {
+                    "aws:SourceArn" : [
+                        formatArn("aws", "logs", getRegion(), {"Ref" : "AWS::AccountId"}, "log-group:*")
+                    ]
+                }
+            }
+        ) +
+        getS3Statement(
+            [
+                "s3:PutObject"
+            ],
+            bucketReference,
+            "",
+            "*",
+            { "Service": "logs." + getRegion() + ".amazonaws.com" },
+            {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control",
+                    "aws:SourceAccount": [ {"Ref" : "AWS::AccountId"} ]
+                },
+                "ArnLike": {
+                    "aws:SourceArn" : [
+                        formatArn("aws", "logs", getRegion(), {"Ref" : "AWS::AccountId"}, "log-group:*")
+                    ]
+                }
+            }
+        )
+    /]
+
+[/#macro]

--- a/aws/extensions/s3_elb_log_delivery_access/extension.ftl
+++ b/aws/extensions/s3_elb_log_delivery_access/extension.ftl
@@ -1,0 +1,54 @@
+[#ftl]
+
+[@addExtension
+    id="s3_elb_log_delivery_access"
+    aliases=[
+        "_s3_elb_log_delivery_access"
+    ]
+    description=[
+        "Grants access to the ELB to deliver logs in s3"
+    ]
+    supportedTypes=[
+        BASELINE_DATA_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_s3_elb_log_delivery_access_deployment_setup occurrence ]
+
+    [#-- context needs to provide the bucket name/arn/id --]
+    [#local bucketReference = _context.BucketReference!"HamletFatal Missing bucket reference" ]
+
+    [@Policy
+        [#-- The legacy approach before optional regions --]
+        getS3Statement(
+            [
+                "s3:PutObject"
+            ],
+            bucketReference,
+            "AWSLogs",
+            "*",
+            {
+                "AWS": "arn:aws:iam::" + getRegionObject().Accounts["ELB"] + ":root"
+            }
+        ) +
+        [#-- LB logging for new regions --]
+        [#-- https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy --]
+        getS3Statement(
+            [
+                "s3:PutObject"
+            ],
+            bucketReference,
+            "AWSLogs",
+            "*",
+            {
+                "Service": "logdelivery.elasticloadbalancing.amazonaws.com"
+            },
+            {
+                "StringEquals" : {
+                    "aws:SourceAccount": [ {"Ref" : "AWS::AccountId"} ]
+                }
+            }
+        )
+    /]
+
+[/#macro]

--- a/aws/extensions/s3_log_delivery_access/extension.ftl
+++ b/aws/extensions/s3_log_delivery_access/extension.ftl
@@ -1,0 +1,72 @@
+[#ftl]
+
+[@addExtension
+    id="s3_log_delivery_access"
+    aliases=[
+        "_s3_log_delivery_access"
+    ]
+    description=[
+        "Grants access to the delivery.logs.amazonaws.com principal to save logs in s3"
+    ]
+    supportedTypes=[
+        BASELINE_DATA_COMPONENT_TYPE
+    ]
+/]
+
+[#macro shared_extension_s3_log_delivery_access_deployment_setup occurrence ]
+
+    [#-- context needs to provide the bucket name/arn/id --]
+    [#local bucketReference = _context.BucketReference!"HamletFatal Missing bucket reference" ]
+
+    [@Policy
+        s3ReadBucketACLPermission(
+            bucketReference,
+            { "Service": "delivery.logs.amazonaws.com" },
+            {
+                "StringEquals" : {
+                    "aws:SourceAccount": [ {"Ref" : "AWS::AccountId"} ]
+                },
+                "ArnLike": {
+                    "aws:SourceArn" : [
+                        formatArn("aws", "logs", getRegion(), {"Ref" : "AWS::AccountId"}, "*")
+                    ]
+                }
+            }
+        ) +
+        s3ListBucketPermission(
+            bucketReference,
+            { "Service": "delivery.logs.amazonaws.com" },
+            {
+                "StringEquals" : {
+                    "aws:SourceAccount": [ {"Ref" : "AWS::AccountId"} ]
+                },
+                "ArnLike": {
+                    "aws:SourceArn" : [
+                        formatArn("aws", "logs", getRegion(), {"Ref" : "AWS::AccountId"}, "*")
+                    ]
+                }
+            }
+        ) +
+        getS3Statement(
+            [
+                "s3:PutObject"
+            ],
+            bucketReference,
+            "",
+            "*",
+            { "Service": "delivery.logs.amazonaws.com" },
+            {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control",
+                    "aws:SourceAccount": [ {"Ref" : "AWS::AccountId"} ]
+                },
+                "ArnLike": {
+                    "aws:SourceArn" : [
+                        formatArn("aws", "logs", getRegion(), {"Ref" : "AWS::AccountId"}, "*")
+                    ]
+                }
+            }
+        )
+    /]
+
+[/#macro]

--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -112,6 +112,11 @@
                         "deployment:Unit": "baseline",
                         "DataBuckets": {
                             "opsdata": {
+                                "Extensions" : [
+                                    "_s3_elb_log_delivery_access",
+                                    "_s3_cw_log_export_access",
+                                    "_s3_log_delivery_access"
+                                ],
                                 "Role": "operations",
                                 "Encryption": {
                                     "EncryptionSource": "LocalService"

--- a/aws/modules/baseline/module.ftl
+++ b/aws/modules/baseline/module.ftl
@@ -20,6 +20,11 @@
                                 "DataBuckets": {
                                     "opsdata": {
                                         "Role": "operations",
+                                        "Extensions" : [
+                                            "_s3_elb_log_delivery_access",
+                                            "_s3_cw_log_export_access",
+                                            "_s3_log_delivery_access"
+                                        ],
                                         "Encryption": {
                                             "EncryptionSource": "LocalService"
                                         },


### PR DESCRIPTION

## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Handle the simple bucket policy statements via extensions to give greater flexibility as to what gets included. The masterdata reflects the current situation but can be overridden as desired.

## Motivation and Context
Extensions permit more flexibility in what policies are configured on the baseline buckets, and also neatly separate the specific policy rules associated with a given type of access.

## How Has This Been Tested?
Local template generation. Customer deployment post relase.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

