### PR TITLE
refactor(datafeed): undeployed lambda functions

### DIFF
--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -118,7 +118,7 @@
         [/#list]
     [/#list]
 
-    [#local links = getLinkTargets(occurrence) ]
+    [#local links = getLinkTargets(occurrence, {}, false) ]
     [#local linkPolicies = []]
 
     [#list links as linkId,linkTarget]
@@ -130,7 +130,8 @@
 
         [#switch linkTargetCore.Type]
             [#case LAMBDA_FUNCTION_COMPONENT_TYPE]
-
+                [#-- Include lambda processor even if not deployed as config is required if bucket keys use lambda partitioning --]
+                [#-- This permits the firehose to be deployed before the lambda function --]
                 [#local linkPolicies += lambdaKinesisPermission( linkTargetAttributes["ARN"])]
 
                 [#local streamProcessors +=
@@ -143,7 +144,9 @@
                 [#break]
 
             [#default]
-                [#local linkPolicies += getLinkTargetsOutboundRoles( { linkId, linkTarget} ) ]
+                [#if isOccurrenceDeployed(linkTarget) ]
+                    [#local linkPolicies += getLinkTargetsOutboundRoles( { linkId, linkTarget} ) ]
+                [/#if]
         [/#switch]
     [/#list]
 


### PR DESCRIPTION


## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Include any lambda function processor definitions even if the lambda function isn't deployed.

## Motivation and Context
AWS requires that a lambda processor is configured if the prefix definitions include lambda based partitioning.

To permit the datafeed to be deployed at the solution level before the lambda has been deployed, the lambda processor configuration needs to be included even if the lambda function isn't deployed.

This also adds the necessary iam permissions that will take effect as soon as the lambda function is deployed.

## How Has This Been Tested?
- local template generation with customer cmdb
- deployment to customer post merge

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

