### PR TITLE
feat(vpcendpoint): source vpc endpoint extension

### DIFF
--- a/aws/extensions/vpcendpoint_source_access/extension.ftl
+++ b/aws/extensions/vpcendpoint_source_access/extension.ftl
@@ -1,0 +1,42 @@
+[#ftl]
+
+[@addExtension
+    id="vpcendpoint_source_access"
+    aliases=[
+        "_vpcendpoint_source_access"
+    ]
+    description=[
+        "Limits access FROM a set of vpc endpoints"
+    ]
+    supportedTypes=["*"]
+/]
+
+[#macro shared_extension_vpcendpoint_source_access_deployment_setup occurrence ]
+
+    [#local resources = [] ]
+    [#list _context.Links as id, linkTarget]
+        [#switch linkTarget.Core.Type]
+            [#case EXTERNALSERVICE_COMPONENT_TYPE]
+            [#case NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE]
+                [#local endpoints = (linkTarget.State.Attributes["VPC_ENDPOINTS"])!""]
+                [#if endpoints?has_content]
+                    [#local resources = getUniqueArrayElements(resources, endpoints?split(",")) ]
+                [/#if]
+                [#break]
+        [/#switch]
+    [/#list]
+    [#if resources?has_content]
+        [@Policy
+            [
+                getPolicyStatement(
+                    "*",
+                    "*",
+                    "",
+                    getVPCEndpointCondition(resources, false),
+                    false,
+                    "Limit access to specific vpc endpoints"
+                )
+            ]
+        /]
+    [/#if]
+[/#macro]

--- a/aws/services/policy.ftl
+++ b/aws/services/policy.ftl
@@ -21,7 +21,7 @@
         } +
         attributeIfContent("Action", actions)+
         attributeIfContent("NotAction", notActions) +
-        attributeIfContent("Sid", sid) +
+        attributeIfContent("Sid", replaceAlphaNumericOnly(sid?capitalize)) +
         attributeIfContent("Resource", resources) +
         attributeIfContent("Principal", principals) +
         attributeIfContent("NotPrincipal", notprincipals) +


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
- Add an extension to limit access via policy to a component from specific vpc endpoints.
    The initial user case is access to an IAM user.
- Add an attribute to a gateway destination to permit the corresponding vpc endpoint ids to be available.
- Modify any policy SID to ensure to meets the character limits.


## Motivation and Context
As the source IP of packets is changed when using privatelinks, adding a condition to limit traffic to be from specified vpc endpoints is more reliable/functional that the use of source IPs. (AWS also requires IP addresses in public ranges).

In the process of testing, it was noted that the character constraints on policy Sids were not begin enforced. The are now title-cased alphanumeric strings.

## How Has This Been Tested?
- local template generation against customer cmdb

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

