### PR TITLE
fix(gateway): route table collection

### DIFF
--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -556,7 +556,7 @@
                             [#list linkTargetResources["routeTables"] as zone, zoneRouteTableResources ]
 
                                 [#local zoneRouteTableId = zoneRouteTableResources["routeTable"].Id]
-                                [#local routeTableIds = [zoneRouteTableId] ]
+                                [#local routeTableIds += [zoneRouteTableId] ]
                                 [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, true)]
 
                                     [#switch gwSolution.Engine ]


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Correct a bug introduced by recent changes while attempting to correct duplicate route table entries in vpc endpoints.

## Motivation and Context
The absence of the addition operator meant the code would only work correctly where one route table was expected - ironically the situation used to verify the original change post merge.

## How Has This Been Tested?
- local template generation
- customer site application post merge

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

