### PR TITLE
fix: add tagPatternList for tagged max count ECR lifecycle rule

### DIFF
--- a/aws/components/image/setup.ftl
+++ b/aws/components/image/setup.ftl
@@ -119,6 +119,7 @@
                                     "description": "Keep a number limited set of tagged images, expire all others",
                                     "selection": {
                                         "tagStatus": "tagged",
+                                        "tagPatternList": ["*"],
                                         "countType": "imageCountMoreThan",
                                         "countNumber": dockerConfig.Lifecycle.Expiry.TaggedMaxCount
                                     },


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
Adds a default value for tagPatternList for ECR Lifecycle rule set to `["*"]`.
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
 tagPatternList is required when tagStatus is set to tagged and tagPrefixList isn't specified
https://docs.aws.amazon.com/AmazonECR/latest/userguide/lifecycle_policy_parameters.html
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Locally
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

