### PR TITLE
fix(objectsql): permissions state details

### DIFF
--- a/aws/components/objectsql/setup.ftl
+++ b/aws/components/objectsql/setup.ftl
@@ -114,7 +114,8 @@
                     pseudoStackOutputScript(
                         "Athena WorkGroup",
                         {
-                            formatId( workGroupId, NAME_ATTRIBUTE_TYPE ) : workGroupName
+                            formatId(workGroupId) : workGroupName,
+                            formatId(workGroupId, NAME_ATTRIBUTE_TYPE ) : workGroupName
                         }
                     ) +
                 [

--- a/aws/components/objectsql/state.ftl
+++ b/aws/components/objectsql/state.ftl
@@ -30,7 +30,7 @@
                 "Outbound" : {
                     "default" : "consume",
                     "consume" :
-                        athenaConsumePermission(workGroupId) +
+                        athenaConsumePermission(workGroupName) +
                         s3AllPermission(dataBucket, getAppDataFilePrefix(occurrence))
             }
             }

--- a/aws/services/athena/policy.ftl
+++ b/aws/services/athena/policy.ftl
@@ -36,8 +36,10 @@
                 "athena:GetNamespace",
                 "athena:GetCatalogs",
                 "athena:GetNamespaces",
-                "athena:GetTables",
-                "athena:GetTable"
+                "glue:GetTableVersion",
+                "glue:GetTableVersions",
+                "glue:GetTables",
+                "glue:GetTable"
             ],
             "*",
             principals,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds the REF attr to the workgroup creation output
- Updates the policy provided through links to the objectsql component to query athena

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The first fix ensures that the objectsql component is considered deployed and the policy updates all for another component to consume the objectsql service 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

