### PR TITLE
feat(iam): extend use of the large policy setup

### DIFF
--- a/aws/services/iam/resource.ftl
+++ b/aws/services/iam/resource.ftl
@@ -178,7 +178,6 @@
                         context=context
                     /]
                     [#local managedEntries += [newEntry] ]
-                    ]
                 [/#list]
             [/#if]
         [/#list]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds support for handling large iam policies across services that have user defined roles which can grow to hit iam policy limits
- Update the user policy setup to be deployed as part of the user instead of IAM to allow for the policy to be attached as required
- Minor typo fix in IAM service

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
The lambda component has had support for handling IAM policies which are outside of the policy document size for a little while now and that works as expected. This extends  this to other components which could hit the same limits 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

