### PR TITLE
fix(firewall): add both log destinations for all

### DIFF
--- a/aws/components/firewall/setup.ftl
+++ b/aws/components/firewall/setup.ftl
@@ -142,19 +142,19 @@
                 [#break]
         [/#switch]
 
-        [#local logType = ""]
+        [#local logTypes = []]
         [#switch solution.Logging.Events]
             [#case "all"]
-                [#local logType = "flow"]
+                [#local logTypes = ["flow", "alert"]]
                 [#break]
 
             [#case "alert-only"]
-                [#local logType = "alert"]
+                [#local logTypes = ["alert"]]
                 [#break]
         [/#switch]
 
         [#local logConfig = getNetworkFirewallLoggingConfiguration(
-                                logType,
+                                logTypes,
                                 solution.Logging.DestinationType,
                                 loggingDestinationId,
                                 loggingS3Prefix)]

--- a/awstest/modules/firewall/module.ftl
+++ b/awstest/modules/firewall/module.ftl
@@ -74,6 +74,69 @@
         }
     /]
 
+    [#-- flowlogs --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "mgmt" : {
+                    "Components" : {
+                        "firewalllogs" : {
+                            "Type": "firewall",
+                            "deployment:Unit" : "aws-firewall",
+                            "Profiles" : {
+                                "Testing" : ["firewalllogs"]
+                            },
+                            "Logging": {
+                                "Events": "all"
+                            },
+                            "Engine" : "network",
+                            "Rules" : {
+                                "default" : {
+                                    "Action" : "drop",
+                                    "Priority" : "default",
+                                    "Inspection" : "Stateless"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "firewalllogs" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "loggingConfig" : {
+                                    "Name" : "networkfirewallloggingXmgmtXfirewalllogs",
+                                    "Type" : "AWS::NetworkFirewall::LoggingConfiguration"
+                                }
+                            }
+                        },
+                        "JSON" : {
+                            "Length" : {
+                                "LogDestinations" : {
+                                    "Path": "Resources.networkfirewallloggingXmgmtXfirewalllogs.Properties.LoggingConfiguration.LogDestinationConfigs",
+                                    "Count": 2
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "firewalllogs" : {
+                    "firewall" : {
+                        "TestCases" : [ "firewalllogs" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
+                    }
+                }
+            }
+        }
+    /]
+
     [#-- Simple Network rule --]
     [@loadModule
         blueprint={


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
When selecting the all log types for firewalls only the flow log was being created not the alerts which log when a drop or deny occurs 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
- When selecting the all option two log destinations should be created one for the flow logs and one for the alert logs

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with test suite

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

