### PR TITLE
feat: add support for kms replication of objects

### DIFF
--- a/aws/services/kms/policy.ftl
+++ b/aws/services/kms/policy.ftl
@@ -76,7 +76,13 @@
                 "",
                 {
                     "StringLike" : {
-                        "kms:EncryptionContext:aws:s3:arn" : "arn:aws:s3:::" + formatRelativePath(bucketName, bucketPrefix?ensure_ends_with("*") )
+                        "kms:EncryptionContext:aws:s3:arn" : formatRelativePath(
+                            bucketName?is_string?then(
+                                bucketName?ensure_starts_with("arn:aws:s3:::"),
+                                bucketName
+                            ),
+                            bucketPrefix?ensure_ends_with("*")
+                        )
                     }
                 }
             )

--- a/aws/services/s3/policy.ftl
+++ b/aws/services/s3/policy.ftl
@@ -243,6 +243,7 @@
     [#return
         getS3Statement(
             [
+                "s3:PutObject",
                 "s3:ReplicateObject",
                 "s3:ReplicateDelete",
                 "s3:ObjectOwnerOverrideToBucketOwner",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- When doing cross account replications for items that are encrypted at rest using SSE-KMS you need to provide a new key in the S3 account that can be used
- This update covers the extra permissions and processes that we do
- Adds PutObject permissions into the replication rule to accomodate Multipart uploads

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Make secure buckets with SSE replication work to other accounts

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally with active replication and works fine

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

