### PR TITLE
fix(gateway): duplicate route table ids

### DIFF
--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -556,7 +556,8 @@
                             [#list linkTargetResources["routeTables"] as zone, zoneRouteTableResources ]
 
                                 [#local zoneRouteTableId = zoneRouteTableResources["routeTable"].Id]
-                                [#local routeTableIds += [ zoneRouteTableId ]]
+                                [#-- For manually configured vpcs, the same route table may be used in multiple zones --]
+                                [#local routeTableIds = getUniqueArrayElements( routeTableIds, zoneRouteTableId ) ]
 
                                     [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, true)]
 


### PR DESCRIPTION

## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Ensure route table ids are unique when creating vpc endpoints.

## Motivation and Context
Where a route table is shared across zones, the current logic generates duplicate ids.

## How Has This Been Tested?
- local template generation
- customer site post release
- 
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

