### PR TITLE
fix: docker image tag extension

### DIFF
--- a/aws/extensions/runbook_registry_destination_image_tag/extension.ftl
+++ b/aws/extensions/runbook_registry_destination_image_tag/extension.ftl
@@ -25,7 +25,7 @@
         _context,
         {
             "TaskParameters" : {
-                "DestinationImage" : ((image.Registry)!"") + ":__input:Tag__"
+                "DestinationImage" : ((image.RegistryPath)!"") + ":__input:Tag__"
             }
         }
     )]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Correct the provision of the destination image when pushing docker tags.

## Motivation and Context
The code was attempting to use a non-existent image attribute resulting in an invalid image path and exceptions in the cli.

## How Has This Been Tested?
Will be tested on site once merged. Customer is actively using the extension.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

