### PR TITLE
feat: support recommended token auth method for Pinpoint channels

### DIFF
--- a/aws/components/correspondent/setup.ftl
+++ b/aws/components/correspondent/setup.ftl
@@ -34,28 +34,67 @@
 
             [#switch solution.Engine ]
                 [#case "apns"]
-                    [@createPinpointAPNSChannel
-                        id=channelId
-                        pinpointAppId=correspondentId
-                        certificate=(solution["engine:APNS"].Certificate)!"HamletFatal: engine:APNS.Certificate configuration required for APNS Channel"
-                        privateKey=(solution["engine:APNS"].PrivateKey)!"HamletFatal: engine:APNS.PrivateKey configuration required for APNS Channel"
-                    /]
+                    [#switch solution.AuthMethod ]
+                        [#case "certificate"]
+                            [@createPinpointAPNSChannel
+                                id=channelId
+                                pinpointAppId=correspondentId
+                                certificate=(solution["engine:APNS"].Certificate)!"HamletFatal: engine:APNS.Certificate configuration required for APNS Channel"
+                                privateKey=(solution["engine:APNS"].PrivateKey)!"HamletFatal: engine:APNS.PrivateKey configuration required for APNS Channel"
+                            /]
+                            [#break]
+                        [#case "token"]
+                            [@createPinpointAPNSChannelWithTokenKey
+                                id=channelId
+                                pinpointAppId=correspondentId
+                                tokenKeyId=(solution["engine:APNS"].TokenKeyId)!"HamletFatal: engine:APNS.TokenKeyId configuration required for APNS Channel"
+                                bundleId=(solution["engine:APNS"].BundleId)!"HamletFatal: engine:APNS.BundleId configuration required for APNS Channel"
+                                teamId=(solution["engine:APNS"].TeamId)!"HamletFatal: engine:APNS.TeamId configuration required for APNS Channel"
+                                tokenKey=(solution["engine:APNS"].TokenKey)!"HamletFatal: engine:APNS.TokenKey configuration required for APNS Channel"
+                            /]
+                            [#break]
+                    [/#switch]
                     [#break]
                 [#case "apns_sandbox"]
-                    [@createPinpointAPNSSandboxChannel
-                        id=channelId
-                        pinpointAppId=correspondentId
-                        certificate=(solution["engine:APNSSandbox"].Certificate)!"HamletFatal: engine:APNSSandbox.Certificate configuration required for APNS Channel"
-                        privateKey=(solution["engine:APNSSandbox"].PrivateKey)!"HamletFatal: engine:APNSSandbox.PrivateKey configuration required for APNS Channel"
-                    /]
+                    [#switch solution.AuthMethod ]
+                        [#case "certificate"]
+                            [@createPinpointAPNSSandboxChannel
+                                id=channelId
+                                pinpointAppId=correspondentId
+                                certificate=(solution["engine:APNSSandbox"].Certificate)!"HamletFatal: engine:APNSSandbox.Certificate configuration required for APNS Sandbox Channel"
+                                privateKey=(solution["engine:APNSSandbox"].PrivateKey)!"HamletFatal: engine:APNSSandbox.PrivateKey configuration required for APNS Sandbox Channel"
+                            /]
+                            [#break]
+                        [#case "token"]
+                            [@createPinpointAPNSSandboxChannelWithTokenKey
+                                id=channelId
+                                pinpointAppId=correspondentId
+                                tokenKeyId=(solution["engine:APNSSandbox"].TokenKeyId)!"HamletFatal: engine:APNSSandbox.TokenKeyId configuration required for APNS Sandbox Channel"
+                                bundleId=(solution["engine:APNSSandbox"].BundleId)!"HamletFatal: engine:APNSSandbox.BundleId configuration required for APNS Sandbox Channel"
+                                teamId=(solution["engine:APNSSandbox"].TeamId)!"HamletFatal: engine:APNSSandbox.TeamId configuration required for APNS Sandbox Channel"
+                                tokenKey=(solution["engine:APNSSandbox"].TokenKey)!"HamletFatal: engine:APNSSandbox.TokenKey configuration required for APNS Sandbox Channel"
+                            /]
+                            [#break]
+                    [/#switch]
                     [#break]
 
                 [#case "firebase"]
-                    [@createPinpointGCMChannel
-                        id=channelId
-                        pinpointAppId=correspondentId
-                        apiKey=(solution["engine:Firebase"].APIKey)!"HamletFatal: engine:Firebase.APIKey configuration required for APNS Channel"
-                    /]
+                    [#switch solution.AuthMethod ]
+                        [#case "apikey"]
+                            [@createPinpointGCMChannel
+                                id=channelId
+                                pinpointAppId=correspondentId
+                                apiKey=(solution["engine:Firebase"].APIKey)!"HamletFatal: engine:Firebase.APIKey configuration required for GCM Channel"
+                            /]
+                            [#break]
+                        [#case "token"]
+                            [@createPinpointGCMChannelWithToken
+                                id=channelId
+                                pinpointAppId=correspondentId
+                                token=(solution["engine:Firebase"].Token)!"HamletFatal: engine:Firebase.Token configuration required for GCM Channel"
+                            /]
+                            [#break]
+                    [/#switch]
                     [#break]
 
                 [#default]

--- a/aws/services/pinpoint/resource.ftl
+++ b/aws/services/pinpoint/resource.ftl
@@ -66,13 +66,59 @@
     /]
 [/#macro]
 
+[#macro createPinpointAPNSChannelWithTokenKey id pinpointAppId tokenKeyId bundleId teamId tokenKey dependencies=[] ]
+    [@cfResource
+        id=id
+        type="AWS::Pinpoint::APNSChannel"
+        properties={
+            "ApplicationId": getReference(pinpointAppId),
+            "DefaultAuthenticationMethod" : "TOKEN",
+            "TokenKeyId" : tokenKeyId,
+            "BundleId" : bundleId,
+            "TeamId" : teamId,
+            "TokenKey" : tokenKey
+        }
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#macro createPinpointAPNSSandboxChannelWithTokenKey id pinpointAppId tokenKeyId bundleId teamId tokenKey dependencies=[] ]
+    [@cfResource
+        id=id
+        type="AWS::Pinpoint::APNSSandboxChannel"
+        properties={
+            "ApplicationId": getReference(pinpointAppId),
+            "DefaultAuthenticationMethod" : "TOKEN",
+            "TokenKeyId" : tokenKeyId,
+            "BundleId" : bundleId,
+            "TeamId" : teamId,
+            "TokenKey" : tokenKey
+        }
+        dependencies=dependencies
+    /]
+[/#macro]
+
 [#macro createPinpointGCMChannel id pinpointAppId apiKey dependencies=[]]
     [@cfResource
         id=id
         type="AWS::Pinpoint::GCMChannel"
         properties={
             "ApplicationId" : getReference(pinpointAppId),
+            "DefaultAuthenticationMethod" : "KEY",
             "ApiKey": apiKey
+        }
+        dependencies=dependencies
+    /]
+[/#macro]
+
+[#macro createPinpointGCMChannelWithToken id pinpointAppId token dependencies=[]]
+    [@cfResource
+        id=id
+        type="AWS::Pinpoint::GCMChannel"
+        properties={
+            "ApplicationId" : getReference(pinpointAppId),
+            "DefaultAuthenticationMethod" : "TOKEN",
+            "ServiceJson": token
         }
         dependencies=dependencies
     /]


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
The recommended DefaultAuthenticationMethod for APNSChannel and GCMChannel is "TOKEN", which wasn't supported in hamlet

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
To get the push notifications working for one of our tenant.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
The Pinpoint configuration was updated and push notifications are confirmed to be working for two environments and both ios and android platforms.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- hamlet-io/engine/pull/2133

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

