### PR TITLE
feat: add support of AL2023 for bastion component

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,12 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         run: |
           pip install hamlet cfn-lint==0.87.3
+          pip install "pytest>=7.2.0" --break-system-packages
 
       - name: Run Tests
         run: |

--- a/aws/components/bastion/state.ftl
+++ b/aws/components/bastion/state.ftl
@@ -2,6 +2,54 @@
 [#macro aws_bastion_cf_state occurrence parent={} ]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
+    [#local operatingSystem = solution.ComputeInstance.OperatingSystem]
+
+    [#local computeTasks = []]
+    [#switch operatingSystem.Family ]
+        [#case "linux" ]
+            [#switch operatingSystem.Distribution ]
+                [#case "awslinux" ]
+                    [#switch operatingSystem.MajorVersion ]
+                        [#case "2023"]
+                            [#local computeTasks = [
+                                COMPUTE_TASK_RUN_STARTUP_CONFIG,
+                                COMPUTE_TASK_AWS_CFN_SIGNAL,
+                                COMPUTE_TASK_AWS_ASG_STARTUP_SIGNAL,
+                                COMPUTE_TASK_SYSTEM_VOLUME_MOUNTING,
+                                COMPUTE_TASK_FILE_DIR_CREATION,
+                                COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES,
+                                COMPUTE_TASK_OS_SECURITY_PATCHING,
+                                COMPUTE_TASK_ANTIVIRUS_CONFIG,
+                                COMPUTE_TASK_SYSTEM_LOG_FORWARDING,
+                                COMPUTE_TASK_AWS_EIP,
+                                COMPUTE_TASK_USER_ACCESS,
+                                COMPUTE_TASK_EFS_MOUNT
+                            ]]
+                            [#break]
+                        [#case "2"]
+                        [#case "1" ]
+                            [#local computeTasks = [
+                                COMPUTE_TASK_RUN_STARTUP_CONFIG,
+                                COMPUTE_TASK_AWS_CFN_SIGNAL,
+                                COMPUTE_TASK_AWS_ASG_STARTUP_SIGNAL,
+                                COMPUTE_TASK_SYSTEM_VOLUME_MOUNTING,
+                                COMPUTE_TASK_FILE_DIR_CREATION,
+                                COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES,
+                                COMPUTE_TASK_OS_SECURITY_PATCHING,
+                                COMPUTE_TASK_ANTIVIRUS_CONFIG,
+                                COMPUTE_TASK_AWS_CLI,
+                                COMPUTE_TASK_SYSTEM_LOG_FORWARDING,
+                                COMPUTE_TASK_AWS_EIP,
+                                COMPUTE_TASK_USER_ACCESS,
+                                COMPUTE_TASK_EFS_MOUNT
+                            ]]
+                            [#break]
+                    [/#switch]
+                    [#break]
+            [/#switch]
+            [#break]
+        [#break]
+    [/#switch]
 
     [#local securityGroupToId = formatResourceId( AWS_VPC_SECURITY_GROUP_RESOURCE_TYPE, core.Id )]
 
@@ -33,21 +81,7 @@
                     "Id" : formatResourceId( AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE, core.Id ),
                     "Name" : core.FullName,
                     "Type" : AWS_EC2_AUTO_SCALE_GROUP_RESOURCE_TYPE,
-                    "ComputeTasks" : [
-                        COMPUTE_TASK_RUN_STARTUP_CONFIG,
-                        COMPUTE_TASK_AWS_CFN_SIGNAL,
-                        COMPUTE_TASK_AWS_ASG_STARTUP_SIGNAL,
-                        COMPUTE_TASK_SYSTEM_VOLUME_MOUNTING,
-                        COMPUTE_TASK_FILE_DIR_CREATION,
-                        COMPUTE_TASK_HAMLET_ENVIRONMENT_VARIABLES,
-                        COMPUTE_TASK_OS_SECURITY_PATCHING,
-                        COMPUTE_TASK_ANTIVIRUS_CONFIG,
-                        COMPUTE_TASK_AWS_CLI,
-                        COMPUTE_TASK_SYSTEM_LOG_FORWARDING,
-                        COMPUTE_TASK_AWS_EIP,
-                        COMPUTE_TASK_USER_ACCESS,
-                        COMPUTE_TASK_EFS_MOUNT
-                    ]
+                    "ComputeTasks" : computeTasks
                 },
                 "lg" : {
                     "Id" : formatLogGroupId(core.Id),

--- a/aws/extensions/computetask_awscli/extension.ftl
+++ b/aws/extensions/computetask_awscli/extension.ftl
@@ -69,20 +69,24 @@
         [#break]
     [/#switch]
 
-    [#if ! (content?has_content) ]
-        [@fatal
-            message="computetask_awscli could not find a way to install the aws cli for this os"
-            detail="Check your operating system config or replace this extension with your own"
-            context={ "OccurrenceId" : core.Id, "OperatingSystem" : operatingSystem }
-        /]
+    [#if ! (operatingSystem.Distribution == "awslinux" && operatingSystem.MajorVersion == "2023")]
+        [#if ! (content?has_content)]
+            [@fatal
+                message="computetask_awscli could not find a way to install the aws cli for this os"
+                detail="Check your operating system config or replace this extension with your own"
+                context={ "OccurrenceId" : core.Id, "OperatingSystem" : operatingSystem }
+            /]
+        [#else]
+            [@computeTaskConfigSection
+                computeTaskTypes=[ COMPUTE_TASK_AWS_CLI ]
+                id="AWSClI"
+                priority=1
+                engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
+                content=content
+            /]
+
+        [/#if]
     [/#if]
 
-    [@computeTaskConfigSection
-        computeTaskTypes=[ COMPUTE_TASK_AWS_CLI ]
-        id="AWSClI"
-        priority=1
-        engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
-        content=content
-    /]
 
 [/#macro]

--- a/aws/extensions/computetask_awslinux_cfninit_asg/extension.ftl
+++ b/aws/extensions/computetask_awslinux_cfninit_asg/extension.ftl
@@ -22,6 +22,95 @@
 
     [#local computeResourceId = (_context.ComputeResourceId)!"" ]
 
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local operatingSystem = solution.ComputeInstance.OperatingSystem]
+
+    [#local contentCFNInitASG = {}]
+    [#local asg_signal_script = []]
+    [#switch operatingSystem.Family ]
+        [#case "linux" ]
+            [#switch operatingSystem.Distribution ]
+                [#case "awslinux" ]
+                    [#switch operatingSystem.MajorVersion ]
+                        [#case "1" ]
+                        [#case "2"]
+                            [#local contentCFNInitASG = [
+                                r'#!/bin/bash',
+                                r'set -uo pipefail',
+                                "exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1",
+                                "# Update cfn bootstrap commands",
+                                "yum install -y aws-cfn-bootstrap",
+                                "# Create staging dirs for cfninit scripts",
+                                "mkdir -p /var/log/hamlet_cfninit/",
+                                "mkdir -p /opt/hamlet_cfninit/",
+                                "# Remainder of configuration via metadata",
+                                {
+                                    "Fn::Sub" : [
+                                        r'/opt/aws/bin/cfn-init -v --stack ${StackName} --resource ${Resource} --region ${Region} --configset ${ConfigSet}',
+                                        {
+                                            "StackName" : { "Ref" : "AWS::StackName" },
+                                            "Region" : { "Ref" : "AWS::Region" },
+                                            "Resource" : computeResourceId,
+                                            "ConfigSet" : computeResourceId
+                                        }
+                                    ]
+                                },
+                                r'init_status=$?',
+                                "# Signal the status from cfn-init",
+                                {
+                                    "Fn::Sub" : [
+                                        r'/opt/aws/bin/cfn-signal -e ${!init_status} --stack ${StackName} --resource ${Resource} --region ${Region}',
+                                        {
+                                            "StackName" : { "Ref" : "AWS::StackName" },
+                                            "Region" : { "Ref" : "AWS::Region" },
+                                            "Resource" : computeResourceId
+                                        }
+                                    ]
+                                }
+                            ]]
+                            [#break]
+                        [#case "2023"]
+                            [#local contentCFNInitASG = [
+                                r'#!/bin/bash',
+                                r'set -uo pipefail',
+                                "exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1",
+                                "# Update cfn bootstrap commands",
+                                "# Create staging dirs for cfninit scripts",
+                                "mkdir -p /var/log/hamlet_cfninit/",
+                                "mkdir -p /opt/hamlet_cfninit/",
+                                "# Remainder of configuration via metadata",
+                                {
+                                    "Fn::Sub" : [
+                                        r'/opt/aws/bin/cfn-init -v --stack ${StackName} --resource ${Resource} --region ${Region} --configset ${ConfigSet}',
+                                        {
+                                            "StackName" : { "Ref" : "AWS::StackName" },
+                                            "Region" : { "Ref" : "AWS::Region" },
+                                            "Resource" : computeResourceId,
+                                            "ConfigSet" : computeResourceId
+                                        }
+                                    ]
+                                },
+                                r'init_status=$?',
+                                "# Signal the status from cfn-init",
+                                {
+                                    "Fn::Sub" : [
+                                        r'/opt/aws/bin/cfn-signal -e ${!init_status} --stack ${StackName} --resource ${Resource} --region ${Region}',
+                                        {
+                                            "StackName" : { "Ref" : "AWS::StackName" },
+                                            "Region" : { "Ref" : "AWS::Region" },
+                                            "Resource" : computeResourceId
+                                        }
+                                    ]
+                                }
+                            ]]
+                            [#break]
+                    [/#switch]
+                    [#break]
+            [/#switch]
+            [#break]
+        [#break]
+    [/#switch]
+
     [@computeTaskConfigSection
         computeTaskTypes=[
             COMPUTE_TASK_RUN_STARTUP_CONFIG,
@@ -30,137 +119,203 @@
         id="CFNInitASG"
         priority=0
         engine=AWS_EC2_USERDATA_COMPUTE_TASK_CONFIG_TYPE
-        content=[
-            r'#!/bin/bash',
-            r'set -uo pipefail',
-            "exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1",
-            "# Update cfn bootstrap commands",
-            "yum install -y aws-cfn-bootstrap",
-            "# Create staging dirs for cfninit scripts",
-            "mkdir -p /var/log/hamlet_cfninit/",
-            "mkdir -p /opt/hamlet_cfninit/",
-            "# Remainder of configuration via metadata",
-            {
-                "Fn::Sub" : [
-                    r'/opt/aws/bin/cfn-init -v --stack ${StackName} --resource ${Resource} --region ${Region} --configset ${ConfigSet}',
-                    {
-                        "StackName" : { "Ref" : "AWS::StackName" },
-                        "Region" : { "Ref" : "AWS::Region" },
-                        "Resource" : computeResourceId,
-                        "ConfigSet" : computeResourceId
-                    }
-                ]
-            },
-            r'init_status=$?',
-            "# Signal the status from cfn-init",
-            {
-                "Fn::Sub" : [
-                    r'/opt/aws/bin/cfn-signal -e ${!init_status} --stack ${StackName} --resource ${Resource} --region ${Region}',
-                    {
-                        "StackName" : { "Ref" : "AWS::StackName" },
-                        "Region" : { "Ref" : "AWS::Region" },
-                        "Resource" : computeResourceId
-                    }
-                ]
-            }
-        ]
+        content=contentCFNInitASG
     /]
 
+    [#local contentCFNHup = {}]
+    [#switch operatingSystem.Family ]
+        [#case "linux" ]
+            [#switch operatingSystem.Distribution ]
+                [#case "awslinux" ]
+                    [#switch operatingSystem.MajorVersion ]
+                        [#case "1" ]
+                        [#case "2"]
+                            [#local contentCFNHup = {
+                                "files": {
+                                    "/etc/cfn/cfn-hup.conf" : {
+                                        "content" : { "Fn::Join" : ["", [
+                                        "[main]\n",
+                                        "stack=", { "Ref" : "AWS::StackName" }, "\n",
+                                        "region=", { "Ref" : "AWS::Region" }, "\n"
+                                        ]]}
+                                    },
+                                    "/etc/cfn/hooks.d/cfn-auto-reloader.conf" : {
+                                        "content": {
+                                            "Fn::Join" : [
+                                                "\n",
+                                                [
+                                                    "[cfn-auto-reloader-hook]",
+                                                    "triggers=post.update",
+                                                    {
+                                                        "Fn::Sub" : [
+                                                            r'path=Resources.${Resource}.Metadata.AWS::CloudFormation::Init',
+                                                            {
+                                                                "Resource" : computeResourceId
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "Fn::Sub" : [
+                                                            r'action=/opt/aws/bin/cfn-init -v -s ${StackName} -r ${Resource} --configsets ${Resource} --region ${Region}',
+                                                            {
+                                                                "StackName" : { "Ref" : "AWS::StackName" },
+                                                                "Region" : { "Ref" : "AWS::Region" },
+                                                                "Resource" : computeResourceId
+                                                            }
+                                                        ]
+                                                    },
+                                                    "runas=root",
+                                                    ""
+                                                ]
+                                            ]
+                                        },
+                                        "mode"  : "000400",
+                                        "owner" : "root",
+                                        "group" : "root"
+                                    }
+                                },
+                                "services" : {
+                                    "sysvinit" : {
+                                        "cfn-hup" : {
+                                            "enabled" : "true",
+                                            "ensureRunning" : "true",
+                                            "files" : [
+                                                "/etc/cfn/cfn-hup.conf",
+                                                "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }]
+
+                            [#local asg_signal_script = [
+                                r'#!/bin/bash',
+                                r'set -euo pipefail',
+                                r'exec > >(tee /var/log/hamlet_cfninit/asg_signal.log | logger -t codeontap-asg-signal -s 2>/dev/console) 2>&1',
+                                r'# Signal the status to the ASG',
+                                r'instance_id="$(curl http://169.254.169.254/latest/meta-data/instance-id)"',
+                                {
+                                    "Fn::Sub": [
+                                        r'region="${Region}"',
+                                        {
+                                            "Region" : { "Ref" : "AWS::Region" }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Fn::Sub": [
+                                        r'hook_name="${HookName}"',
+                                        {
+                                            "HookName" : computeResourceId
+                                        }
+                                    ]
+                                },
+                                r'asg_name="$(aws --region ${region} autoscaling describe-auto-scaling-instances --instance-ids "${instance_id}" --query "AutoScalingInstances[0].AutoScalingGroupName" --output text)"',
+                                r'lifecycle_state="$(aws --region ${region} autoscaling describe-auto-scaling-instances --instance-ids "${instance_id}" --query "AutoScalingInstances[0].LifecycleState" --output text)"',
+                                r'if [[ "${lifecycle_state}" != "InService" ]]; then',
+                                r'  aws --region ${region} autoscaling complete-lifecycle-action  --lifecycle-hook-name ${hook_name} --auto-scaling-group-name ${asg_name} --instance-id ${instance_id} --lifecycle-action-result CONTINUE',
+                                r'else',
+                                r'  echo "Already in service"',
+                                r'fi'
+                            ]]
+                            [#break]
+                        [#case "2023"]
+                            [#local contentCFNHup = {
+                                "files": {
+                                    "/etc/cfn/cfn-hup.conf" : {
+                                        "content" : { "Fn::Join" : ["", [
+                                        "[main]\n",
+                                        "stack=", { "Ref" : "AWS::StackName" }, "\n",
+                                        "region=", { "Ref" : "AWS::Region" }, "\n"
+                                        ]]}
+                                    },
+                                    "/etc/cfn/hooks.d/cfn-auto-reloader.conf" : {
+                                        "content": {
+                                            "Fn::Join" : [
+                                                "\n",
+                                                [
+                                                    "[cfn-auto-reloader-hook]",
+                                                    "triggers=post.update",
+                                                    {
+                                                        "Fn::Sub" : [
+                                                            r'path=Resources.${Resource}.Metadata.AWS::CloudFormation::Init',
+                                                            {
+                                                                "Resource" : computeResourceId
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "Fn::Sub" : [
+                                                            r'action=/opt/aws/bin/cfn-init -v -s ${StackName} -r ${Resource} --configsets ${Resource} --region ${Region}',
+                                                            {
+                                                                "StackName" : { "Ref" : "AWS::StackName" },
+                                                                "Region" : { "Ref" : "AWS::Region" },
+                                                                "Resource" : computeResourceId
+                                                            }
+                                                        ]
+                                                    },
+                                                    "runas=root",
+                                                    ""
+                                                ]
+                                            ]
+                                        },
+                                        "mode"  : "000400",
+                                        "owner" : "root",
+                                        "group" : "root"
+                                    }
+                                }
+                            }]
+                            [#local asg_signal_script = [
+                                r'#!/bin/bash',
+                                r'set -euo pipefail',
+                                r'exec > >(tee /var/log/hamlet_cfninit/asg_signal.log | logger -t codeontap-asg-signal -s 2>/dev/console) 2>&1',
+                                r'TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")',
+                                r'IMDS() { curl -s -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/$1"; }',
+                                r'# Signal the status to the ASG',
+                                r'instance_id="$(IMDS instance-id)"',
+                                {
+                                    "Fn::Sub": [
+                                        r'region="${Region}"',
+                                        {
+                                            "Region" : { "Ref" : "AWS::Region" }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Fn::Sub": [
+                                        r'hook_name="${HookName}"',
+                                        {
+                                            "HookName" : computeResourceId
+                                        }
+                                    ]
+                                },
+                                r'asg_name="$(aws --region ${region} autoscaling describe-auto-scaling-instances --instance-ids "${instance_id}" --query "AutoScalingInstances[0].AutoScalingGroupName" --output text)"',
+                                r'lifecycle_state="$(aws --region ${region} autoscaling describe-auto-scaling-instances --instance-ids "${instance_id}" --query "AutoScalingInstances[0].LifecycleState" --output text)"',
+                                r'if [[ "${lifecycle_state}" != "InService" ]]; then',
+                                r'  aws --region ${region} autoscaling complete-lifecycle-action  --lifecycle-hook-name ${hook_name} --auto-scaling-group-name ${asg_name} --instance-id ${instance_id} --lifecycle-action-result CONTINUE',
+                                r'else',
+                                r'  echo "Already in service"',
+                                r'fi'
+                            ]]
+                            [#break]
+                    [/#switch]
+                    [#break]
+            [/#switch]
+            [#break]
+        [#break]
+    [/#switch]
+
     [@computeTaskConfigSection
-        computeTaskTypes=[ COMPUTE_TASK_AWS_CLI ]
+        computeTaskTypes=[
+            COMPUTE_TASK_RUN_STARTUP_CONFIG,
+            COMPUTE_TASK_AWS_CFN_SIGNAL,
+            COMPUTE_TASK_AWS_CFN_WAIT_SIGNAL
+        ]
         id="CFNHup"
         priority=1
         engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
-        content={
-            "files": {
-                "/etc/cfn/cfn-hup.conf" : {
-                    "content" : { "Fn::Join" : ["", [
-                    "[main]\n",
-                    "stack=", { "Ref" : "AWS::StackName" }, "\n",
-                    "region=", { "Ref" : "AWS::Region" }, "\n"
-                    ]]}
-                },
-                "/etc/cfn/hooks.d/cfn-auto-reloader.conf" : {
-                    "content": {
-                        "Fn::Join" : [
-                            "\n",
-                            [
-                                "[cfn-auto-reloader-hook]",
-                                "triggers=post.update",
-                                {
-                                    "Fn::Sub" : [
-                                        r'path=Resources.${Resource}.Metadata.AWS::CloudFormation::Init',
-                                        {
-                                            "Resource" : computeResourceId
-                                        }
-                                    ]
-                                },
-                                {
-                                    "Fn::Sub" : [
-                                        r'action=/opt/aws/bin/cfn-init -v -s ${StackName} -r ${Resource} --configsets ${Resource} --region ${Region}',
-                                        {
-                                            "StackName" : { "Ref" : "AWS::StackName" },
-                                            "Region" : { "Ref" : "AWS::Region" },
-                                            "Resource" : computeResourceId
-                                        }
-                                    ]
-                                },
-                                "runas=root",
-                                ""
-                            ]
-                        ]
-                    },
-                    "mode"  : "000400",
-                    "owner" : "root",
-                    "group" : "root"
-                }
-            },
-            "services" : {
-                "sysvinit" : {
-                    "cfn-hup" : {
-                        "enabled" : "true",
-                        "ensureRunning" : "true",
-                        "files" : [
-                            "/etc/cfn/cfn-hup.conf",
-                            "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
-                        ]
-                    }
-                }
-            }
-        }
+        content=contentCFNHup
     /]
-
-
-    [#local asg_signal_script = [
-        r'#!/bin/bash',
-        r'set -euo pipefail',
-        r'exec > >(tee /var/log/hamlet_cfninit/asg_signal.log | logger -t codeontap-asg-signal -s 2>/dev/console) 2>&1',
-        r'# Signal the status to the ASG',
-        r'instance_id="$(curl http://169.254.169.254/latest/meta-data/instance-id)"',
-        {
-            "Fn::Sub": [
-                r'region="${Region}"',
-                {
-                    "Region" : { "Ref" : "AWS::Region" }
-                }
-            ]
-        },
-        {
-            "Fn::Sub": [
-                r'hook_name="${HookName}"',
-                {
-                    "HookName" : computeResourceId
-                }
-            ]
-        },
-        r'asg_name="$(aws --region ${region} autoscaling describe-auto-scaling-instances --instance-ids "${instance_id}" --query "AutoScalingInstances[0].AutoScalingGroupName" --output text)"',
-        r'lifecycle_state="$(aws --region ${region} autoscaling describe-auto-scaling-instances --instance-ids "${instance_id}" --query "AutoScalingInstances[0].LifecycleState" --output text)"',
-        r'if [[ "${lifecycle_state}" != "InService" ]]; then',
-        r'  aws --region ${region} autoscaling complete-lifecycle-action  --lifecycle-hook-name ${hook_name} --auto-scaling-group-name ${asg_name} --instance-id ${instance_id} --lifecycle-action-result CONTINUE',
-        r'else',
-        r'  echo "Already in service"',
-        r'fi'
-    ]]
 
 
     [@computeTaskConfigSection

--- a/aws/extensions/computetask_awslinux_cwlog/extension.ftl
+++ b/aws/extensions/computetask_awslinux_cwlog/extension.ftl
@@ -25,60 +25,242 @@
 
     [#local logFileProfile = _context.LogFileProfile ]
 
-    [#local logContent = [
-        "[general]",
-        "state_file = /var/lib/awslogs/agent-state",
-        ""
-    ]]
-
-    [#list ((logFileProfile.LogFileGroups)![])?map(
-                x -> (getReferenceData(LOGFILEGROUP_REFERENCE_TYPE)[x])!{}
-            ) as logFileGroup ]
-
-        [#local logFileGroupName = _context.InstanceLogGroup ]
-        [#if logFileGroup.LogStore.Destination == "link"]
-            [#local logFileGroupName = getLinkTarget(occurrence, logFileGroup.LogStore.Link, false).State.Resources.lg.Name ]
-        [/#if]
-
-        [#list logFileGroup.LogFiles?map(
-                    x -> (getReferenceData(LOGFILE_REFERENCE_TYPE)[x])!{}
-                )?filter(
-                    x -> x?has_content) as logFileDetails ]
-
-            [#local logContent +=
-                [
-                    "[${logFileDetails.FilePath}]",
-                    "file = ${logFileDetails.FilePath}",
-                    "log_group_name = ${logFileGroupName}",
-                    "log_stream_name = {instance_id}${logFileDetails.FilePath}"
-                ] +
-                (logFileDetails.TimeFormat!"")?has_content?then(
-                    [ "datetime_format = ${logFileDetails.TimeFormat}"],
-                    []
-                ) +
-                (logFileDetails.MultiLinePattern!"")?has_content?then(
-                    [ "awslogs-multiline-pattern = ${logFileDetails.MultiLinePattern}" ],
-                    []
-                ) +
-                [ "" ]
-            ]
-        [/#list]
-    [/#list]
 
     [#local solution = occurrence.Configuration.Solution ]
     [#local operatingSystem = solution.ComputeInstance.OperatingSystem]
 
+    [#local content=[]]
     [#local awsLogsServiceName = "" ]
     [#switch operatingSystem.Family ]
         [#case "linux" ]
             [#switch operatingSystem.Distribution ]
                 [#case "awslinux" ]
                     [#switch operatingSystem.MajorVersion ]
-                        [#case "2"]
-                            [#local awsLogsServiceName = "awslogsd"]
+                        [#case "2023"]
+                            [#local collectList = []]
+
+                            [#list ((logFileProfile.LogFileGroups)![])?map(
+                                        x -> (getReferenceData(LOGFILEGROUP_REFERENCE_TYPE)[x])!{}
+                                    ) as logFileGroup ]
+
+                                [#local logFileGroupName = _context.InstanceLogGroup ]
+                                [#if logFileGroup.LogStore.Destination == "link"]
+                                    [#local logFileGroupName = getLinkTarget(occurrence, logFileGroup.LogStore.Link, false).State.Resources.lg.Name ]
+                                [/#if]
+
+                                [#list logFileGroup.LogFiles?map(
+                                            x -> (getReferenceData(LOGFILE_REFERENCE_TYPE)[x])!{}
+                                        )?filter(
+                                            x -> x?has_content) as logFileDetails ]
+
+                                    [#local entryLines = [
+                                        "          {",
+                                        "            \"file_path\": \"${logFileDetails.FilePath}\",",
+                                        "            \"log_group_name\": \"${logFileGroupName}\",",
+                                        "            \"log_stream_name\": \"{instance_id}${logFileDetails.FilePath}\""
+                                    ]]
+
+                                    [#if (logFileDetails.TimeFormat!"")?has_content]
+                                        [#local entryLines = entryLines[0..*entryLines?size-1] 
+                                            + [ entryLines?last?replace("}", ",}") ]
+                                        ]
+                                        [#local entryLines += ["            ,\"timestamp_format\": \"${logFileDetails.TimeFormat}\""]]
+                                    [/#if]
+
+                                    [#if (logFileDetails.MultiLinePattern!"")?has_content]
+                                        [#local entryLines = entryLines[0..*entryLines?size-1] 
+                                            + [ entryLines?last?replace("}", ",}") ]
+                                        ]
+                                        [#local entryLines += ["            ,\"multi_line_start_pattern\": \"${logFileDetails.MultiLinePattern}\""]]
+                                    [/#if]
+
+                                    [#local entryLines += ["          }"]]
+                                    [#local collectList += [entryLines?join("\n")]]
+
+                                [/#list]
+                            [/#list]
+
+                            [#local logContent = [
+                                "{",
+                                "  \"logs\": {",
+                                "    \"logs_collected\": {",
+                                "      \"files\": {",
+                                "        \"collect_list\": [",
+                                collectList?join(",\n"),
+                                "        ]",
+                                "      }",
+                                "    }",
+                                "  }",
+                                "}"
+                            ]]
+
+                            [#local content={
+                                "packages" : {
+                                    "yum" : {
+                                        "amazon-cloudwatch-agent" : [],
+                                        "jq" : []
+                                    }
+                                },
+                                "files" : {
+                                    "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json" : {
+                                        "content": {
+                                            "Fn::Join": [
+                                                "\n",
+                                                logContent
+                                            ]
+                                        },
+                                        "mode": "000644"
+                                    },
+                                    "/opt/hamlet_cfninit/awslogs.sh" : {
+                                        "content": {
+                                            "Fn::Join": [
+                                                "\n",
+                                                [
+                                                "#!/bin/bash",
+                                                "set -euo pipefail",
+                                                "TOKEN=$(curl -s -X PUT \"http://169.254.169.254/latest/api/token\" -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\")",
+                                                "IMDS() { curl -s -H \"X-aws-ec2-metadata-token: $TOKEN\" \"http://169.254.169.254/latest/meta-data/$1\"; }",
+                                                "instance_id=$(IMDS instance-id)",
+                                                "sed -i -e \"s/{instance_id}/$instance_id/g\" /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json",
+                                                "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
+                                                ]
+                                            ]
+                                        },
+                                        "mode": "000755"
+                                    }
+                                },
+                                "commands": {
+                                    "ConfigureLogsAgent" : {
+                                        "command" : "/opt/hamlet_cfninit/awslogs.sh",
+                                        "ignoreErrors" : false
+                                    }
+                                }
+                            }]
                             [#break]
+                        [#case "2"]
                         [#case "1" ]
-                            [#local awsLogsServiceName = "awslogs"]
+                            [#if operatingSystem.MajorVersion == "2"]
+                                [#local awsLogsServiceName = "awslogsd"]
+                            [#else]
+                                [#local awsLogsServiceName = "awslogs"]
+                            [/#if]
+
+
+                            [#local logContent = [
+                                "[general]",
+                                "state_file = /var/lib/awslogs/agent-state",
+                                ""
+                            ]]
+
+                            [#list ((logFileProfile.LogFileGroups)![])?map(
+                                        x -> (getReferenceData(LOGFILEGROUP_REFERENCE_TYPE)[x])!{}
+                                    ) as logFileGroup ]
+
+                                [#local logFileGroupName = _context.InstanceLogGroup ]
+                                [#if logFileGroup.LogStore.Destination == "link"]
+                                    [#local logFileGroupName = getLinkTarget(occurrence, logFileGroup.LogStore.Link, false).State.Resources.lg.Name ]
+                                [/#if]
+
+                                [#list logFileGroup.LogFiles?map(
+                                            x -> (getReferenceData(LOGFILE_REFERENCE_TYPE)[x])!{}
+                                        )?filter(
+                                            x -> x?has_content) as logFileDetails ]
+
+                                    [#local logContent +=
+                                        [
+                                            "[${logFileDetails.FilePath}]",
+                                            "file = ${logFileDetails.FilePath}",
+                                            "log_group_name = ${logFileGroupName}",
+                                            "log_stream_name = {instance_id}${logFileDetails.FilePath}"
+                                        ] +
+                                        (logFileDetails.TimeFormat!"")?has_content?then(
+                                            [ "datetime_format = ${logFileDetails.TimeFormat}"],
+                                            []
+                                        ) +
+                                        (logFileDetails.MultiLinePattern!"")?has_content?then(
+                                            [ "awslogs-multiline-pattern = ${logFileDetails.MultiLinePattern}" ],
+                                            []
+                                        ) +
+                                        [ "" ]
+                                    ]
+                                [/#list]
+                            [/#list]
+
+                            [#local content={
+                                "packages" : {
+                                    "yum" : {
+                                        "awslogs" : [],
+                                        "jq" : []
+                                    }
+                                },
+                                "files" : {
+                                    "/etc/awslogs/awscli.conf" : {
+                                        "content" : {
+                                            "Fn::Join" : [
+                                                "\n",
+                                                [
+                                                    "[plugins]",
+                                                    "cwlogs = cwlogs",
+                                                    "[default]",
+                                                    { "Fn::Sub" : r'region = ${AWS::Region}' }
+                                                ]
+                                            ]
+                                        },
+                                        "mode" : "000644"
+                                    },
+                                    "/etc/awslogs/awslogs.conf" : {
+                                        "content" : {
+                                            "Fn::Join" : [
+                                                "\n",
+                                                logContent
+                                            ]
+                                        },
+                                        "mode" : "000644"
+                                    },
+                                    "/opt/hamlet_cfninit/awslogs.sh" : {
+                                        "content" : {
+                                            "Fn::Join" : [
+                                                "\n",
+                                                [
+                                                    r'#!/bin/bash',
+                                                    r'# Metadata log details',
+                                                    r"ecs_cluster=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .Cluster')",
+                                                    r"ecs_container_instance_id=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .ContainerInstanceArn' | awk -F/ '{print $2}' )",
+                                                    r'macs=$(curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/ | head -1 )',
+                                                    r'vpc_id=$(curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$macs/vpc-id )',
+                                                    r'instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)',
+                                                    r'',
+                                                    r'sed -i -e "s/{instance_id}/$instance_id/g" /etc/awslogs/awslogs.conf',
+                                                    r'sed -i -e "s/{ecs_container_instance_id}/$ecs_container_instance_id/g" /etc/awslogs/awslogs.conf',
+                                                    r'sed -i -e "s/{ecs_cluster}/$ecs_cluster/g" /etc/awslogs/awslogs.conf',
+                                                    r'sed -i -e "s/{vpc_id}/$vpc_id/g" /etc/awslogs/awslogs.conf'
+                                                ]
+                                            ]
+                                        },
+                                        "mode" : "000755"
+                                    }
+                                },
+                                "services" : {
+                                    "sysvinit" : {
+                                        awsLogsServiceName : {
+                                            "ensureRunning" : true,
+                                            "enabled" : true,
+                                            "files" : [
+                                                "/etc/awslogs/awslogs.conf",
+                                                "/etc/awslogs/awscli.conf"
+                                            ],
+                                            "packages" : [ "awslogs" ],
+                                            "commands" : [ "ConfigureLogsAgent" ]
+                                        }
+                                    }
+                                },
+                                "commands": {
+                                    "ConfigureLogsAgent" : {
+                                        "command" : "/opt/hamlet_cfninit/awslogs.sh",
+                                        "ignoreErrors" : false
+                                    }
+                                }
+                            }]
                             [#break]
                     [/#switch]
                     [#break]
@@ -87,86 +269,13 @@
         [#break]
     [/#switch]
 
+
     [@computeTaskConfigSection
         computeTaskTypes=[ COMPUTE_TASK_SYSTEM_LOG_FORWARDING ]
         id="CloudWatchLogs"
         priority=2
         engine=AWS_EC2_CFN_INIT_COMPUTE_TASK_CONFIG_TYPE
-        content={
-            "packages" : {
-                "yum" : {
-                    "awslogs" : [],
-                    "jq" : []
-                }
-            },
-            "files" : {
-                "/etc/awslogs/awscli.conf" : {
-                    "content" : {
-                        "Fn::Join" : [
-                            "\n",
-                            [
-                                "[plugins]",
-                                "cwlogs = cwlogs",
-                                "[default]",
-                                { "Fn::Sub" : r'region = ${AWS::Region}' }
-                            ]
-                        ]
-                    },
-                    "mode" : "000644"
-                },
-                "/etc/awslogs/awslogs.conf" : {
-                    "content" : {
-                        "Fn::Join" : [
-                            "\n",
-                            logContent
-                        ]
-                    },
-                    "mode" : "000644"
-                },
-                "/opt/hamlet_cfninit/awslogs.sh" : {
-                    "content" : {
-                        "Fn::Join" : [
-                            "\n",
-                            [
-                                r'#!/bin/bash',
-                                r'# Metadata log details',
-                                r"ecs_cluster=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .Cluster')",
-                                r"ecs_container_instance_id=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .ContainerInstanceArn' | awk -F/ '{print $2}' )",
-                                r'macs=$(curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/ | head -1 )',
-                                r'vpc_id=$(curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$macs/vpc-id )',
-                                r'instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)',
-                                r'',
-                                r'sed -i -e "s/{instance_id}/$instance_id/g" /etc/awslogs/awslogs.conf',
-                                r'sed -i -e "s/{ecs_container_instance_id}/$ecs_container_instance_id/g" /etc/awslogs/awslogs.conf',
-                                r'sed -i -e "s/{ecs_cluster}/$ecs_cluster/g" /etc/awslogs/awslogs.conf',
-                                r'sed -i -e "s/{vpc_id}/$vpc_id/g" /etc/awslogs/awslogs.conf'
-                            ]
-                        ]
-                    },
-                    "mode" : "000755"
-                }
-            },
-            "services" : {
-                "sysvinit" : {
-                    awsLogsServiceName : {
-                        "ensureRunning" : true,
-                        "enabled" : true,
-                        "files" : [
-                            "/etc/awslogs/awslogs.conf",
-                            "/etc/awslogs/awscli.conf"
-                        ],
-                        "packages" : [ "awslogs" ],
-                        "commands" : [ "ConfigureLogsAgent" ]
-                    }
-                }
-            },
-            "commands": {
-                "ConfigureLogsAgent" : {
-                    "command" : "/opt/hamlet_cfninit/awslogs.sh",
-                    "ignoreErrors" : false
-                }
-            }
-        }
+        content=content
     /]
 
 [/#macro]

--- a/aws/extensions/computetask_awslinux_eip/extension.ftl
+++ b/aws/extensions/computetask_awslinux_eip/extension.ftl
@@ -23,29 +23,70 @@
 
     [#local eips = _context.ElasticIPs ]
     [#local content = {}]
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local operatingSystem = solution.ComputeInstance.OperatingSystem]
+
 
     [#if eips?has_content]
         [#local allocationIds = eips?map( eip -> getReference(eip, ALLOCATION_ATTRIBUTE_TYPE))]
 
-        [#local script = [
-            r'#!/bin/bash',
-            r'set -euo pipefail',
-            r'exec > >(tee /var/log/hamlet_cfninit/eip.log | logger -t codeontap-eip -s 2>/dev/console) 2>&1',
-            r'INSTANCE=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)',
-            { "Fn::Sub" : r'export AWS_DEFAULT_REGION="${AWS::Region}"' },
-            {
-                "Fn::Sub" : [
-                    r'available_eip="$(aws ec2 describe-addresses --filter "Name=allocation-id,Values=${AllocationIds}" --query ' + r"'Addresses[?AssociationId==`null`].AllocationId | [0]' " + '--output text )"',
-                    { "AllocationIds": { "Fn::Join" : [ ",", allocationIds ] }}
-                ]
-            },
-            r'if [[ -n "${available_eip}" && "${available_eip}" != "None" ]]; then',
-            r'  aws ec2 associate-address --instance-id ${INSTANCE} --allocation-id ${available_eip} --no-allow-reassociation',
-            r'else',
-            r'  >&2 echo "No elastic IP available to allocate"',
-            r'  exit 255',
-            r'fi'
-        ]]
+        [#local script = []]
+            [#switch operatingSystem.Family ]
+                [#case "linux" ]
+                    [#switch operatingSystem.Distribution ]
+                        [#case "awslinux" ]
+                            [#switch operatingSystem.MajorVersion ]
+                                [#case "1" ]
+                                [#case "2"]
+                                    [#local script = [
+                                        r'#!/bin/bash',
+                                        r'set -euo pipefail',
+                                        r'exec > >(tee /var/log/hamlet_cfninit/eip.log | logger -t codeontap-eip -s 2>/dev/console) 2>&1',
+                                        r'INSTANCE=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)',
+                                        { "Fn::Sub" : r'export AWS_DEFAULT_REGION="${AWS::Region}"' },
+                                        {
+                                            "Fn::Sub" : [
+                                                r'available_eip="$(aws ec2 describe-addresses --filter "Name=allocation-id,Values=${AllocationIds}" --query ' + r"'Addresses[?AssociationId==`null`].AllocationId | [0]' " + '--output text )"',
+                                                { "AllocationIds": { "Fn::Join" : [ ",", allocationIds ] }}
+                                            ]
+                                        },
+                                        r'if [[ -n "${available_eip}" && "${available_eip}" != "None" ]]; then',
+                                        r'  aws ec2 associate-address --instance-id ${INSTANCE} --allocation-id ${available_eip} --no-allow-reassociation',
+                                        r'else',
+                                        r'  >&2 echo "No elastic IP available to allocate"',
+                                        r'  exit 255',
+                                        r'fi'
+                                    ]]
+                                    [#break]
+                                [#case "2023"]
+                                    [#local script = [
+                                        r'#!/bin/bash',
+                                        r'set -euo pipefail',
+                                        r'exec > >(tee /var/log/hamlet_cfninit/eip.log | logger -t codeontap-eip -s 2>/dev/console) 2>&1',
+                                        r'TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")',
+                                        r'IMDS() { curl -s -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/$1"; }',
+                                        r'INSTANCE=$(IMDS instance-id)',
+                                        { "Fn::Sub" : r'export AWS_DEFAULT_REGION="${AWS::Region}"' },
+                                        {
+                                            "Fn::Sub" : [
+                                                r'available_eip="$(aws ec2 describe-addresses --filter "Name=allocation-id,Values=${AllocationIds}" --query ' + r"'Addresses[?AssociationId==`null`].AllocationId | [0]' " + '--output text )"',
+                                                { "AllocationIds": { "Fn::Join" : [ ",", allocationIds ] }}
+                                            ]
+                                        },
+                                        r'if [[ -n "${available_eip}" && "${available_eip}" != "None" ]]; then',
+                                        r'  aws ec2 associate-address --instance-id ${INSTANCE} --allocation-id ${available_eip} --no-allow-reassociation',
+                                        r'else',
+                                        r'  >&2 echo "No elastic IP available to allocate"',
+                                        r'  exit 255',
+                                        r'fi'
+                                    ]]
+                                    [#break]
+                            [/#switch]
+                            [#break]
+                    [/#switch]
+                    [#break]
+                [#break]
+            [/#switch]
 
         [#local content = {
             "files" : {

--- a/aws/extensions/computetask_awslinux_ospatching/extension.ftl
+++ b/aws/extensions/computetask_awslinux_ospatching/extension.ftl
@@ -25,31 +25,89 @@
     [#local schedule = OSPatching.Schedule ]
     [#local securityOnly = OSPatching.SecurityOnly ]
 
-    [#local updateCommand = "yum clean all && yum -y update"]
+    [#local solution = occurrence.Configuration.Solution ]
+    [#local operatingSystem = solution.ComputeInstance.OperatingSystem]
+
+    [#local updateCommand = ""]
+    [#local content = ""]
+
+    [#switch operatingSystem.Family ]
+        [#case "linux" ]
+            [#switch operatingSystem.Distribution ]
+                [#case "awslinux" ]
+                    [#switch operatingSystem.MajorVersion ]
+                        [#case "1" ]
+                        [#case "2"]
+                            [#local updateCommand = "yum clean all && yum -y update"]
+                            [#local content = {
+                                "commands": {
+                                    "InitialUpdate" : {
+                                        "command" : updateCommand,
+                                        "ignoreErrors" : false
+                                    }
+                                } +
+                                securityOnly?then(
+                                    {
+                                        "DailySecurity" : {
+                                            "command" : 'echo \"${schedule} ${updateCommand} --security >> /var/log/update.log 2>&1\" >crontab.txt && crontab crontab.txt',
+                                            "ignoreErrors" : false
+                                        }
+                                    },
+                                    {
+                                        "DailyUpdates" : {
+                                            "command" : 'echo \"${schedule} ${updateCommand} >> /var/log/update.log 2>&1\" >crontab.txt && crontab crontab.txt',
+                                            "ignoreErrors" : false
+                                        }
+                                    }
+                                )
+                            }]
+                            [#break]
+                        [#case "2023"]
+                            [#local updateCommand = "dnf clean all && dnf -y update"]
+                            [#local content = {
+                                "packages": {
+                                    "yum": {
+                                        "cronie": []
+                                    }
+                                },
+                                "commands": {
+                                    "00EnableCrond": {
+                                        "command": "systemctl enable --now crond"
+                                    },
+                                    "02CreateUpdateLog": {
+                                        "command": "touch /var/log/update.log && chmod 644 /var/log/update.log",
+                                        "ignoreErrors": false
+                                    },
+                                    "InitialUpdate" : {
+                                        "command" : updateCommand,
+                                        "ignoreErrors" : false
+                                    }
+                                } +
+                                securityOnly?then(
+                                    {
+                                        "DailySecurity" : {
+                                            "command" : "echo '${schedule} ${updateCommand} --security >> /var/log/update.log 2>&1' > /etc/cron.d/dnf-updates && chmod 644 /etc/cron.d/dnf-updates",
+                                            "ignoreErrors" : false
+                                        }
+                                    },
+                                    {
+                                        "DailyUpdates" : {
+                                            "command" : "echo '${schedule} ${updateCommand} >> /var/log/update.log 2>&1' > /etc/cron.d/dnf-updates && chmod 644 /etc/cron.d/dnf-updates",
+                                            "ignoreErrors" : false
+                                        }
+                                    }
+                                )
+                            }]
+                            [#break]
+                    [/#switch]
+                    [#break]
+            [/#switch]
+            [#break]
+        [#break]
+    [/#switch]
 
     [#if OSPatching.Enabled ]
-        [#local content = {
-                "commands": {
-                    "InitialUpdate" : {
-                        "command" : updateCommand,
-                        "ignoreErrors" : false
-                    }
-                } +
-                securityOnly?then(
-                    {
-                        "DailySecurity" : {
-                            "command" : 'echo \"${schedule} ${updateCommand} --security >> /var/log/update.log 2>&1\" >crontab.txt && crontab crontab.txt',
-                            "ignoreErrors" : false
-                        }
-                    },
-                    {
-                        "DailyUpdates" : {
-                            "command" : 'echo \"${schedule} ${updateCommand} >> /var/log/update.log 2>&1\" >crontab.txt && crontab crontab.txt',
-                            "ignoreErrors" : false
-                        }
-                    }
-                )
-            }]
+        [#local content = content]
     [#else]
         [#local content = {
             "copmmands" : {

--- a/aws/inputseeders/aws/masterdata.json
+++ b/aws/inputseeders/aws/masterdata.json
@@ -1096,6 +1096,75 @@
                 }
             }
         },
+        "_awslinux2023" : {
+            "Modes" : {
+                "*" : {
+                    "ecs" : {
+                        "Profiles" : {
+                            "Storage" : "ecs_awslinux2"
+                        },
+                        "ComputeInstance" : {
+                            "OperatingSystem" : {
+                                "Family" : "linux",
+                                "Distribution" : "awslinux",
+                                "MajorVersion" : "2023"
+                            },
+                            "Image" : {
+                                "Source" : "aws:SSMParam",
+                                "aws:Source:SSMParam" : {
+                                    "Name" : "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
+                                }
+                            }
+                        }
+                    },
+                    "computecluster" : {
+                        "ComputeInstance" : {
+                            "OperatingSystem" : {
+                                "Family" : "linux",
+                                "Distribution" : "awslinux",
+                                "MajorVersion" : "2023"
+                            },
+                            "Image" : {
+                                "Source" : "aws:SSMParam",
+                                "aws:Source:SSMParam" : {
+                                    "Name" : "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+                                }
+                            }
+                        }
+                    },
+                    "bastion" : {
+                        "ComputeInstance" : {
+                            "OperatingSystem" : {
+                                "Family" : "linux",
+                                "Distribution" : "awslinux",
+                                "MajorVersion" : "2023"
+                            },
+                            "Image" : {
+                                "Source" : "aws:SSMParam",
+                                "aws:Source:SSMParam" : {
+                                    "Name" : "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+                                }
+                            }
+                        }
+                    },
+                    "ec2" : {
+                        "ComputeInstance" : {
+                            "OperatingSystem" : {
+                                "Family" : "linux",
+                                "Distribution" : "awslinux",
+                                "MajorVersion" : "2023"
+                            },
+                            "Image" : {
+                                "Source" : "aws:SSMParam",
+                                "aws:Source:SSMParam" : {
+                                    "Name" : "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "_awswin" : {
             "Modes" : {
                 "*" : {


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
<!--- Describe your changes in detail -->
Supports AL2023 for bastion component
## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Amazon Linux 2 (AL2) reaches end of support on June 30, 2026.
## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Locally
## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

