### PR TITLE
fix: autoMinorVersionUpdate flag for Amazon MQ resource

### DIFF
--- a/aws/components/queuehost/setup.ftl
+++ b/aws/components/queuehost/setup.ftl
@@ -194,7 +194,7 @@
                         getSecretManagerSecretRef(resources["rootCredentials"]["secret"].Id, "password")
                     )
                 ]
-                autoMinorVersionUpdate=solution.AutoMinorUpgrade
+                autoMinorVersionUpdate=solution.AutoMinorVersionUpgrade
                 logging=true
                 maintenanceWindow=
                     solution.MaintenanceWindow.Configured?then(


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Setup template uses the default property defined in the resource.
```
{
                "Names" : ["AutoMinorVersionUpgrade", "AutoMinorUpgrade"],
                "Types" : BOOLEAN_TYPE,
                "Default" : true
            }
``` 
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
AmazonMQ v3.13 requires auto minor version upgrade to be enabled. The flag `AutoMinorUpgrade` set to true in the solution was ignored, because when the solution object is generated it uses the first name from the array.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

