### PR TITLE
feat: initial deployment contract support

### DIFF
--- a/aws/components/adaptor/setup.ftl
+++ b/aws/components/adaptor/setup.ftl
@@ -7,9 +7,13 @@
     [/#if]
 
     [@addDefaultGenerationContract
-        subsets=["pregeneration", "config", "template", "prologue", "epilogue" ]
+        subsets=["deploymentcontract", "pregeneration", "config", "template", "prologue", "epilogue" ]
         converters=converters
     /]
+[/#macro]
+
+[#macro aws_adaptor_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true epilogue=true /]
 [/#macro]
 
 [#macro aws_adaptor_cf_deployment_application occurrence ]

--- a/aws/components/apigateway/setup.ftl
+++ b/aws/components/apigateway/setup.ftl
@@ -1,7 +1,11 @@
 [#ftl]
 
 [#macro aws_apigateway_cf_deployment_generationcontract_application occurrence ]
-    [@addDefaultGenerationContract subsets=["pregeneration", "prologue", "template", "epilogue", "config", "cli" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "pregeneration", "prologue", "template", "epilogue", "config", "cli" ] /]
+[/#macro]
+
+[#macro aws_apigateway_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true epilogue=true /]
 [/#macro]
 
 [#macro aws_apigateway_cf_deployment_application occurrence ]

--- a/aws/components/apiusageplan/setup.ftl
+++ b/aws/components/apiusageplan/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_apiusageplan_cf_deployment_generationcontract_application occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"]  /]
+[/#macro]
+
+[#macro aws_apiusageplan_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_apiusageplan_cf_deployment_application occurrence ]

--- a/aws/components/backupstore/setup.ftl
+++ b/aws/components/backupstore/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_backupstore_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["template"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_backupstore_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_backupstore_cf_deployment_solution occurrence ]

--- a/aws/components/baseline/setup.ftl
+++ b/aws/components/baseline/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_baseline_cf_deployment_generationcontract_segment occurrence ]
-    [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "prologue", "template", "epilogue"] /]
+[/#macro]
+
+[#macro aws_baseline_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true epilogue=true /]
 [/#macro]
 
 [#macro aws_baseline_cf_deployment_segment occurrence ]

--- a/aws/components/bastion/setup.ftl
+++ b/aws/components/bastion/setup.ftl
@@ -1,13 +1,17 @@
 [#ftl]
 [#macro aws_bastion_cf_deployment_generationcontract_segment occurrence ]
     [@addDefaultGenerationContract
-        subsets="template"
+        subsets=["deploymentcontract", "template"]
         alternatives=[
             "primary",
             { "subset" : "template", "alternative" : "replace1"},
             { "subset" : "template", "alternative" : "replace2"}
         ]
     /]
+[/#macro]
+
+[#macro aws_bastion_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract changeset=true stack=false /]
 [/#macro]
 
 [#macro aws_bastion_cf_deployment_segment occurrence ]

--- a/aws/components/cache/setup.ftl
+++ b/aws/components/cache/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_cache_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_cache_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_cache_cf_deployment_solution occurrence ]
@@ -219,7 +223,7 @@
                         }
                     ) +
                     attributeIfTrue(
-                        "SnapshotRetentionLimit", 
+                        "SnapshotRetentionLimit",
                         solution.Backup.RetentionPeriod > 0,
                         solution.Backup.RetentionPeriod
                     )

--- a/aws/components/cdn/setup.ftl
+++ b/aws/components/cdn/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_cdn_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue", "cli" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "prologue", "template", "epilogue", "cli" ] /]
+[/#macro]
+
+[#macro aws_cdn_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true epilogue=true /]
 [/#macro]
 
 [#macro aws_cdn_cf_deployment_solution occurrence ]

--- a/aws/components/certificateauthority/setup.ftl
+++ b/aws/components/certificateauthority/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_certificateauthority_cf_deployment_generationcontract occurrence ]
-    [@addDefaultGenerationContract subsets=["template" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template" ] /]
+[/#macro]
+
+[#macro aws_certificateauthority_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_certificateauthority_cf_deployment_solution occurrence ]

--- a/aws/components/clientvpn/setup.ftl
+++ b/aws/components/clientvpn/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_clientvpn_cf_deployment_generationcontract occurrence ]
-    [@addDefaultGenerationContract subsets=["template"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_clientvpn_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_clientvpn_cf_deployment occurrence ]

--- a/aws/components/computecluster/setup.ftl
+++ b/aws/components/computecluster/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_computecluster_cf_deployment_generationcontract_application occurrence ]
-    [@addDefaultGenerationContract subsets=[ "pregeneration", "template" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "pregeneration", "template" ] /]
+[/#macro]
+
+[#macro aws_computecluster_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_computecluster_cf_deployment_application occurrence ]

--- a/aws/components/configstore/setup.ftl
+++ b/aws/components/configstore/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_configstore_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["template", "epilogue", "cli"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template", "epilogue", "cli"] /]
+[/#macro]
+
+[#macro aws_configstore_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract epilogue=true /]
 [/#macro]
 
 [#macro aws_configstore_cf_deployment occurrence_solution ]

--- a/aws/components/contenthub/setup.ftl
+++ b/aws/components/contenthub/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_contenthub_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets="prologue" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "prologue"] /]
+[/#macro]
+
+[#macro aws_contenthub_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true stack=false /]
 [/#macro]
 
 [#macro aws_contenthub_cf_deployment_solution occurrence ]

--- a/aws/components/contentnode/setup.ftl
+++ b/aws/components/contentnode/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_contentnode_cf_deployment_generationcontract_application occurrence ]
-    [@addDefaultGenerationContract subsets=[ "pregeneration", "prologue" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "pregeneration", "prologue" ] /]
+[/#macro]
+
+[#macro aws_contentnode_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true stack=false /]
 [/#macro]
 
 [#macro aws_contentnode_cf_deployment_application occurrence ]

--- a/aws/components/correspondent/setup.ftl
+++ b/aws/components/correspondent/setup.ftl
@@ -1,7 +1,11 @@
 [#ftl]
 
 [#macro aws_correspondent_cf_deployment_generationcontract occurrence ]
-    [@addDefaultGenerationContract subsets=["template"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_correspondent_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_correspondent_cf_deployment occurrence ]

--- a/aws/components/datacatalog/setup.ftl
+++ b/aws/components/datacatalog/setup.ftl
@@ -1,7 +1,11 @@
 [#ftl]
 
 [#macro aws_datacatalog_cf_deployment_generationcontract occurrence ]
-    [@addDefaultGenerationContract subsets=["template"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_datacatalog_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_datacatalog_cf_deployment occurrence ]

--- a/aws/components/datafeed/setup.ftl
+++ b/aws/components/datafeed/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_datafeed_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_datafeed_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_datafeed_cf_deployment_solution occurrence ]

--- a/aws/components/dataset/setup.ftl
+++ b/aws/components/dataset/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_dataset_cf_deployment_generationcontract_application occurrence ]
-    [@addDefaultGenerationContract subsets=[ "pregeneration", "prologue" ] /]
+    [@addDefaultGenerationContract subsets=[ "deploymentcontract", "pregeneration", "prologue" ] /]
+[/#macro]
+
+[#macro aws_dataset_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true stack=false /]
 [/#macro]
 
 [#macro aws_dataset_cf_deployment_application occurrence ]

--- a/aws/components/datastream/setup.ftl
+++ b/aws/components/datastream/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_datastream_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_datastream_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_datastream_cf_deployment_solution occurrence ]

--- a/aws/components/datavolume/setup.ftl
+++ b/aws/components/datavolume/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_datavolume_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["template", "epilogue"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template", "epilogue"] /]
+[/#macro]
+
+[#macro aws_datavolume_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract epilogue=true /]
 [/#macro]
 
 [#macro aws_datavolume_cf_deployment_solution occurrence ]

--- a/aws/components/db/setup.ftl
+++ b/aws/components/db/setup.ftl
@@ -1,13 +1,17 @@
 [#ftl]
 [#macro aws_db_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract
-        subsets=["prologue", "template", "epilogue"]
+        subsets=["deploymentcontract", "prologue", "template", "epilogue"]
         alternatives=[
             "primary",
             { "subset" : "template", "alternative" : "replace1"},
             { "subset" : "template", "alternative" : "replace2"}
         ]
     /]
+[/#macro]
+
+[#macro aws_db_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true changeset=true stack=false epilogue=true  /]
 [/#macro]
 
 [#macro aws_db_cf_deployment_solution occurrence ]

--- a/aws/components/directory/setup.ftl
+++ b/aws/components/directory/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_directory_cf_deployment_generationcontract occurrence ]
-    [@addDefaultGenerationContract subsets=[ "template", "epilogue" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template", "epilogue" ] /]
+[/#macro]
+
+[#macro aws_directory_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract epilogue=true /]
 [/#macro]
 
 [#macro aws_directory_cf_deployment occurrence ]

--- a/aws/components/dnszone/setup.ftl
+++ b/aws/components/dnszone/setup.ftl
@@ -1,8 +1,12 @@
 [#ftl]
 [#macro aws_dnszone_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract
-        subsets=["template"]
+        subsets=["deploymentcontract", "template"]
     /]
+[/#macro]
+
+[#macro aws_dnszone_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_dnszone_cf_deployment_solution occurrence ]

--- a/aws/components/docdb/setup.ftl
+++ b/aws/components/docdb/setup.ftl
@@ -1,13 +1,17 @@
 [#ftl]
 [#macro aws_docdb_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract
-        subsets=["prologue", "template", "epilogue"]
+        subsets=["deploymentcontract", "prologue", "template", "epilogue"]
         alternatives=[
             "primary",
             { "subset" : "template", "alternative" : "replace1"},
             { "subset" : "template", "alternative" : "replace2"}
         ]
     /]
+[/#macro]
+
+[#macro aws_docdb_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true stack=false changeset=true epilogue=true /]
 [/#macro]
 
 [#macro aws_docdb_cf_deployment_solution occurrence ]

--- a/aws/components/ec2/setup.ftl
+++ b/aws/components/ec2/setup.ftl
@@ -1,13 +1,17 @@
 [#ftl]
 [#macro aws_ec2_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract
-        subsets=[ "template" ]
+        subsets=[ "deploymentcontract", "template" ]
         alternatives=[
             "primary",
             { "subset" : "template", "alternative" : "replace1" },
             { "subset" : "template", "alternative" : "replace2" }
         ]
     /]
+[/#macro]
+
+[#macro aws_ec2_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract stack=false changeset=true /]
 [/#macro]
 
 [#macro aws_ec2_cf_deployment_solution occurrence ]

--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_ecs_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=[ "prologue", "template" ] /]
+    [@addDefaultGenerationContract subsets=[ "deploymentcontract", "prologue", "template" ] /]
+[/#macro]
+
+[#macro aws_ecs_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true /]
 [/#macro]
 
 [#macro aws_ecs_cf_deployment_solution occurrence ]

--- a/aws/components/es/setup.ftl
+++ b/aws/components/es/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_es_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["template", "epilogue" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template", "epilogue" ] /]
+[/#macro]
+
+[#macro aws_es_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract epilogue=true /]
 [/#macro]
 
 [#macro aws_es_cf_deployment_solution occurrence ]
@@ -464,11 +468,11 @@
                     "DomainEndpointOptions": {
                         "EnforceHTTPS": (securityProfile.ProtocolPolicy == "https-only"),
                         "TLSSecurityPolicy": securityProfile.HTTPSProfile
-                    } + 
+                    } +
                     attributeIfContent(
                         "CustomEndpoint",
                         esHostName
-                    ) + 
+                    ) +
                     attributeIfContent(
                         "CustomEndpointEnabled",
                         esHostName,
@@ -483,10 +487,10 @@
                 attributeIfContent("AdvancedOptions", esAdvancedOptions) +
                 attributeIfContent("SnapshotOptions", solution.Snapshot.Hour, solution.Snapshot.Hour) +
                 attributeIfTrue(
-                    "NodeToNodeEncryptionOptions", 
-                    (securityProfile.NodeTransitEncryption)!false, 
-                    {"Enabled": securityProfile.NodeTransitEncryption} 
-                ) + 
+                    "NodeToNodeEncryptionOptions",
+                    (securityProfile.NodeTransitEncryption)!false,
+                    {"Enabled": securityProfile.NodeTransitEncryption}
+                ) +
                 attributeIfContent(
                     "EBSOptions",
                     volume,

--- a/aws/components/externalnetwork/setup.ftl
+++ b/aws/components/externalnetwork/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_externalnetwork_cf_deployment_generationcontract_segment occurrence ]
-    [@addDefaultGenerationContract subsets=[ "template", "cli", "epilogue" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template", "cli", "epilogue" ] /]
+[/#macro]
+
+[#macro aws_externalnetwork_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract epilogue=true /]
 [/#macro]
 
 [#macro aws_externalnetwork_cf_deployment_segment occurrence ]

--- a/aws/components/federatedrole/setup.ftl
+++ b/aws/components/federatedrole/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_federatedrole_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_federatedrole_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_federatedrole_cf_deployment_solution occurrence ]

--- a/aws/components/fileshare/setup.ftl
+++ b/aws/components/fileshare/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_fileshare_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_fileshare_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_fileshare_cf_deployment_solution occurrence ]

--- a/aws/components/filetransfer/setup.ftl
+++ b/aws/components/filetransfer/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_filetransfer_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=[ "prologue", "template", "epilogue" ] /]
+    [@addDefaultGenerationContract subsets=[ "deploymentcontract", "prologue", "template", "epilogue" ] /]
+[/#macro]
+
+[#macro aws_filetransfer_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true epilogue=true /]
 [/#macro]
 
 [#macro aws_filetransfer_cf_deployment_solution occurrence ]

--- a/aws/components/firewall/setup.ftl
+++ b/aws/components/firewall/setup.ftl
@@ -1,7 +1,11 @@
 [#ftl]
 
 [#macro aws_firewall_cf_deployment_generationcontract occurrence ]
-    [@addDefaultGenerationContract subsets=["template"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_firewall_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_firewall_cf_deployment occurrence ]

--- a/aws/components/gateway/setup.ftl
+++ b/aws/components/gateway/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_gateway_cf_deployment_generationcontract_segment occurrence ]
-    [@addDefaultGenerationContract subsets=["template", "cli", "epilogue"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template", "cli", "epilogue"] /]
+[/#macro]
+
+[#macro aws_gateway_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract epilogue=true /]
 [/#macro]
 
 [#macro aws_gateway_cf_deployment_segment occurrence ]

--- a/aws/components/globaldb/setup.ftl
+++ b/aws/components/globaldb/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_globaldb_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["template" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template" ] /]
+[/#macro]
+
+[#macro aws_globaldb_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_globaldb_cf_deployment_solution occurrence ]

--- a/aws/components/healthcheck/setup.ftl
+++ b/aws/components/healthcheck/setup.ftl
@@ -1,8 +1,12 @@
 [#ftl]
 [#macro aws_healthcheck_cf_deployment_generationcontract occurrence ]
     [@addDefaultGenerationContract
-        subsets=[ "prologue", "template", "epilogue" ]
+        subsets=[ "deploymentcontract", "prologue", "template", "epilogue" ]
     /]
+[/#macro]
+
+[#macro aws_healthcheck_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true epilogue=true /]
 [/#macro]
 
 [#macro aws_healthcheck_cf_deployment occurrence ]

--- a/aws/components/image/setup.ftl
+++ b/aws/components/image/setup.ftl
@@ -2,8 +2,12 @@
 
 [#macro aws_image_cf_deployment_generationcontract_application occurrence ]
     [@addDefaultGenerationContract
-        subsets=["template", "epilogue" ]
+        subsets=["deploymentcontract", "template", "epilogue" ]
     /]
+[/#macro]
+
+[#macro aws_image_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract epilogue=true /]
 [/#macro]
 
 [#macro aws_image_cf_deployment_application occurrence ]

--- a/aws/components/lambda/setup.ftl
+++ b/aws/components/lambda/setup.ftl
@@ -12,7 +12,11 @@
         [/#if]
     [/#list]
 
-    [@addDefaultGenerationContract subsets=[ "pregeneration", "prologue", "template", "config", "epilogue"] converters=converters /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "pregeneration", "prologue", "template", "config", "epilogue"] converters=converters /]
+[/#macro]
+
+[#macro aws_lambda_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true epilogue=true /]
 [/#macro]
 
 [#macro aws_lambda_cf_deployment_application occurrence ]

--- a/aws/components/lb/setup.ftl
+++ b/aws/components/lb/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_lb_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["prologue", "template", "cli", "epilogue" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "prologue", "template", "cli", "epilogue" ] /]
+[/#macro]
+
+[#macro aws_lb_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true epilogue=true /]
 [/#macro]
 
 [#macro aws_lb_cf_deployment_solution occurrence ]

--- a/aws/components/logstore/setup.ftl
+++ b/aws/components/logstore/setup.ftl
@@ -1,7 +1,11 @@
 [#ftl]
 
 [#macro aws_logstore_cf_deployment_generationcontract occurrence ]
-    [@addDefaultGenerationContract subsets=[ "template" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template" ] /]
+[/#macro]
+
+[#macro aws_logstore_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_logstore_cf_deployment occurrence ]

--- a/aws/components/mobileapp/setup.ftl
+++ b/aws/components/mobileapp/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_mobileapp_cf_deployment_generationcontract_application occurrence ]
-    [@addDefaultGenerationContract subsets=["pregeneration", "prologue", "config"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "pregeneration", "prologue", "config"] /]
+[/#macro]
+
+[#macro aws_mobileapp_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true stack=false /]
 [/#macro]
 
 [#macro aws_mobileapp_cf_deployment_application occurrence ]

--- a/aws/components/mobilenotifier/setup.ftl
+++ b/aws/components/mobilenotifier/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_mobilenotifier_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue", "cli"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "prologue", "template", "epilogue", "cli"] /]
+[/#macro]
+
+[#macro aws_mobilenotifier_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true epilogue=true /]
 [/#macro]
 
 [#macro aws_mobilenotifier_cf_deployment_solution occurrence ]

--- a/aws/components/mta/setup.ftl
+++ b/aws/components/mta/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_mta_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["template"]+(occurrence.Configuration.Solution.Direction == "send")?then(["epilogue"],[]) /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"]+(occurrence.Configuration.Solution.Direction == "send")?then(["epilogue"],[]) /]
+[/#macro]
+
+[#macro aws_mta_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract epilogue=true /]
 [/#macro]
 
 [#macro aws_mta_cf_deployment_solution occurrence ]

--- a/aws/components/network/setup.ftl
+++ b/aws/components/network/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_network_cf_deployment_generationcontract_segment occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_network_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_network_cf_deployment_segment occurrence ]

--- a/aws/components/objectsql/setup.ftl
+++ b/aws/components/objectsql/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_objectsql_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["cli", "prologue"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "cli", "prologue"] /]
+[/#macro]
+
+[#macro aws_objectsql_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true stack=false /]
 [/#macro]
 
 [#macro aws_objectsql_cf_deployment_solution occurrence ]

--- a/aws/components/privateservice/setup.ftl
+++ b/aws/components/privateservice/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_privateservice_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"]  /]
+[/#macro]
+
+[#macro aws_privateservice_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_privateservice_cf_deployment_solution occurrence ]

--- a/aws/components/queuehost/setup.ftl
+++ b/aws/components/queuehost/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_queuehost_cf_deployment_generationcontract occurrence ]
-    [@addDefaultGenerationContract subsets=[ "template", "epilogue" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template", "epilogue" ] /]
+[/#macro]
+
+[#macro aws_queuehost_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract epilogue=true /]
 [/#macro]
 
 [#macro aws_queuehost_cf_deployment occurrence ]

--- a/aws/components/router/setup.ftl
+++ b/aws/components/router/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_router_cf_deployment_generationcontract_segment occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_router_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_router_cf_deployment_segment occurrence ]

--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_s3_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_s3_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_s3_cf_deployment_solution occurrence ]

--- a/aws/components/secretstore/setup.ftl
+++ b/aws/components/secretstore/setup.ftl
@@ -1,7 +1,11 @@
 [#ftl]
 
 [#macro aws_secretstore_cf_deployment_generationcontract occurrence ]
-    [@addDefaultGenerationContract subsets=[ "template", "epilogue" ] /]
+    [@addDefaultGenerationContract subsets=[ "deploymentcontract", "template", "epilogue" ] /]
+[/#macro]
+
+[#macro aws_secretstore_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract epilogue=true /]
 [/#macro]
 
 [#macro aws_secretstore_cf_deployment occurrence ]

--- a/aws/components/serviceregistry/setup.ftl
+++ b/aws/components/serviceregistry/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_serviceregistry_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_serviceregistry_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_serviceregistry_cf_deployment_solution occurrence ]

--- a/aws/components/spa/setup.ftl
+++ b/aws/components/spa/setup.ftl
@@ -8,7 +8,11 @@
 [/#macro]
 
 [#macro aws_spa_cf_deployment_generationcontract_application occurrence  ]
-    [@addDefaultGenerationContract subsets=["pregeneration", "prologue", "config", "epilogue" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "pregeneration", "prologue", "config", "epilogue" ] /]
+[/#macro]
+
+[#macro aws_spa_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true epilogue=true/]
 [/#macro]
 
 [#macro aws_spa_cf_deployment_application occurrence  ]

--- a/aws/components/sqs/setup.ftl
+++ b/aws/components/sqs/setup.ftl
@@ -1,13 +1,17 @@
 [#ftl]
 [#macro aws_sqs_cf_deployment_generationcontract_solution occurrence ]
     [@addDefaultGenerationContract
-        subsets="template"
+        subsets=["deploymentcontract", "template"]
         alternatives=[
             "primary",
             { "subset" : "template", "alternative" : "replace1" },
             { "subset" : "template", "alternative" : "replace2" }
         ]
     /]
+[/#macro]
+
+[#macro aws_sqs_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract changeset=true stack=false /]
 [/#macro]
 
 [#macro aws_sqs_cf_deployment_solution occurrence ]

--- a/aws/components/template/setup.ftl
+++ b/aws/components/template/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_template_cf_deployment_generationcontract_application occurrence ]
-    [@addDefaultGenerationContract subsets=[ "pregeneration", "prologue", "template" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract",  "pregeneration", "prologue", "template" ] /]
+[/#macro]
+
+[#macro aws_template_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_template_cf_deployment_application occurrence ]

--- a/aws/components/topic/setup.ftl
+++ b/aws/components/topic/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_topic_cf_deployment_generationcontract occurrence ]
-    [@addDefaultGenerationContract subsets="template" /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template"] /]
+[/#macro]
+
+[#macro aws_topic_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract /]
 [/#macro]
 
 [#macro aws_topic_cf_deployment occurrence ]

--- a/aws/components/user/setup.ftl
+++ b/aws/components/user/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_user_cf_deployment_generationcontract_application occurrence ]
-    [@addDefaultGenerationContract subsets=["prologue", "template", "epilogue"] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "prologue", "template", "epilogue"] /]
+[/#macro]
+
+[#macro aws_user_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract prologue=true epilogue=true /]
 [/#macro]
 
 [#macro aws_user_cf_deployment_application occurrence ]

--- a/aws/components/userpool/setup.ftl
+++ b/aws/components/userpool/setup.ftl
@@ -1,6 +1,10 @@
 [#ftl]
 [#macro aws_userpool_cf_deployment_generationcontract_solution occurrence ]
-    [@addDefaultGenerationContract subsets=["template", "epilogue" ] /]
+    [@addDefaultGenerationContract subsets=["deploymentcontract", "template", "epilogue" ] /]
+[/#macro]
+
+[#macro aws_userpool_cf_deployment_deploymentcontract occurrence ]
+    [@addDefaultAWSDeploymentContract epilogue=true /]
 [/#macro]
 
 [#macro aws_userpool_cf_deployment_solution occurrence ]

--- a/aws/tasks/aws_cfn_create_change_set/id.ftl
+++ b/aws/tasks/aws_cfn_create_change_set/id.ftl
@@ -1,0 +1,65 @@
+[#ftl]
+
+[@addTask
+    type=AWS_CFN_CREATE_CHANGE_SET_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Create a change set for a cloudformation stack"
+            }
+        ]
+    attributes=[
+        {
+            "Names": "StackName",
+            "Description": "The name to use for the stack",
+            "Types": STRING_TYPE,
+            "Mandatory": true
+        },
+        {
+            "Names": "ChangeSetName",
+            "Description": "The name of the change set to create",
+            "Types": STRING_TYPE,
+            "Mandatory": true
+        },
+        {
+            "Names": "TemplateS3Uri",
+            "Description": "An S3 Url to where the template is stored",
+            "Types": STRING_TYPE
+        },
+        {
+            "Names": "TemplateBody",
+            "Description": "A string containing the template to deploy",
+            "Types": STRING_TYPE
+        },
+        {
+            "Names": "Parameters",
+            "Description": "A JSON escaped string containing the paramters for the template",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Capabilities",
+            "Description" : "A comma seperated list of capabilities that can be used in the template",
+            "Default" : "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/aws_cfn_delete_stack/id.ftl
+++ b/aws/tasks/aws_cfn_delete_stack/id.ftl
@@ -1,0 +1,39 @@
+[#ftl]
+
+[@addTask
+    type=AWS_CFN_DELETE_STACK_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Delete a cloudformation stack"
+            }
+        ]
+    attributes=[
+        {
+            "Names": "StackName",
+            "Description": "The name to use for the stack",
+            "Types": STRING_TYPE,
+            "Mandatory": true
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/aws_cfn_execute_change_set/id.ftl
+++ b/aws/tasks/aws_cfn_execute_change_set/id.ftl
@@ -1,0 +1,45 @@
+[#ftl]
+
+[@addTask
+    type=AWS_CFN_EXECUTE_CHANGE_SET_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Execute a change set for a cloudformation stack"
+            }
+        ]
+    attributes=[
+        {
+            "Names": "StackName",
+            "Description": "The name to use for the stack",
+            "Types": STRING_TYPE,
+            "Mandatory": true
+        },
+        {
+            "Names": "ChangeSetName",
+            "Description": "The name of the change set to create",
+            "Types": STRING_TYPE,
+            "Mandatory": true
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/aws_cfn_get_change_set_changes_types/id.ftl
+++ b/aws/tasks/aws_cfn_get_change_set_changes_types/id.ftl
@@ -1,0 +1,45 @@
+[#ftl]
+
+[@addTask
+    type=AWS_CFN_GET_CHANGE_SET_CHANGES_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Return a list of resources that are changed in the stack set"
+            }
+        ]
+    attributes=[
+        {
+            "Names": "StackName",
+            "Description": "The name to use for the stack",
+            "Types": STRING_TYPE,
+            "Mandatory": true
+        },
+        {
+            "Names": "ChangeSetName",
+            "Description": "The name of the change set to create",
+            "Types": STRING_TYPE,
+            "Mandatory": true
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/aws_cfn_get_stack_outputs/id.ftl
+++ b/aws/tasks/aws_cfn_get_stack_outputs/id.ftl
@@ -1,0 +1,39 @@
+[#ftl]
+
+[@addTask
+    type=AWS_CFN_GET_STACK_OUTPUTS_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Get the outputs of a stack"
+            }
+        ]
+    attributes=[
+        {
+            "Names": "StackName",
+            "Description": "The name to use for the stack",
+            "Types": STRING_TYPE,
+            "Mandatory": true
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/aws_cfn_run_stack/id.ftl
+++ b/aws/tasks/aws_cfn_run_stack/id.ftl
@@ -1,0 +1,59 @@
+[#ftl]
+
+[@addTask
+    type=AWS_CFN_RUN_STACK_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Update or create cfn stack"
+            }
+        ]
+    attributes=[
+        {
+            "Names": "StackName",
+            "Description": "The name to use for the stack",
+            "Types": STRING_TYPE,
+            "Mandatory": true
+        },
+        {
+            "Names": "TemplateS3Uri",
+            "Description": "An S3 Url to where the template is stored",
+            "Types": STRING_TYPE
+        },
+        {
+            "Names": "TemplateBody",
+            "Description": "A string containing the template to deploy",
+            "Types": STRING_TYPE
+        },
+        {
+            "Names": "Parameters",
+            "Description": "A JSON escaped string containing the paramters for the template",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "Capabilities",
+            "Description" : "A comma seperated list of capabilities that can be used in the template",
+            "Default" : "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/aws_cfn_write_stack_outputs_to_file/id.ftl
+++ b/aws/tasks/aws_cfn_write_stack_outputs_to_file/id.ftl
@@ -1,23 +1,23 @@
 [#ftl]
 
 [@addTask
-    type=AWS_RUN_BASH_SCRIPT_TASK_TYPE
+    type=AWS_CFN_WRITE_STACK_OUTPUTS_TO_FILE_TASK_TYPE
     properties=[
             {
                 "Type"  : "Description",
-                "Value" : "Run a provided bash script with AWS Credentials set in the environment"
+                "Value" : "Get the outputs of a stack and write them to file"
             }
         ]
     attributes=[
         {
-            "Names": "ScriptPath",
-            "Description": "The path to the script to run",
+            "Names": "StackName",
+            "Description": "The name to use for the stack",
             "Types": STRING_TYPE,
             "Mandatory": true
         },
         {
-            "Names": "Environment",
-            "Description": "A json escaped dict with k/v environment variable pairs",
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
             "Types" : STRING_TYPE
         },
         {
@@ -34,6 +34,12 @@
             "Names" : "AWSSessionToken",
             "Description" : "The AWS Session Token with access to decrypt",
             "Types" : STRING_TYPE
+        },
+        {
+            "Names": "FilePath",
+            "Description": "The path to where the file should be written",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
         }
     ]
 /]

--- a/aws/tasks/aws_run_bash_script/id.ftl
+++ b/aws/tasks/aws_run_bash_script/id.ftl
@@ -1,0 +1,34 @@
+[#ftl]
+
+[@addTask
+    type=AWS_RUN_BASH_SCRIPT_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Run a provided bash script with AWS Credentials set in the environment"
+            }
+        ]
+    attributes=[
+        {
+            "Names": "ScriptPath",
+            "Description": "The path to the script to run",
+            "Types": STRING_TYPE,
+            "Mandatory": true
+        },
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/aws_s3_presign_url/id.ftl
+++ b/aws/tasks/aws_s3_presign_url/id.ftl
@@ -1,0 +1,58 @@
+[#ftl]
+
+[@addTask
+    type=AWS_S3_PRESIGN_URL_TASK_TYPE
+    properties=[
+            {
+                "Type"  : "Description",
+                "Value" : "Return a presigned URL for an S3 object"
+            }
+        ]
+    attributes=[
+        {
+            "Names" : "BucketName",
+            "Description" : "The name of the S3 Bucket",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names": "Object",
+            "Description" : "The path of the object in the bucket",
+            "Types" : STRING_TYPE,
+            "Mandatory" : true
+        },
+        {
+            "Names": "ClientMethod",
+            "Description": "The aws s3 methods that can be performed on the object - comma seperated",
+            "Values" : [ "get_object" ],
+            "Types": STRING_TYPE,
+            "Default": "get_object"
+        },
+        {
+            "Names": "Expiration",
+            "Description": "The expiration time in seconds for the presigned URL",
+            "Types": [ NUMBER_TYPE, STRING_TYPE],
+            "Default": 300
+        },
+        {
+            "Names" : "Region",
+            "Description" : "The name of the region to use for the aws session",
+            "Types" : STRING_TYPE
+        }
+        {
+            "Names" : "AWSAccessKeyId",
+            "Description" : "The AWS Access Key Id with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSecretAccessKey",
+            "Description" : "The AWS Secret Access Key with access to decrypt",
+            "Types" : STRING_TYPE
+        },
+        {
+            "Names" : "AWSSessionToken",
+            "Description" : "The AWS Session Token with access to decrypt",
+            "Types" : STRING_TYPE
+        }
+    ]
+/]

--- a/aws/tasks/task.ftl
+++ b/aws/tasks/task.ftl
@@ -25,5 +25,6 @@
 [#assign AWS_CFN_GET_STACK_OUTPUTS_TASK_TYPE = "aws_cfn_get_stack_outputs"]
 [#assign AWS_CFN_GET_CHANGE_SET_CHANGES_TASK_TYPE = "aws_cfn_get_change_set_changes_types"]
 [#assign AWS_CFN_RUN_STACK_TASK_TYPE = "aws_cfn_run_stack"]
+[#assign AWS_CFN_WRITE_STACK_OUTPUTS_TO_FILE_TASK_TYPE = "aws_cfn_write_stack_outputs_to_file"]
 
 [#assign AWS_RUN_BASH_SCRIPT_TASK_TYPE = "aws_run_bash_script"]

--- a/aws/tasks/task.ftl
+++ b/aws/tasks/task.ftl
@@ -9,9 +9,21 @@
 [#assign AWS_KMS_ENCRYPT_VALUE_TASK_TYPE = "aws_kms_encrypt_value" ]
 [#assign AWS_KMS_DECRYPT_CIPHERTEXT_TASK_TYPE = "aws_kms_decrypt_ciphertext" ]
 [#assign AWS_LAMBDA_INVOKE_FUNCTION_TASK_TYPE = "aws_lambda_invoke_function"]
+
 [#assign AWS_S3_DOWNLOAD_BUCKET_TASK_TYPE = "aws_s3_download_bucket"]
 [#assign AWS_S3_DOWNLOAD_OBJECT_TASK_TYPE = "aws_s3_download_object" ]
 [#assign AWS_S3_EMPTY_BUCKET_TASK_TYPE = "aws_s3_empty_bucket"]
 [#assign AWS_S3_UPLOAD_OBJECT_TASK_TYPE = "aws_s3_upload_object" ]
+[#assign AWS_S3_PRESIGN_URL_TASK_TYPE = "aws_s3_presign_url" ]
+
 [#assign AWS_SECRETSMANAGER_GET_SECRET_VALUE_TASK_TYPE = "aws_secretsmanager_get_secret_value"]
 [#assign AWS_SES_SMTP_PASSWORD_TASK_TYPE = "aws_ses_smtp_password" ]
+
+[#assign AWS_CFN_CREATE_CHANGE_SET_TASK_TYPE = "aws_cfn_create_change_set"]
+[#assign AWS_CFN_EXECUTE_CHANGE_SET_TASK_TYPE = "aws_cfn_execute_change_set"]
+[#assign AWS_CFN_DELETE_STACK_TASK_TYPE = "aws_cfn_delete_stack"]
+[#assign AWS_CFN_GET_STACK_OUTPUTS_TASK_TYPE = "aws_cfn_get_stack_outputs"]
+[#assign AWS_CFN_GET_CHANGE_SET_CHANGES_TASK_TYPE = "aws_cfn_get_change_set_changes_types"]
+[#assign AWS_CFN_RUN_STACK_TASK_TYPE = "aws_cfn_run_stack"]
+
+[#assign AWS_RUN_BASH_SCRIPT_TASK_TYPE = "aws_run_bash_script"]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
Adds support for deployment contract based deployments of AWS resources

A standard AWS deployment contract is included which runs the standard prolouge and epilogue scripts either side of a cloudformation stack run

As part of the component definition either change set or stack can be used which will either create a CFN change set or just run an update/create on the stack

The contract also takes into account the mode and includes all the steps to complete a full stop start or stop deployment in a single contract

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
To make deployment control work as part of the python exector and give control over defining the deployment to the engine. 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Ongoing testing locally 

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

