### PR TITLE
feat(apigateway): private APIs

### DIFF
--- a/aws/services/policy.ftl
+++ b/aws/services/policy.ftl
@@ -67,3 +67,12 @@
         }
     ]
 [/#function]
+
+[#function getVPCEndpointCondition vpcEndpoints=[] match=true]
+    [#return
+        {
+            match?then("StringEquals", "StringNotEquals") :
+                { "aws:SourceVpce": asFlattenedArray(vpcEndpoints) }
+        }
+    ]
+[/#function]


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add support for private APIs, with resource policy control based on vpc endpoints, following the pattern already used for IP address filtering on public APIs.

Consumer VPC endpoints are obtained via inbound links from external services.

Like IP address group support, if no limit is to be placed on where traffic to the API can originate, then an external service with a endpoint value of `_global` (or equivalent) must be provided.

## Motivation and Context
- support new AWS feature
- support more security conscious deployment

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- https://github.com/hamlet-io/engine/pull/2115

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

