### PR TITLE
feat(ec2): lb fixed target mapping

### DIFF
--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -463,7 +463,7 @@
                             )
                     }
                 tags=getOccurrenceTags(occurrence, { "zone" : zone }, [ zone, "eth0"])
-                outputs={}
+                outputs=AWS_EC2_NETWORK_INTERFACE_OUTPUT_MAPPINGS
             /]
 
             [#if fixedIP || publicRouteTable]

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -257,6 +257,20 @@
                         )]
                         [#break]
                     [#break]
+
+                    [#case EC2_COMPONENT_TYPE]
+                        [#list linkTargetResources["Zones"] as zone, resources ]
+                            [#if getExistingReference(resources["ec2ENI"].Id, IP_ADDRESS_ATTRIBUTE_TYPE)?has_content ]
+                                [#local staticTargets +=
+                                    getTargetGroupTarget(
+                                        "ip",
+                                        getExistingReference(resources["ec2ENI"].Id, IP_ADDRESS_ATTRIBUTE_TYPE),
+                                        port.Port,
+                                        false
+                                    )]
+                            [/#if]
+                        [/#list]
+                        [#break]
             [/#switch]
         [/#list]
 
@@ -974,6 +988,20 @@
                             "lambda",
                             linkTargetAttributes["ARN"]
                         )]
+                        [#break]
+
+                    [#case EC2_COMPONENT_TYPE]
+                        [#list linkTargetResources["Zones"] as zone, resources ]
+                            [#if getExistingReference(resources["ec2ENI"].Id, IP_ADDRESS_ATTRIBUTE_TYPE)?has_content ]
+                                [#local staticTargets +=
+                                    getTargetGroupTarget(
+                                        "ip",
+                                        getExistingReference(resources["ec2ENI"].Id, IP_ADDRESS_ATTRIBUTE_TYPE),
+                                        destinationPort.Port,
+                                        false
+                                    )]
+                            [/#if]
+                        [/#list]
                         [#break]
                 [/#switch]
             [/#if]

--- a/aws/services/ec2/resource.ftl
+++ b/aws/services/ec2/resource.ftl
@@ -42,6 +42,23 @@
     mappings=AWS_EC2_INSTANCE_OUTPUT_MAPPINGS
 /]
 
+[#assign AWS_EC2_NETWORK_INTERFACE_OUTPUT_MAPPINGS =
+    {
+        REFERENCE_ATTRIBUTE_TYPE : {
+            "UseRef" : true
+        },
+        IP_ADDRESS_ATTRIBUTE_TYPE: {
+            "Attribute": "PrimaryPrivateIpAddress"
+        }
+    }
+]
+
+[@addOutputMapping
+    provider=AWS_PROVIDER
+    resourceType=AWS_EC2_NETWORK_INTERFACE_RESOURCE_TYPE
+    mappings=AWS_EC2_NETWORK_INTERFACE_OUTPUT_MAPPINGS
+/]
+
 [#function getCFNInitFromComputeTasks computeTaskConfig ]
 
     [#local configSetName = ""]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Add support for referencing an ec2 instance in a fixed target pool
- Adds IP output for ec2 eni interfaces

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Simplifies the LB registration process from relying on a scripted process to having the load balancer look after it 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

