### PR TITLE
feat(lb): client IP control

### DIFF
--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -1084,6 +1084,15 @@
                             "deregistration_delay.timeout_seconds" : solution.Forward.DeregistrationTimeout
                         }]
                 [/#if]
+                [#switch solution.Forward.ClientIP!""]
+                    [#case "preserve"]
+                        [#local tgAttributes += { "preserve_client_ip.enabled" : true } ]
+                        [#break]
+
+                    [#case "proxy_protocol"]
+                        [#local tgAttributes += { "proxy_protocol_v2.enabled" : true } ]
+                        [#break]
+                [/#switch]
 
                 [#if engine == "network" && deploymentSubsetRequired(LB_COMPONENT_TYPE, true) ]
                     [@createTargetGroup


### PR DESCRIPTION

## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Provide the ability to control the way in which client IP information will be provided to a target.

## Motivation and Context
The default mirrors the current situation where the lb client is hidden and the lb address is presented.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
- https://github.com/hamlet-io/engine/pull/2119

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

