### PR TITLE
fix(gateway): duplicate route table ids

### DIFF
--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -556,10 +556,8 @@
                             [#list linkTargetResources["routeTables"] as zone, zoneRouteTableResources ]
 
                                 [#local zoneRouteTableId = zoneRouteTableResources["routeTable"].Id]
-                                [#-- For manually configured vpcs, the same route table may be used in multiple zones --]
-                                [#local routeTableIds = getUniqueArrayElements( routeTableIds, zoneRouteTableId ) ]
-
-                                    [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, true)]
+                                [#local routeTableIds = [zoneRouteTableId] ]
+                                [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, true)]
 
                                     [#switch gwSolution.Engine ]
                                         [#case "natgw" ]

--- a/aws/services/vpc/resource.ftl
+++ b/aws/services/vpc/resource.ftl
@@ -907,7 +907,8 @@
             (type == "gateway")?then(
                 {
                     "VpcEndpointType" : "Gateway",
-                    "RouteTableIds" : getReferences(routeTableIds)
+                    [#-- For manually configured vpcs, the same route table may be used in multiple zones --]
+                    "RouteTableIds" : getUniqueArrayElements(getReferences(routeTableIds))
                 } +
                 valueIfContent(getPolicyDocument(statements), statements),
                 {}


### PR DESCRIPTION

## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Revert a previous fix to this issue and implement a new solution.

## Motivation and Context
The previous code checked for duplicate cloud formation ids rather than duplicate AWS assigned ids.

## How Has This Been Tested?
- local template generation with customer configuration

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

