### PR TITLE
fix(ecs): set security group for a scheduled task

### DIFF
--- a/aws/components/ecs/setup.ftl
+++ b/aws/components/ecs/setup.ftl
@@ -1468,9 +1468,11 @@
                      }]
 
                     [#if networkMode == "awsvpc" ]
+                        [#local ecsSecurityGroupId = resources["securityGroup"].Id ]
                         [#local ecsParameters += {
                             "NetworkConfiguration" : {
                                 "AwsVpcConfiguration" : {
+                                    "SecurityGroups" : getReferences(ecsSecurityGroupId),
                                     "Subnets" : subnets,
                                     "AssignPublicIp" : publicRouteTable?then(
                                                         "ENABLE",


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)
## Description
<!--- Describe your changes in detail -->
Security group needs to be set for a scheduled tasks running on aws fargate.
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Without a security group specified for scheduled tasks running on aws fargate a default one is used which may have not required ingress and egress rules set for a task to access EFS volume.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Locally.
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

