### PR TITLE
feat(s3): batch replication support

### DIFF
--- a/aws/components/s3/setup.ftl
+++ b/aws/components/s3/setup.ftl
@@ -301,10 +301,10 @@
                             [#local replicationExternalPolicy +=   s3ReplicaDestinationPermission( linkTargetAttributes["ARN"] ) ]
                             [#local replicationBucket = linkTargetAttributes["ARN"]]
                             [#local replicationKMSKey = (linkTargetAttributes["KMS_KEY_ARN"])!""]
-                            [#local replicationKMSKeyARN = (linkTargetAttributes["KMS_KEY_REGION"])!""]
+                            [#local replicationKMSKeyRegion = (linkTargetAttributes["KMS_KEY_REGION"])!""]
 
                             [#if replicationKMSKey?has_content ]
-                                [#local replicationExternalPolicy += s3EncryptionAllPermission(replicationKMSKey, replicationBucket, "*", replicationKMSKeyARN)]
+                                [#local replicationExternalPolicy += s3EncryptionAllPermission(replicationKMSKey, replicationBucket, "*", replicationKMSKeyRegion)]
                             [/#if]
 
                             [#break]
@@ -446,6 +446,7 @@
                     linkPolicies) +
                 arrayIfContent(
                     getPolicyDocument(
+                        s3ReplicaSourceBatchPermission(s3Id) +
                         s3ReplicaSourcePermission(s3Id) +
                         s3ReplicationConfigurationPermission(s3Id),
                         "replication"),
@@ -462,7 +463,11 @@
         [#if rolePolicies?has_content ]
             [@createRole
                 id=roleId
-                trustedServices=["s3.amazonaws.com"]
+                trustedServices=[
+                    "s3.amazonaws.com"
+                    [#-- Included here so that the same IAM Role can be used for batch replication --]
+                    "batchoperations.s3.amazonaws.com"
+                ]
                 policies=rolePolicies
                 tags=getOccurrenceTags(occurrence)
             /]

--- a/aws/services/s3/policy.ftl
+++ b/aws/services/s3/policy.ftl
@@ -227,6 +227,30 @@
     ]
 [/#function]
 
+[#function s3ReplicaSourceBatchPermission bucket prefix="" object="*"]
+    [#return
+        getS3BucketStatement(
+            [
+                "s3:GetReplicationConfiguration",
+                "s3:PutInventoryConfiguration"
+            ],
+            bucket
+        ) +
+        getS3Statement(
+            [
+                "s3:InitiateReplication",
+                "s3:GetObject",
+                "s3:GetObjectVersion",
+                "s3:PutObject"
+            ],
+            bucket,
+            prefix,
+            object
+        )
+    ]
+[/#function]
+
+
 [#function s3ReplicationConfigurationPermission bucket ]
     [#return
         getS3BucketStatement(

--- a/aws/services/s3/resource.ftl
+++ b/aws/services/s3/resource.ftl
@@ -314,6 +314,9 @@
 
     [#return
         {
+            "Id": replaceAlphaNumericOnly(
+                destinationBucket?remove_beginning("arn:aws:s3:::") + "_" + prefix
+            ),
             "Status" : enabled?then(
                 "Enabled",
                 "Disabled"


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
- Updates the existing IAM role used for the s3 object replication so that it can also be used for batch replication tasks
- Adds baseline support for providing a different KMS key when working with cross account replication

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
When you enable S3 bucket replication only new items are replicated and anything that matches the replication prefix before then isn't replicated. To replicate existing objects you need to use the S3 Batch Operations process to run a batch replication job. This needs an IAM role with very similar permissions to the replication role. So this just tweaks the role to work with both processes 

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

