### PR TITLE
feat(user): add permissions boundary arn config

### DIFF
--- a/aws/components/user/id.ftl
+++ b/aws/components/user/id.ftl
@@ -13,3 +13,16 @@
             AWS_TRANSFER_SERVICE
         ]
 /]
+
+
+[@addResourceGroupAttributeValues
+    type=USER_COMPONENT_TYPE
+    provider=AWS_PROVIDER
+    extensions=[
+        {
+            "Names" : "PermissionsBoundaryPolicyArn",
+            "Types": STRING_TYPE,
+            "Description": "The Arn of a Permissions Boundary Policy Arn"
+        }
+    ]
+/]

--- a/aws/components/user/setup.ftl
+++ b/aws/components/user/setup.ftl
@@ -234,6 +234,10 @@
                 attributeIfContent(
                     "ManagedPolicyArns",
                     getManagedPoliciesFromSet(policySet)
+                ) +
+                attributeIfContent(
+                    "PermissionsBoundary",
+                    (solution["aws:PermissionsBoundaryPolicyArn"])!""
                 )
             outputs=USER_OUTPUT_MAPPINGS
             tags=getOccurrenceTags(occurrence)


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Allows for setting a permissions boundary on a user creation which can be set via the solution. This is generally an enforced value provided through external processes so configuring it makes sense

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Permissions boundaries control what permissions can be assigned to a user. They are generally managed externally (i.e. via security policy ) so we make it a configured arn here

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

