### PR TITLE
refactor(datafeed): check for undeployed lambda

### DIFF
--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -130,17 +130,23 @@
 
         [#switch linkTargetCore.Type]
             [#case LAMBDA_FUNCTION_COMPONENT_TYPE]
-                [#-- Include lambda processor even if not deployed as config is required if bucket keys use lambda partitioning --]
-                [#-- This permits the firehose to be deployed before the lambda function --]
-                [#local linkPolicies += lambdaKinesisPermission( linkTargetAttributes["ARN"])]
+                [#if isOccurrenceDeployed(linkTarget) ]
+                    [#local linkPolicies += lambdaKinesisPermission( linkTargetAttributes["ARN"])]
 
-                [#local streamProcessors +=
-                        [ getFirehoseStreamLambdaProcessor(
-                            linkTargetAttributes["ARN"],
-                            streamRoleId,
-                            solution.Buffering.Interval,
-                            solution.Buffering.Size
-                        )]]
+                    [#local streamProcessors +=
+                            [ getFirehoseStreamLambdaProcessor(
+                                linkTargetAttributes["ARN"],
+                                streamRoleId,
+                                solution.Buffering.Interval,
+                                solution.Buffering.Size
+                            )]]
+                [#else]
+                    [@fatal
+                        message="Lambda stream processor must be deployed before the associated datafeed can be deployed"
+                        detail="Deploy the lambda first. One option is to adjust its deployment group and priority."
+                        context=occurrence
+                    /]
+                [/#if]
                 [#break]
 
             [#default]


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
If a datafeed is configured with a processing lambda, expect the lambda to be deployed before the datafeed can be deployed.

## Motivation and Context
The datafeed will not deploy unless the lambda already exists if the prefixes reference partition keys from a lambda function.

## How Has This Been Tested?
- local template generation
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

