### PR TITLE
feat(db): add storage type configuration support

### DIFF
--- a/aws/components/db/id.ftl
+++ b/aws/components/db/id.ftl
@@ -14,3 +14,36 @@
             AWS_AUTOSCALING_SERVICE
         ]
 /]
+
+
+[@addResourceGroupAttributeValues
+    type=DB_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names" : "Storage",
+            "Description" : "Additional storage configuration options",
+            "Children" : [
+                {
+                    "Names": "Type",
+                    "Description": "The type of storage to use for the database",
+                    "Types": STRING_TYPE,
+                    "Values" : ["gp2", "gp3", "io1", "standard"],
+                    "Default": "gp2"
+                },
+                {
+                    "Names": "Throughput",
+                    "Description": "Specifiy the throughput you want for gp-3 volumes",
+                    "Types" : NUMBER_TYPE,
+                    "Default" : -1
+                },
+                {
+                    "Names" : "Iops",
+                    "Description" : "Specify the IOPS you want for types that support it",
+                    "Types" : NUMBER_TYPE,
+                    "Default": -1
+                }
+            ]
+        }
+    ]
+/]

--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -1197,6 +1197,9 @@
                     copyTagsToSnapshot=true
                     deletionProtection=deletionProtection
                     cloudWatchLogExports=cloudWatchLogExports
+                    storageType=solution["aws:Storage"].Type
+                    storageIops=solution["aws:Storage"].Iops
+                    storageThroughput=solution["aws:Storage"].Throughput
                     maintenanceWindow=
                         solution.MaintenanceWindow.Configured?then(
                             getAmazonRdsMaintenanceWindow(


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds options for provisioned Iops and throughput on rds instances

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
AWS recently released the new gp3 storage option which provides a better way to manage IOPS on databases without them falling off the cliff when they hit burst balances. This allows for it to be used when required 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

