### PR TITLE
fix(ecs): policy split for ecs tasks

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -1334,7 +1334,6 @@
         [#if solution.UseTaskRole]
             [#local roleId = resources["taskrole"].Id ]
             [#if deploymentSubsetRequired("iam", true) && isPartOfCurrentDeploymentUnit(roleId)]
-                [#local managedPolicy = []]
 
                 [#list containers as container]
                     [#-- Managed Policies --]
@@ -1348,8 +1347,8 @@
                     [#local policySet =
                         addInlinePolicyToSet(
                             policySet,
-                            formatDependentPolicyId(taskId, container.Id),
-                            container.Name,
+                            formatDependentPolicyId(taskId, container.ContaierId),
+                            container.ContaierId,
                             container.Policy
                         )
                     ]
@@ -1357,7 +1356,7 @@
                     [#local policySet =
                         addInlinePolicyToSet(
                             policySet,
-                            formatDependentPolicyId(taskId, container.Id, "links"),
+                            formatDependentPolicyId(taskId, container.ContaierId, "links"),
                             "links",
                             getLinkTargetsOutboundRoles(container.Links)
                         )
@@ -1395,7 +1394,7 @@
                 [@createRole
                     id=roleId
                     trustedServices=["ecs-tasks.amazonaws.com"]
-                    managedArns=managedPolicy
+                    managedArns=getManagedPoliciesFromSet(policySet)
                     tags=getOccurrenceTags(subOccurrence)
                 /]
 

--- a/aws/services/ecs/resource.ftl
+++ b/aws/services/ecs/resource.ftl
@@ -1099,6 +1099,7 @@
         [#local _context =
             containerDetails +
             {
+                "ContaierId": containerId,
                 "Essential" : container.Essential,
                 "Image": image.ImageLocation,
                 "MemoryReservation" : container.MemoryReservation,


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- Fixes an issue where iam policies split into managed policies aren't assigned to the task role
- Fixes an Id issue where the context id is used for policy naming which might not be unique

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Large policies were completely removed from the task role 
Using the container id would create duplicate policies that couldn't be assigned to the managed policy list

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

