### PR TITLE
feat: add the cluster type when calling snapshot username

### DIFF
--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -365,6 +365,7 @@
                         "# Check Snapshot Username",
                         "check_rds_snapshot_username" +
                         " \"" + getRegion() + "\" " +
+                        " \"" + hostType + "\" " +
                         " \"" + rdsManualSnapshot + "\" " +
                         " \"" + rdsUsername + "\" || return $?"
                     ],


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Support checking the db username for a cluster as well as an instance

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Deployments currently fail when the cluster is restoring from a snapshot

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- https://github.com/hamlet-io/executor-bash/pull/373

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

