### PR TITLE
fix(topic): kms permissions

### DIFF
--- a/aws/components/topic/state.ftl
+++ b/aws/components/topic/state.ftl
@@ -40,7 +40,10 @@
                     "publish" : [snsPublishPermission(topicId)] +
                                 (solution.Encrypted)?then(
                                     snsEncryptionStatement(
-                                        [ "kms:GenerateDataKey*" ],
+                                        [
+                                            "kms:GenerateDataKey*",
+                                            "kms:Decrypt"
+                                        ],
                                         (baselineIds["Encryption"])!"",
                                         getExistingReference(topicId, REGION_ATTRIBUTE_TYPE)
                                     ),


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Adds decrypt permissions to the topic permissions policy when encryption at rest is enabled

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Decrypt permissions are required for some reason when publishing mesages to SNS

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

