### PR TITLE
fix(ecs): round max memory when calculated

### DIFF
--- a/aws/services/ecs/resource.ftl
+++ b/aws/services/ecs/resource.ftl
@@ -1140,7 +1140,7 @@
             attributeIfTrue(
                 "MaximumMemory",
                 !container.MaximumMemory??,
-                container.MemoryReservation*ECS_DEFAULT_MEMORY_LIMIT_MULTIPLIER
+                (container.MemoryReservation * ECS_DEFAULT_MEMORY_LIMIT_MULTIPLIER)?round
             ) +
             attributeIfContent("PortMappings", containerPortMappings) +
             attributeIfContent("IngressRules", ingressRules) +


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Round MaximumMemory when it is calculated

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
- Recent versions of freemarker have extended their number support and looks like decimal multiplication will return a decimal value now. So round it to the nearest whole number

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

