### PR TITLE
feat: cdn aliases

### DIFF
--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -49,6 +49,15 @@
         [#local aliases += [ formatDomainName(hostName, domain.Name) ] ]
     [/#list]
 
+    [#list solution.Aliases as id, alias ]
+        [#local aliasCertificateObject = getCertificateObject(alias.Hostname) ]
+        [#local aliasHostName = getHostName(aliasCertificateObject, occurrence) ]
+
+        [#list aliasCertificateObject.Domains as aliasDomain ]
+            [#local aliases += [ formatDomainName(aliasHostName, aliasDomain)]]
+        [/#list]
+    [/#list]
+
     [#local origins = []]
     [#local cacheBehaviours = []]
     [#local defaultCacheBehaviour = []]

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -1005,14 +1005,26 @@
 
                     [#case EC2_COMPONENT_TYPE]
                         [#list linkTargetResources["Zones"] as zone, resources ]
-                            [#if getExistingReference(resources["ec2ENI"].Id, IP_ADDRESS_ATTRIBUTE_TYPE)?has_content ]
-                                [#local staticTargets +=
-                                    getTargetGroupTarget(
-                                        "ip",
-                                        getExistingReference(resources["ec2ENI"].Id, IP_ADDRESS_ATTRIBUTE_TYPE),
-                                        destinationPort.Port,
-                                        false
-                                    )]
+                            [#if solution.Forward.TargetType == "ip" ]
+                                [#if getExistingReference(resources["ec2ENI"].Id, IP_ADDRESS_ATTRIBUTE_TYPE)?has_content ]
+                                    [#local staticTargets +=
+                                        getTargetGroupTarget(
+                                            "ip",
+                                            getExistingReference(resources["ec2ENI"].Id, IP_ADDRESS_ATTRIBUTE_TYPE),
+                                            destinationPort.Port,
+                                            false
+                                        )]
+                                [/#if]
+                            [#elseif solution.Forward.TargetType == "instance" ]
+                                [#if getExistingReference(resources["ec2Instance"].Id)?has_content ]
+                                    [#local staticTargets +=
+                                        getTargetGroupTarget(
+                                            "instance",
+                                            getExistingReference(resources["ec2Instance"].Id),
+                                            destinationPort.Port,
+                                            false
+                                        )]
+                                [/#if]
                             [/#if]
                         [/#list]
                         [#break]

--- a/awstest/modules/cdn/module.ftl
+++ b/awstest/modules/cdn/module.ftl
@@ -536,4 +536,86 @@
             }
         ]
     /]
+
+    [#-- Aliases --]
+    [@loadModule
+        blueprint={
+            "Tiers" : {
+                "web" : {
+                    "Components" : {
+                        "cdnaliases": {
+                            "Type": "cdn",
+                            "deployment:Unit": "aws-cdn",
+                            "Hostname" : {},
+                            "Aliases": {
+                                "env": {
+                                    "Hostname" : {
+                                        "IncludeInDomain" : {
+                                            "Environment" : true
+                                        },
+                                        "IncludeInHost" : {
+                                            "Environment" : false,
+                                            "Component": false,
+                                            "Host": true
+                                        },
+                                        "Host": "alias"
+                                    }
+                                }
+                            },
+                            "Routes" : {
+                                "default" : {
+                                    "PathPattern" : "_default",
+                                    "OriginSource" : "Placeholder",
+                                    "RedirectAliases" : {
+                                        "Enabled": false
+                                    }
+                                }
+                            },
+                            "Profiles" : {
+                                "Testing" : [ "cdnaliases" ]
+                            }
+                        }
+                    }
+                }
+            },
+            "TestCases" : {
+                "cdnaliases" : {
+                    "OutputSuffix" : "template.json",
+                    "Structural" : {
+                        "CFN" : {
+                            "Resource" : {
+                                "cfXwebXcdnaliases" : {
+                                    "Name" : "cfXwebXcdnaliases",
+                                    "Type" : "AWS::CloudFront::Distribution"
+                                }
+                            },
+                            "Output" : [
+                                "cfXwebXcdnaliasesXdns",
+                                "cfXwebXcdnaliases"
+                            ]
+                        },
+                        "JSON" : {
+                            "Match" : {
+                                "Aliases" : {
+                                    "Path"  : "Resources.cfXwebXcdnaliases.Properties.DistributionConfig.Aliases",
+                                    "Value" : ["cdnaliases-integration.mock.local", "alias.integration.mock.local"]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "TestProfiles" : {
+                "cdnaliases" : {
+                    "cdn" : {
+                        "TestCases" : [ "cdnaliases" ]
+                    },
+                    "*" : {
+                        "TestCases" : [ "_cfn-lint" ]
+                    }
+                }
+            }
+        }
+
+    /]
 [/#macro]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- AWS implementation of https://github.com/hamlet-io/engine/pull/2128 
- Adds the same features from #788 into the LB port SubComponent ( was previously only added to the backend component) 

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Makes it easy to configure multiple hostname aliases on CloudFront

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally and with test cases. 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

