### PR TITLE
feat: SQS and SNS endpoint policies

### DIFF
--- a/aws/extensions/vpcendpoint_sns_access/extension.ftl
+++ b/aws/extensions/vpcendpoint_sns_access/extension.ftl
@@ -1,28 +1,28 @@
 [#ftl]
 
 [@addExtension
-    id="vpcendpoint_apigateway_access"
+    id="vpcendpoint_sns_access"
     aliases=[
-        "_vpcendpoint_apigateway_access"
+        "_vpcendpoint_sns_access"
     ]
     description=[
-        "Limits access to the linked apis"
+        "Limits access to the sns queues"
     ]
     supportedTypes=[
         NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE
     ]
 /]
 
-[#macro shared_extension_vpcendpoint_apigateway_access_deployment_setup occurrence ]
+[#macro shared_extension_vpcendpoint_sns_access_deployment_setup occurrence ]
 
     [#local resources = [] ]
     [#list _context.Links as id, linkTarget]
         [#switch linkTarget.Core.Type]
             [#case EXTERNALSERVICE_COMPONENT_TYPE]
-            [#case APIGATEWAY_COMPONENT_TYPE]
+            [#case TOPIC_COMPONENT_TYPE]
                 [#local resource = (linkTarget.State.Attributes["ARN"])!"" ]
                 [#if resource?has_content]
-                    [#local resources += [ resource?ensure_ends_with("/*") ] ]
+                    [#local resources += [ resource ] ]
                 [/#if]
                 [#break]
         [/#switch]
@@ -32,13 +32,13 @@
             [
                 getPolicyStatement(
                     [
-                        "execute-api:Invoke"
+                        "sns:*"
                     ],
                     resources,
                     "*",
                     {},
                     true,
-                    "Private API Gateway access"
+                    "SNS topic access"
                 )
             ]
         /]

--- a/aws/extensions/vpcendpoint_sqs_access/extension.ftl
+++ b/aws/extensions/vpcendpoint_sqs_access/extension.ftl
@@ -1,28 +1,28 @@
 [#ftl]
 
 [@addExtension
-    id="vpcendpoint_apigateway_access"
+    id="vpcendpoint_sqs_access"
     aliases=[
-        "_vpcendpoint_apigateway_access"
+        "_vpcendpoint_sqs_access"
     ]
     description=[
-        "Limits access to the linked apis"
+        "Limits access to the sqs queues"
     ]
     supportedTypes=[
         NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE
     ]
 /]
 
-[#macro shared_extension_vpcendpoint_apigateway_access_deployment_setup occurrence ]
+[#macro shared_extension_vpcendpoint_sqs_access_deployment_setup occurrence ]
 
     [#local resources = [] ]
     [#list _context.Links as id, linkTarget]
         [#switch linkTarget.Core.Type]
             [#case EXTERNALSERVICE_COMPONENT_TYPE]
-            [#case APIGATEWAY_COMPONENT_TYPE]
+            [#case SQS_COMPONENT_TYPE]
                 [#local resource = (linkTarget.State.Attributes["ARN"])!"" ]
                 [#if resource?has_content]
-                    [#local resources += [ resource?ensure_ends_with("/*") ] ]
+                    [#local resources += [ resource ] ]
                 [/#if]
                 [#break]
         [/#switch]
@@ -32,13 +32,13 @@
             [
                 getPolicyStatement(
                     [
-                        "execute-api:Invoke"
+                        "sqs:*"
                     ],
                     resources,
                     "*",
                     {},
                     true,
-                    "Private API Gateway access"
+                    "SQS queue access"
                 )
             ]
         /]


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Add extensions to permit addition of endpoint policies on vpc endpoints controlling access to SQS queues and SNS topics.

Also tighten the corresponding extension for private api access to only detect API gateway endpoints.

## Motivation and Context
- limit queues/topics accessible from a VPC

## How Has This Been Tested?
- local template generation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

